### PR TITLE
feat: add ClusterFuzzLite fuzzing scaffold for jquantstats

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,9 @@
+# ClusterFuzzLite build image for jquantstats.
+# Uses the OSS-Fuzz Python base image, which provides Atheris and the
+# compile_python_fuzzer helper.
+# Pinned by SHA256 so the build image only changes through reviewed updates.
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:99c714c91ec30778a3ce3ae5b37491a81fc043808bc8f2955159c2f608f80116
+
+COPY . $SRC
+WORKDIR $SRC
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# ClusterFuzzLite build script — installs jquantstats and compiles each Python
+# harness in tests/fuzz/ via OSS-Fuzz's compile_python_fuzzer helper.
+
+cd "$SRC"
+
+# Pin pip so the build environment is reproducible and only changes through a
+# reviewed bump (the same rationale as the SHA-pinned base image).
+pip3 install --upgrade "pip==24.3.1"
+
+# Install the package and its runtime dependencies (numpy, polars, scipy, ...)
+# into the build environment so PyInstaller can discover and bundle jquantstats
+# into each frozen fuzzer binary.
+pip3 install .
+
+# PyInstaller does not discover numpy's C-extension submodules on its own, so
+# the frozen fuzzer crashes at runtime with
+# "No module named 'numpy._core._exceptions'". --collect-all pulls in every
+# numpy submodule, data file and shared library. polars and scipy are bundled
+# correctly via the static import graph and PyInstaller's built-in hooks.
+for fuzzer in tests/fuzz/fuzz_*.py; do
+  compile_python_fuzzer "$fuzzer" --collect-all numpy
+done

--- a/tests/fuzz/fuzz_stats.py
+++ b/tests/fuzz/fuzz_stats.py
@@ -21,9 +21,18 @@ import sys
 
 import atheris
 
-with atheris.instrument_imports():
-    import polars as pl
+# Pre-import the heavy native dependencies OUTSIDE the instrumentation block.
+# Atheris's bytecode instrumentation miscompiles parts of polars' Python
+# machinery (an instrumented build returns None from Series.is_not_null(),
+# which crashes interpolate()), so we let these libraries load uninstrumented
+# and instrument only the first-party package under test. Importing the
+# top-level packages pulls in their submodules, so jquantstats's own imports
+# below hit the module cache and are never re-instrumented.
+import narwhals  # noqa: F401  # pre-imported uninstrumented (see note above)
+import numpy as np  # noqa: F401  # pre-imported uninstrumented (see note above)
+import polars as pl
 
+with atheris.instrument_imports():
     from jquantstats import Data, interpolate
     from jquantstats.exceptions import JQuantStatsError
 

--- a/tests/fuzz/fuzz_stats.py
+++ b/tests/fuzz/fuzz_stats.py
@@ -1,0 +1,70 @@
+"""Fuzz jquantstats null-handling and returns ingestion against arbitrary frames.
+
+``interpolate`` interior-forward-fills the numeric columns of an arbitrary
+polars frame and is contracted to *never* crash, while ``Data.from_returns``
+ingests an untrusted returns frame and must either build a ``Data`` object or
+raise one of its documented errors (its guards raise ``ValueError``/``TypeError``
+subclasses; polars raises its own errors on schema problems). This harness
+exercises both contracts with coverage-guided input.
+
+Run locally:
+    pip install atheris polars numpy
+    python tests/fuzz/fuzz_stats.py -atheris_runs=20000
+
+Run in ClusterFuzzLite: this file is built by .clusterfuzzlite/build.sh.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    import polars as pl
+
+    from jquantstats import Data, interpolate
+    from jquantstats.exceptions import JQuantStatsError
+
+# Errors ``from_returns`` is allowed to raise on malformed input. Anything
+# outside this set propagates and is recorded by Atheris as a crash.
+_ALLOWED = (JQuantStatsError, ValueError, TypeError, pl.exceptions.PolarsError)
+
+
+def _frame(fdp: atheris.FuzzedDataProvider) -> pl.DataFrame:
+    """Build a small frame of (nullable) float columns from fuzzed bytes."""
+    n_rows = fdp.ConsumeIntInRange(0, 16)
+    n_cols = fdp.ConsumeIntInRange(1, 4)
+    data: dict[str, list[float | None]] = {}
+    for c in range(n_cols):
+        column: list[float | None] = []
+        for _ in range(n_rows):
+            # Sprinkle nulls so the interior-forward-fill logic is exercised.
+            column.append(None if fdp.ConsumeBool() else fdp.ConsumeFloat())
+        data[f"R{c}"] = column
+    return pl.DataFrame(data)
+
+
+def test_one_input(data: bytes) -> None:
+    """Exercise interpolate() and Data.from_returns() with a fuzzed frame."""
+    fdp = atheris.FuzzedDataProvider(data)
+    frame = _frame(fdp)
+
+    # interpolate is contracted to never raise on any frame.
+    interpolate(frame)
+
+    # Prepend a monotonically increasing Date column and feed the ingester.
+    returns = frame.with_columns(pl.int_range(0, frame.height).alias("Date")).select(["Date", *frame.columns])
+    with contextlib.suppress(_ALLOWED):
+        Data.from_returns(returns=returns)
+
+
+def main() -> None:
+    """Run the Atheris fuzz loop."""
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the opt-in **ClusterFuzzLite** fuzzing scaffold so the existing `rhiza_fuzzing.yml` workflow actually runs.

- `.clusterfuzzlite/Dockerfile` — OSS-Fuzz Python base image, SHA-pinned
- `.clusterfuzzlite/build.sh` — installs `jquantstats` and compiles each `tests/fuzz/fuzz_*.py` harness, passing `--collect-all numpy` so PyInstaller bundles numpy's C-extension submodules (polars/scipy ride the import graph)
- `tests/fuzz/fuzz_stats.py` — Atheris harness fuzzing `interpolate()` (contracted to never crash) and `Data.from_returns()` (must raise only documented errors) over arbitrary polars frames

The `FUZZING_ENABLED` repo variable is already set to `true`.

## Test plan
- [x] Build verified locally against the OSS-Fuzz `base-builder-python` image — `fuzz_stats` compiles and the frozen binary loads numpy/polars
- [ ] Runtime fuzz loop on CI (cannot run locally: polars' Rust binary SIGILLs under x86-on-arm64 emulation; native-amd64 CI is unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
