### PR TITLE
fix(reports): narrow broad except blocks swallowing benchmark-metric errors

### DIFF
--- a/src/jquantstats/_reports/_metrics.py
+++ b/src/jquantstats/_reports/_metrics.py
@@ -258,7 +258,11 @@ def _add_full_mode_rows(
     rows.append(("Best Day", _pct(_safe(s.best))))
     rows.append(("Worst Day", _pct(_safe(s.worst))))
 
-    # Benchmark greeks (only if benchmark is present)
+    # Benchmark greeks (only if benchmark is present). Without a benchmark,
+    # ``s.greeks()`` reaches ``benchmark_data.columns`` on a ``None`` benchmark
+    # and raises ``AttributeError``; we tolerate only that case and omit the
+    # rows. Any other error (malformed column, polars schema/arithmetic bug)
+    # propagates so genuine bugs are not silently swallowed.
     try:
         greeks = s.greeks()
         if greeks:  # pragma: no branch — greeks() raises without a benchmark, so falsy is unreachable
@@ -266,9 +270,14 @@ def _add_full_mode_rows(
             alpha = {k: v["alpha"] * 100.0 for k, v in greeks.items()}
             rows.append(("Beta", beta))
             rows.append(("Alpha", alpha))
-    except Exception:  # noqa: S110
-        pass  # nosec B110
+    except AttributeError:
+        pass
 
+    # Correlation against the benchmark. When the benchmark column is absent
+    # (no benchmark configured, or it is missing from the joined frame) polars
+    # raises ``ColumnNotFoundError`` and ``None.columns`` raises
+    # ``AttributeError`` — both mean "no benchmark to correlate against", so the
+    # row is omitted. Any other error propagates.
     try:
         bench_obj = getattr(data, "benchmark", None)
         if bench_obj is not None and all_df is not None and date_col is not None:  # pragma: no branch
@@ -281,8 +290,8 @@ def _add_full_mode_rows(
                 corr_val = float(sub.select(pl.corr(ac, bench_col))[0, 0])
                 corr_dict[ac] = corr_val * 100.0
             rows.append(("Correlation", corr_dict))
-    except Exception:  # noqa: S110
-        pass  # nosec B110
+    except (AttributeError, pl.exceptions.ColumnNotFoundError):
+        pass
 
     rows.append(("R²", _safe(s.r_squared)))
     rows.append(("Treynor Ratio", _safe(s.treynor_ratio, periods=ppy)))

--- a/tests/test_jquantstats/test__reports/test_reports.py
+++ b/tests/test_jquantstats/test__reports/test_reports.py
@@ -17,6 +17,7 @@ from jquantstats._reports._html import (
 )
 from jquantstats._reports._metrics import (
     _add_drawdown_rows,
+    _add_full_mode_rows,
     _add_overview_rows,
     _add_recent_returns_rows,
     _add_risk_adjusted_rows,
@@ -627,6 +628,95 @@ def test_metrics_full_mode_correlation_raises(data):
     # Correlation row is absent but R² is still computed
     assert "R²" in df["Metric"].to_list()
     assert "Correlation" not in df["Metric"].to_list()
+
+
+def test_metrics_full_mode_no_benchmark_omits_benchmark_rows(data_no_benchmark):
+    """Full mode omits Beta/Alpha/Correlation when no benchmark is configured.
+
+    This is the legitimate degenerate-input path the narrowed except blocks must
+    keep tolerating: ``greeks()`` raises ``AttributeError`` and the correlation
+    block is skipped because no benchmark is present.
+    """
+    df = data_no_benchmark.reports.metrics(mode="full")
+    labels = df["Metric"].to_list()
+    assert "Beta" not in labels
+    assert "Alpha" not in labels
+    assert "Correlation" not in labels
+    # Non-benchmark rows are still computed.
+    assert "R²" in labels
+
+
+def test_full_mode_unexpected_greeks_error_propagates(data):
+    """An unexpected error in the greeks block now propagates, not silently swallowed."""
+
+    class _BoomStats:
+        """Stats proxy whose greeks() raises an unexpected error."""
+
+        def __init__(self, real: object) -> None:
+            """Wrap a real Stats object."""
+            self._real = real
+
+        def __getattr__(self, name: str) -> object:
+            """Delegate every other attribute to the wrapped Stats object."""
+            return getattr(self._real, name)
+
+        def greeks(self) -> dict:
+            """Simulate a genuine bug in the beta/alpha computation."""
+            raise ValueError("boom")
+
+    rows: list = []
+    with pytest.raises(ValueError, match="boom"):
+        _add_full_mode_rows(
+            rows,
+            _BoomStats(data.stats),
+            float(data._periods_per_year),
+            data,
+            data.all,
+            "Date",
+            ["AAPL", "META"],
+        )
+
+
+def test_full_mode_unexpected_correlation_error_propagates(data):
+    """An unexpected error in the correlation block now propagates, not silently swallowed."""
+
+    class _BoomBenchmark:
+        """Benchmark proxy whose column access raises an unexpected error."""
+
+        @property
+        def columns(self) -> list[str]:
+            """Simulate a genuine bug while resolving the benchmark column."""
+            raise RuntimeError("boom")
+
+    class _DataProxy:
+        """Data proxy that returns a benchmark whose column access blows up."""
+
+        def __init__(self, real: object) -> None:
+            """Wrap a real Data object."""
+            self._real = real
+
+        def __getattr__(self, name: str) -> object:
+            """Delegate every other attribute to the wrapped Data object."""
+            return getattr(self._real, name)
+
+        @property
+        def benchmark(self) -> _BoomBenchmark:
+            """Return the exploding benchmark proxy."""
+            return _BoomBenchmark()
+
+    rows: list = []
+    # greeks() succeeds on the real stats (benchmark present), so we only reach
+    # the correlation block, where the RuntimeError must propagate.
+    with pytest.raises(RuntimeError, match="boom"):
+        _add_full_mode_rows(
+            rows,
+            data.stats,
+            float(data._periods_per_year),
+            _DataProxy(data),
+            data.all,
+            "Date",
+            ["AAPL", "META"],
+        )
 
 
 def test_full_skips_missing_plot_method(data):


### PR DESCRIPTION
Closes #855

## Summary
The two `try: ... except Exception: pass  # noqa: S110 / # nosec B110` blocks in `src/jquantstats/_reports/_metrics.py` (the Beta/Alpha greeks block and the Correlation block) silently discarded every error, including genuine bugs in the benchmark math.

This narrows each catch to only the exception(s) that signal the legitimate "no benchmark" degenerate input:

- **greeks block** → `except AttributeError` — without a benchmark, `s.greeks()` reaches `benchmark_data.columns` on a `None` benchmark and raises `AttributeError`.
- **correlation block** → `except (AttributeError, pl.exceptions.ColumnNotFoundError)` — a missing/`None` benchmark column raises one of these when selecting the column / running `pl.corr`.

Any other error (malformed column, polars schema error, arithmetic bug) now propagates. The `# noqa: S110` / `# nosec B110` suppressions are removed since the catches are specific.

## Tests
- `test_metrics_full_mode_no_benchmark_omits_benchmark_rows` — Beta/Alpha/Correlation omitted (R² still present) for the `data_no_benchmark` fixture.
- `test_full_mode_unexpected_greeks_error_propagates` — a `ValueError` raised inside the greeks block now propagates.
- `test_full_mode_unexpected_correlation_error_propagates` — a `RuntimeError` raised while resolving the benchmark column now propagates.
- Existing `*_raises` tests (AttributeError / ColumnNotFoundError) still pass.

## Gate results
- `make fmt` — PASS
- `make test` — PASS (1213 passed, 5 skipped; 100% coverage)
- `make typecheck` — PASS (ty + mypy strict)
- `make security` — PASS (pip-audit + bandit, exit 0)