### PR TITLE
fix(deps): migrate pl.concat to how="horizontal_extend" (#866)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "narwhals>=2.0.0",
     "numpy>=2.0.0",
     "plotly>=6.1.1",
-    "polars>=1.35.2",
+    "polars>=1.42.1",
     "scipy>=1.14.1"
 ]
 license = "MIT"

--- a/src/jquantstats/_utils/_data.py
+++ b/src/jquantstats/_utils/_data.py
@@ -46,7 +46,7 @@ class DataUtils:
 
     def _combined(self) -> pl.DataFrame:
         """Return index hstacked with returns (no benchmark)."""
-        return pl.concat([self._data.index, self._data.returns], how="horizontal")
+        return pl.concat([self._data.index, self._data.returns], how="horizontal_extend")
 
     def _asset_cols(self) -> list[str]:
         """Return the asset column names from returns (excluding benchmark)."""

--- a/src/jquantstats/data.py
+++ b/src/jquantstats/data.py
@@ -597,9 +597,9 @@ class Data:
 
         """
         if self.benchmark is None:
-            return pl.concat([self.index, self.returns], how="horizontal")
+            return pl.concat([self.index, self.returns], how="horizontal_extend")
         else:
-            return pl.concat([self.index, self.returns, self.benchmark], how="horizontal")
+            return pl.concat([self.index, self.returns, self.benchmark], how="horizontal_extend")
 
     def resample(self, every: str = "1mo") -> Data:
         """Resample returns and benchmark to a different frequency.

--- a/uv.lock
+++ b/uv.lock
@@ -844,7 +844,7 @@ requires-dist = [
     { name = "narwhals", specifier = ">=2.0.0" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "plotly", specifier = ">=6.1.1" },
-    { name = "polars", specifier = ">=1.35.2" },
+    { name = "polars", specifier = ">=1.42.1" },
     { name = "python-multipart", marker = "extra == 'web'", specifier = ">=0.0.12" },
     { name = "scipy", specifier = ">=1.14.1" },
     { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.32.0" },


### PR DESCRIPTION
## Summary
polars 1.42.1 (pulled in via the rhiza v1.0.2 boost) deprecates the default `how="horizontal"` behavior of `pl.concat`, emitting ~14.8k `DeprecationWarning`s during the test run and threatening a future breaking change in the core `Data.all` path.

The three locally-owned call sites concat row-aligned frames (index/returns/benchmark), so `how="horizontal_extend"` preserves current behavior explicitly:

- `src/jquantstats/data.py:600`
- `src/jquantstats/data.py:602`
- `src/jquantstats/_utils/_data.py:49`

## Verification
- `make test`: **1213 passed, 5 skipped**, 100% coverage
- Zero `how='horizontal'` DeprecationWarnings remain (grep count: 0)

Closes #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)