### PR TITLE
chore: update rhiza to v1.1.2

### DIFF
--- a/.claude/commands/rhiza_book.md
+++ b/.claude/commands/rhiza_book.md
@@ -1,0 +1,53 @@
+---
+description: Build the documentation book into a local _book folder and open it in the default browser
+allowed-tools: Bash, Read
+---
+
+Build the MkDocs/zensical documentation book locally and open it in the user's
+standard web browser. Follow the command-execution policy: always prefer
+`make <target>`; never invoke `.venv/bin/...` directly.
+
+This command depends on the **book** bundle (it expects a root `mkdocs.yml` and a
+`make book` target from `.rhiza/make.d/book.mk`). If `mkdocs.yml` is missing,
+stop and tell the user the `book` bundle is not set up here rather than guessing.
+
+Do the following, in order:
+
+1. **Build the book.** Run `make book`. This regenerates the `_book/` output
+   folder via zensical (it also runs the `_book-reports` / `_book-notebooks`
+   prerequisites). Run it in the foreground so build errors are visible. If it
+   fails, show the relevant output, diagnose the root cause, and stop — do not
+   try to open a stale or partial book.
+
+2. **Confirm the output.** Verify `_book/index.html` exists after the build. If
+   it does not, report what `make book` produced instead and stop.
+
+3. **Serve it locally (background).** Static zensical sites need to be served
+   over HTTP — search and navigation break under `file://`. Start a local server
+   for the built folder **in the background** so it does not block the session:
+
+   ```
+   (cd _book && uv run python -m http.server 8000)
+   ```
+
+   Use port 8000 by default (this matches `make serve`). If 8000 is already in
+   use, pick the next free port (8001, 8002, …) and use that URL throughout.
+   Do **not** use `make serve` here — it rebuilds the book a second time and
+   blocks the terminal; the book is already built from step 1.
+
+4. **Open the default browser.** Open the served URL with the platform's
+   standard opener:
+   - macOS: `open http://localhost:8000`
+   - Linux: `xdg-open http://localhost:8000`
+   - Windows: `start http://localhost:8000`
+
+   Detect the platform and use the right one.
+
+5. **Report.** Tell the user the book was built at `_book/`, the URL it is being
+   served at, and how to stop the background server (e.g. the background task /
+   PID, or "kill the `http.server` process on port 8000"). Note that `_book/` is
+   a generated, gitignored artifact.
+
+If `$ARGUMENTS` is non-empty, treat it as an override hint — e.g. a custom port
+(`/rhiza_book 9000`) or a request to only build without serving/opening (`/rhiza_book
+build-only`) — and adjust accordingly.

--- a/.claude/commands/rhiza_quality.md
+++ b/.claude/commands/rhiza_quality.md
@@ -1,0 +1,98 @@
+---
+description: Run the Rhiza code-quality gate and score the repo (lint, types, docs, deps, security, tests)
+---
+
+Assess the quality of this repo against Rhiza standards. Follow the
+command-execution policy: always prefer `make <target>`; never invoke
+`.venv/bin/...` directly. Run the gates in order — cheapest checks first so fast
+failures surface before the slow test suite — and collect results:
+
+1. `make fmt` — pre-commit hooks + linting (ruff format/check, markdownlint, bandit, actionlint, …)
+2. `make typecheck` — static type checking (`ty`, and `mypy --strict` if configured) over `src/`
+3. `make docs-coverage` — docstring coverage (interrogate) over `src/`
+4. `make deptry` — unused/missing/misplaced dependency analysis
+5. `make security` — pip-audit + bandit scans
+6. `make validate` — validate project structure against the Rhiza template (`.rhiza/template.yml`)
+7. `make test` — full test suite **with** its coverage gate (slowest, run last)
+
+Guidelines:
+
+- Run each gate as a single, bare `make <target>` command — one Bash call per
+  gate. Do **not** pipe (`| tee`, `| tail`), redirect (`2>&1 >`), chain
+  (`make fmt && make typecheck`), or prefix with `cd`. Bare `make <target>`
+  invocations match the allow-listed `Bash(make *)` rule and run without a
+  permission prompt; compound or piped commands do not and will prompt on every
+  gate. Read the full output directly from each call rather than capturing it to
+  a file.
+- Run all gates even after an early failure, so the full picture is visible
+  rather than stopping at the first red.
+- If something fails, show the relevant output, diagnose the root cause, and
+  propose (or apply, if clearly correct, low-risk, **and** the fix is in a
+  locally-owned file per the scoping rule below) a fix.
+- If `$ARGUMENTS` is non-empty, scope the assessment to that path or topic
+  instead of the whole repo.
+- End with a concise PASS/FAIL summary per gate.
+
+**Coverage expectation.** `make test` enforces a coverage gate
+(`COVERAGE_FAIL_UNDER`, default 90%; many projects raise it to 100%). Treat
+anything below the configured threshold on locally-owned `src/` as a gap to
+flag, not an acceptable baseline. When scoring the test-coverage subcategory,
+the configured threshold is the bar for a 10; report uncovered lines
+(`file:line`) and the test that would close each.
+
+**`make validate`.** A failure means this repo has drifted from the Rhiza
+template (a synced file edited locally, or a missing/extra file). That is
+in-scope: fix it by re-syncing from Rhiza or by adjusting `.rhiza/template.yml`,
+not by editing the synced artifact in place.
+
+Then report:
+
+- A pass/fail summary per step.
+- Failures grouped by file, with the specific rule/error and line.
+- A prioritized list of what to fix first (blocking errors before style nits).
+
+Then analyse the repo and give marks on a scale of 1 to 10 for all relevant
+subcategories. Pick the subcategories that fit what you actually observe — e.g.
+linting/style, type safety, test pass rate, test coverage & depth, code
+structure & readability, documentation, dependency & security hygiene, CI/tooling
+health. For each: the score, a one-line justification grounded in evidence from
+the checks above (and a quick look at the code where needed), and what would
+raise it. Close with an overall score and the single highest-leverage
+improvement.
+
+**Scope the scorecard to locally-owned items — not what the mother repo (Rhiza)
+owns.** This project syncs its dev infrastructure from `jebel-quant/rhiza`; see
+`CLAUDE.md` for the authoritative split and the `files:` block of
+`.rhiza/template.lock` for the machine-generated list of synced files. Score
+only what this repo actually controls — `src/`, `tests/`, `pyproject.toml`,
+`README.md`, project-specific docs, `.rhiza/template.yml`, and any
+locally-hardened config. Do **not** let Rhiza-managed files (the
+`.github/workflows/*`, `Makefile`, `.pre-commit-config.yaml`, `pytest.ini`,
+`ruff.toml`, the typecheck/mutation/fuzzing targets, etc.) drive the marks — a
+gap there is fixed upstream in Rhiza, not here. If a relevant signal is
+Rhiza-owned, note it as "upstream/out-of-scope" rather than scoring it against
+this repo.
+
+Then, from the scorecard above, identify **actionable issues to improve the
+score** — one per subcategory scoring below 10 (skip any that are maxed). For
+each, give: a concrete title, the subcategory and current→target score it moves,
+the specific file(s)/lines or config to change, and a crisp acceptance criterion
+("done when…"). Keep them in-scope (locally-owned, per the scoping rule above) —
+flag anything Rhiza-owned as upstream rather than listing it as a local action.
+Order them by leverage (biggest score gain for least effort first). This is a
+list of recommendations only — do not change code unless I explicitly ask.
+
+Then offer to file the findings as issues — using a menu, not a free-text prompt.
+Present the actionable findings as a multi-select menu (the AskUserQuestion tool
+with `multiSelect: true`), one option per finding labelled by its title, so I can
+pick exactly which ones to file — including none. Create nothing without an
+explicit selection. For each finding I select, detect the hosting platform from
+the git remote (`git remote get-url origin`) and create one issue with the
+matching CLI — GitHub → `gh issue create`, GitLab → `glab issue create` (skip and
+say so if the relevant CLI is unavailable or unauthenticated). Make each issue
+self-contained: title from the finding, and a body carrying the subcategory, the
+current→target score, the specific file(s)/lines or config to change, and the
+"done when…" acceptance criterion. Report back the created issue URLs.
+
+If everything passes, say so plainly — but still produce the 1–10 subcategory
+marks. Do not fix anything unless I ask — this command only assesses.

--- a/.claude/commands/rhiza_release.md
+++ b/.claude/commands/rhiza_release.md
@@ -1,0 +1,82 @@
+---
+description: Cut a release — choose the version bump, push the tag, and watch the release workflow
+allowed-tools: Bash, Read
+---
+
+Cut a release for this repository. Follow the command-execution policy: always
+prefer `make <target>`; never invoke `.venv/bin/...` directly.
+
+How releasing works here. `make release` delegates to `rhiza-tools release`
+(`.rhiza/make.d/releasing.mk`). It **always bumps** the version, folds a freshly
+generated `CHANGELOG.md` into the version-bump commit (git-cliff pre-commit
+hook), creates a `v*` tag, and pushes it. The tag push triggers the
+`rhiza_release.yml` GitHub Actions workflow (validate → build → SBOM → draft →
+publish → finalize). There is no separate post-tag changelog commit — the tagged
+commit already carries the changelog.
+
+**The bump type is a user decision.** Run interactively, `make release` prompts
+the user to pick `MAJOR`, `MINOR`, or `PATCH`. Because this command runs in a
+non-interactive shell (where the tool would silently default to `PATCH`), **you
+must ask the user which bump to apply** and pass their choice through with
+`BUMP=major|minor|patch` (supported by both `make release` and `make bump`).
+
+Do the following, in order:
+
+1. **Pre-flight checks.** Confirm the release is safe to cut and stop with a
+   clear explanation if any check fails (do not push a tag from a dirty or
+   behind branch):
+   - Working tree is clean (`git status --porcelain` is empty).
+   - On the default branch (`main`) — or confirm with the user if not.
+   - Local `main` is up to date with `origin/main` (`git fetch` then compare).
+   - `pyproject.toml` exists (the bump is skipped without it).
+
+2. **Ask the user for the bump type.** Just like `make release` does
+   interactively, ask the user to choose **MAJOR**, **MINOR**, or **PATCH**
+   (semver: breaking / feature / fix). Skip this question only when
+   `$ARGUMENTS` already names a bump type or authorises a default (see below).
+   Hold the chosen `<bump>` (lowercase: `major` / `minor` / `patch`) for the
+   next steps.
+
+3. **Preview the bump (dry run).** Run `make release DRY_RUN=1 BUMP=<bump>` to
+   show the user the planned new version and tag **before** anything is pushed.
+   The `DRY_RUN=1` flag previews the bump/tag/push without applying them.
+   Summarise what the real run will do (old → new version, tag name).
+
+4. **Confirm.** Unless `$ARGUMENTS` explicitly authorises proceeding (see
+   below), stop here and ask the user to confirm the previewed version before
+   cutting the real release. Pushing a tag triggers a public release workflow —
+   treat it as outward-facing and confirm first.
+
+5. **Cut the release.** Run `make release BUMP=<bump> PUSH=1`. This bumps,
+   commits (with changelog), tags, and pushes. The `PUSH=1` flag is **required
+   here**: without it the tool asks an interactive `Push tag to remote? [y/N]`
+   question that this non-interactive shell auto-declines, leaving the bump
+   commit and tag stranded locally (unpushed). Since you already confirmed with
+   the user in step 4, `PUSH=1` pushes straight through. Run it in the
+   foreground so any failure is visible. If it fails, show the relevant output,
+   diagnose the root cause, and stop — do not re-run blindly or hand-craft a tag.
+
+6. **Watch the workflow.** Run `make release-status` to show the release
+   workflow run and the latest release info. If the workflow is still in
+   progress, tell the user it is running and how to re-check
+   (`make release-status`). Report the final release URL once available.
+
+7. **Report.** Tell the user the version that was released, the tag, and the
+   release/workflow URL. If anything is still pending (workflow running, draft
+   not yet published), say so plainly.
+
+`$ARGUMENTS` handling:
+
+- Empty → run the full ask-bump → preview → confirm flow above.
+- `major` / `minor` / `patch` → use that as the bump type and skip the question
+  in step 2 (still preview and confirm).
+- `dry-run` (or `preview`) → do steps 1–3 only and stop; do **not** cut a real
+  release. If no bump type is also given, still ask for it in step 2.
+- `yes` / `confirm` / `--force` → skip the interactive confirmation in step 4
+  and proceed straight through (still run the dry-run preview in step 3 so the
+  user sees what shipped). If no bump type is also given, still ask for it in
+  step 2.
+- `status` → skip to step 6 and just report current release/workflow status.
+
+Argument tokens combine, e.g. `minor yes` cuts a minor release without the
+confirmation prompt; `minor dry-run` previews a minor bump only.

--- a/.claude/commands/rhiza_update.md
+++ b/.claude/commands/rhiza_update.md
@@ -1,0 +1,152 @@
+---
+description: Update the pinned Rhiza version in .rhiza/template.yml, sync, resolve conflicts, and verify
+---
+
+Update this repo's Rhiza template to a newer release: bump the pin in
+`.rhiza/template.yml`, run the sync, resolve every conflict, verify the quality
+gates, and open a PR. Follow the command-execution policy: always prefer
+`make <target>`; never invoke `.venv/bin/...` directly.
+
+`$ARGUMENTS` may name a target version (e.g. `v0.19.1`). If empty, target the
+**latest** release of the upstream template repo.
+
+## 1. Determine current and target versions
+
+- Read `.rhiza/template.yml`: the `repository:` field is the upstream template
+  repo (usually `jebel-quant/rhiza`) and `ref:` is the currently pinned version.
+- Resolve the target version:
+  - If `$ARGUMENTS` names a version, use it (verify the tag exists:
+    `gh api repos/<repository>/git/ref/tags/<ref>`).
+  - Otherwise get the latest release:
+    `gh release view --repo <repository> --json tagName,publishedAt`.
+- If `ref:` already equals the target, report "already up to date" and stop.
+- Briefly summarize what's between the two versions when it's cheap to do so
+  (`gh release view`/release notes), so the reviewer knows what's landing.
+
+### The Rhiza CLI pin (`.rhiza/.rhiza-version`) — ask before changing it
+
+`.rhiza/.rhiza-version` separately pins the **Rhiza CLI** — the `rhiza` package on
+PyPI that `make sync` runs as `uvx "rhiza==<version>"`. It is independent of the
+template `ref:` above, and there is no `$ARGUMENTS` override for it: always target
+the **latest** published version.
+
+- Read the current pin from `.rhiza/.rhiza-version`.
+- Resolve the latest published version on PyPI:
+  `curl -s https://pypi.org/pypi/rhiza/json` and read `.info.version`.
+- If the pin already equals the latest, there is nothing to do — leave it.
+- If a newer version is available, **ask the user whether to update the CLI** to
+  that latest version (state current → latest). Only bump `.rhiza/.rhiza-version`
+  if they agree; if they decline, leave the file untouched and proceed with the
+  template sync alone.
+
+## 2. Bump the pin(s) and commit (the tree must be clean to sync)
+
+- `make sync` refuses to run on a dirty tree, so the bump lands first.
+- Branch off the default branch (don't work on `main`/`master` directly):
+  `git checkout -b sync/rhiza-<target>`.
+- Edit `ref:` in `.rhiza/template.yml` to the target version. If the user agreed
+  to a CLI bump above, also set `.rhiza/.rhiza-version` to the latest PyPI version
+  in the same step, so `make sync` runs with the chosen CLI.
+- Commit the pin change(s) (e.g. `Chore: bump rhiza template ref <old> → <target>`,
+  noting the CLI bump in the message when one was made).
+
+## 3. Sync
+
+- Run `make sync` (it invokes `rhiza sync`). Expect it to either complete
+  cleanly or report conflicts. It writes the refreshed `.rhiza/template.lock`.
+- If it completes with no conflicts, skip to step 5.
+
+## 4. Resolve every conflict
+
+The sync is a 3-way merge. Two kinds of leftovers can appear — handle both, and
+finish with **zero** `*.rej` files and **zero** conflict markers
+(`<<<<<<<` / `=======` / `>>>>>>>`) anywhere tracked
+(`git grep -lE '^(<<<<<<<|=======|>>>>>>>)'`).
+
+**`*.rej` files (rejected hunks).** The 3-way merge often *already applied* a
+hunk and still drops a duplicate `.rej`. For each, verify whether the change is
+already present in the file (the added `+` lines exist; no conflict markers
+remain). If it is, the `.rej` is spurious — delete it. If a hunk genuinely did
+not apply, apply it by hand, then delete the `.rej`.
+
+**Conflict-marked files.** Resolve by the ownership rule (see `CLAUDE.md` and the
+`files:` block of `.rhiza/template.lock` for the authoritative managed-file list):
+
+- **Rhiza-managed files** (the `.github/workflows/*`, `Makefile`,
+  `.pre-commit-config.yaml`, `pytest.ini`, the `.rhiza/` engine, etc.): take the
+  **incoming/upstream** side — these are owned by the template and should match
+  it (`git checkout --theirs -- <file>` then `git add`).
+- **Locally-owned or locally-hardened files** (notably `ruff.toml`, plus
+  `pyproject.toml`, `README.md`, `src/`, your `tests/`): **merge by hand** —
+  keep the local intent (e.g. stricter lint rules) while folding in genuine
+  upstream additions, and make the result internally coherent (dedupe, drop
+  comments that now contradict the config).
+
+Validate every touched workflow/YAML still parses before moving on.
+
+## 5. Verify the gates and fix fallout
+
+A version bump can tighten the gates (new lint rules, `mypy --strict`, expanded
+docs-coverage scope, etc.) and surface pre-existing issues. Run them and get
+them green:
+
+1. `make fmt` — pre-commit + lint
+2. `make typecheck`
+3. `make docs-coverage`
+4. `make deptry`
+5. `make security`
+6. `make test`
+
+**Scope your fixes.** Fix issues only in **locally-owned** files (`src/`,
+`tests/`, `pyproject.toml`, locally-hardened config). If a gate fails because of
+a **Rhiza-managed** file, that is an upstream problem: fix it in
+`jebel-quant/rhiza` and bump again — do **not** edit the synced artifact in
+place. Call out any such upstream-owned failure explicitly rather than papering
+over it locally.
+
+### Configure the CI variables/secrets the synced workflows need (fuzzing & mutation)
+
+If this sync added or updated the fuzzing/mutation workflows
+(`.github/workflows/rhiza_fuzzing.yml`, `.github/workflows/rhiza_mutation.yml`),
+make sure the configuration they read is present. These are **GitHub Actions
+repository variables and secrets** — *not* local env vars or files — set under
+**Settings → Secrets and variables → Actions** (or via `gh`), and documented in
+`.github/CONFIG.md`. Skip this step entirely if neither workflow is present.
+
+Inspect what is already set (presence only — secret values are never readable):
+
+- `gh variable list`
+- `gh secret list`
+
+**Mutation** (`rhiza_mutation.yml`) reads:
+
+- `MUTATION_ENABLED` (variable) — must be `true` for the mutation gate/badge to run.
+- `GH_PAT` (secret) — git auth for installing private dependencies.
+- `UV_EXTRA_INDEX_URL` (secret) — extra package index URL (with credentials) for private deps.
+
+**Fuzzing** (`rhiza_fuzzing.yml`) needs no user configuration — it uses the
+automatic `GITHUB_TOKEN`, so do not prompt for any fuzzing secret.
+
+For each of the above that is **missing**, **ask the user** whether to set it and
+for its value; set only the ones they provide:
+
+- variables: `gh variable set MUTATION_ENABLED --body true`
+- secrets:   `gh secret set GH_PAT` (let `gh` read the value from stdin — never
+  echo a secret value into the transcript or a commit).
+
+Leave anything the user declines unset, and note it in the PR body so the reviewer
+knows the corresponding workflow step will be skipped or fail until it is configured.
+
+## 6. Commit, push, open a PR
+
+- Commit the resolution and any in-scope fixes with clear messages (one logical
+  change per commit: the conflict resolution, then each gate fix).
+- Push the branch and open a PR (`gh pr create`) titled for the bump, e.g.
+  `Chore: sync Rhiza template <old> → <target>`. In the body, summarize how each
+  conflict was resolved, list any gate fallout you fixed, and flag anything that
+  needs an **upstream** fix in Rhiza.
+- Report a concise per-gate PASS/FAIL summary. If the workflow files changed,
+  note that pushing them needs a token with the `workflow` scope.
+
+Do not merge the PR. Stop after it is open and summarize what landed and what
+(if anything) is blocked on an upstream Rhiza change.

--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.1.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.1.2
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.1.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.1.2
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.1.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.1.2
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.1.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.1.2
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.1.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.1.2
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.1.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.1.2
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.1.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.1.2
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.1.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.1.2
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -221,7 +221,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.1.1
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.1.2
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.1.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.1.2
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v1.1.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v1.1.2
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -25,5 +25,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.1.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.1.2
     secrets: inherit

--- a/.rhiza/rhiza.mk
+++ b/.rhiza/rhiza.mk
@@ -145,6 +145,12 @@ post-sync:: ; @:
 pre-validate:: ; @:
 post-validate:: ; @:
 
+# Detected once at parse time: non-empty when origin is the jebel-quant/rhiza
+# mother repository, which by design has no template.yml. The sync/summarise/
+# validate targets are no-ops there. Evaluated a single time and reused so the
+# origin regex lives in exactly one place.
+IS_MOTHER_REPO := $(shell git remote get-url origin 2>/dev/null | grep -iqE 'jebel-quant/rhiza(\.git)?$$' && echo 1)
+
 ##@ Rhiza Workflows
 
 print-logo:
@@ -152,7 +158,7 @@ print-logo:
 
 
 sync: pre-sync ## sync with template repository as defined in .rhiza/template.yml
-	@if git remote get-url origin 2>/dev/null | grep -iqE 'jebel-quant/rhiza(\.git)?$$'; then \
+	@if [ -n "$(IS_MOTHER_REPO)" ]; then \
 		printf "${BLUE}[INFO] Skipping sync in rhiza repository (no template.yml by design)${RESET}\n"; \
 	else \
 		$(MAKE) install-uv && \
@@ -173,7 +179,7 @@ materialize: ## [DEPRECATED] use 'make sync' instead — materialize --force is 
 	@$(MAKE) sync
 
 summarise-sync: install-uv ## summarise differences created by sync with template repository
-	@if git remote get-url origin 2>/dev/null | grep -iqE 'jebel-quant/rhiza(\.git)?$$'; then \
+	@if [ -n "$(IS_MOTHER_REPO)" ]; then \
 		printf "${BLUE}[INFO] Skipping summarise-sync in rhiza repository (no template.yml by design)${RESET}\n"; \
 	else \
 		$(MAKE) install-uv; \
@@ -188,7 +194,7 @@ rhiza-test: install ## run rhiza's own tests (if any)
 	fi
 
 validate: pre-validate rhiza-test ## validate project structure against template repository as defined in .rhiza/template.yml
-	@if git remote get-url origin 2>/dev/null | grep -iqE 'jebel-quant/rhiza(\.git)?$$'; then \
+	@if [ -n "$(IS_MOTHER_REPO)" ]; then \
 		printf "${BLUE}[INFO] Skipping validate in rhiza repository (no template.yml by design)${RESET}\n"; \
 	else \
 		$(MAKE) install-uv; \

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: cc162bbe38291955e0aa5f3418c1bcfd10fbba24
+sha: b0748ea2ac6b1b0e3bbf76470b717427cf22a289
 repo: jebel-quant/rhiza
 host: github
-ref: v1.1.1
+ref: v1.1.2
 include: []
 exclude: []
 templates:
@@ -65,14 +65,9 @@ files:
 - .rhiza/semgrep.yml
 - .rhiza/tests/README.md
 - .rhiza/tests/conftest.py
-- .rhiza/tests/stress/README.md
-- .rhiza/tests/stress/__init__.py
-- .rhiza/tests/stress/conftest.py
 - .rhiza/tests/test_docstrings.py
-- .rhiza/tests/test_git_repo_fixture.py
 - .rhiza/tests/test_pyproject.py
 - .rhiza/tests/test_readme_validation.py
-- .rhiza/tests/test_utils.py
 - LICENSE
 - Makefile
 - SECURITY.md
@@ -86,5 +81,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-07-09T08:44:21Z'
+synced_at: '2026-07-10T06:26:59Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v1.1.1"
+ref: "v1.1.2"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Summary
- Bumps the template `ref` to `v1.1.2` in `.rhiza/template.yml`
- Platform profile: `github-project` (unchanged — origin is on github.com, already matched)
- Runs `make sync` to apply upstream template changes; conflicts resolved taking upstream
- `.rhiza-version` (rhiza tool version) left untouched, per the decoupled-version rule

## Notes
- The `.rhiza/tests/` suite needed no changes: this repo's earlier cleanup (PR #877) already matches the v1.1.2 tests bundle, so the sync flagged the removed files (`stress/`, `test_utils.py`, `test_git_repo_fixture.py`) as already-deleted orphans.
- `.claude/commands/rhiza_*.md` were **restored** by the template (they had been deleted in #875). Kept per the take-upstream policy. If you want them gone permanently, exclude them via `.rhiza/template.yml` rather than deleting the files.
- 12 `.github/workflows/*.yml` updated → the merge needs a token with the `workflow` permission.

## Quality gates
| Gate | Result |
|------|--------|
| `make fmt` (lint/style) | ✅ PASS |
| `make typecheck` (ty + mypy --strict, 52 files) | ✅ PASS |
| `make docs-coverage` (interrogate) | ✅ PASS — 100.0% (1860 items) |
| `make deptry` | ✅ PASS — no dependency issues |
| `make security` (pip-audit + bandit) | ✅ PASS — 0 vulns |
| `make validate` (template fidelity) | ✅ PASS |
| `make test` (suite + coverage gate) | ✅ PASS — 1213 passed, 5 skipped, 100.0% coverage |

## Scorecard (1–10, scoped to locally-owned code)
| Subcategory | Score | Justification |
|-------------|-------|---------------|
| Linting / style | 10 | `make fmt` fully green (ruff format+check, markdownlint, bandit, actionlint) |
| Type safety | 10 | `ty` + `mypy --strict` clean over 52 `src/` files |
| Docstring / API-doc coverage | 10 | interrogate 100.0% (1860 items) |
| Test pass rate | 10 | 1213 passed; 5 skips are env-gated (no Chrome for kaleido) |
| Test coverage & depth | 10 | 100.0% line+branch (3145 stmts, 0 miss); gate set at 100%; 67 snapshots |
| Dependency & security hygiene | 10 | deptry clean; pip-audit 0 vulns; bandit clean |
| Template fidelity (`make validate`) | 10 | validate passes; synced clean to v1.1.2 |
| Code complexity | 9 | avg CC = A (2.86), zero C-or-worse blocks, all MI = A; only watch-item is module size (`data.py` 808 LoC, `_stats/_performance.py` 714) |
| Overall architecture | 9 | clean layering (lower layers never import `data`/`portfolio`), no cycles, TYPE_CHECKING protocol pattern; minor: a few function-local self-imports in `data.py` (`from jquantstats import Data/interpolate`) |
| Test design quality | 9 | strong behaviour assertions (many exact error-message tests); watch snapshot brittleness (67 syrupy snapshots pin plot output) |
| Error handling | 10 | dedicated `exceptions.py`; descriptive, tested messages |
| Security posture & trust boundaries | 10 | numeric library, no `subprocess`/path-remap in `src`; bandit clean |
| Public API / semver discipline | 10 | clean public surface (`data`/`portfolio`/`result`); internals `_`-prefixed |
| User-facing documentation | 10 | README code blocks executed & asserted by the test suite |

**Overall: 9.5 / 10 — exemplary.** All gates pass; 100% coverage and docstrings; A-grade complexity and maintainability throughout.

**Highest-leverage improvement:** split the two largest modules (`src/jquantstats/data.py`, `src/jquantstats/_stats/_performance.py`) along their internal seams to lift Code complexity and Architecture from 9 → 10.
