### PR TITLE
Support Python 3.14; refresh README badges; add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+Guidance for Claude Code sessions working in this repository.
+
+## Project
+
+**jquantstats** — portfolio analytics for quants, built on [Polars](https://pola.rs/)
+(zero pandas at runtime) with interactive [Plotly](https://plotly.com/python/) charts.
+Python `>=3.11`, MIT-licensed, published to PyPI. This is a
+[Rhiza](https://github.com/jebel-quant/rhiza)-managed repository (template `v1.1.2`).
+
+## Commands
+
+Prefer bare `make <target>`. **Never call `.venv/bin/...` directly** — the Makefile
+resolves the environment for you.
+
+| Target | Purpose |
+|---|---|
+| `make install` | Create/refresh the uv environment and install deps |
+| `make fmt` | Format and lint-fix with ruff |
+| `make test` | Run pytest with coverage (fails under the coverage threshold) |
+| `make typecheck` | Static type checking |
+| `make docs-coverage` | Docstring coverage report (interrogate) |
+| `make deptry` | Detect unused / missing / misplaced dependencies |
+| `make security` | Security scan (bandit / semgrep) |
+| `make book` | Build the MkDocs documentation site |
+| `make serve` | Serve the docs locally |
+| `make marimo` | Run/validate the marimo notebooks |
+| `make benchmark` | Run the QuantStats-parity benchmark |
+| `make mutation` | Run mutation testing |
+| `make clean` | Remove build/test artifacts |
+
+Run `make` (or `make help` if available) to list all targets. The Makefile is
+repo-owned (see its header) and can be edited without breaking template sync; it
+includes the template-managed API via `.rhiza/rhiza.mk`.
+
+## Architecture
+
+Source lives under `src/jquantstats/`. Two public entry points, both exposing the
+same `.stats`, `.plots`, and `.report` accessors:
+
+- **`Portfolio`** (`portfolio.py`) — the primary route. Built from prices + positions
+  (`from_cash_position`, `from_position`, `from_risk_position`); compiles NAV and
+  unlocks position-level analysis (execution-delay via `lag(n)`, tilt/timing
+  attribution, turnover, cost models) that a return series can't support.
+- **`Data`** (`data.py`) — the returns route (`from_returns`), for arbitrary return streams.
+
+Internal layering (leading-underscore modules are private):
+
+- `_portfolio_*.py` — Portfolio internals split by concern: `_base`, `_constructors`,
+  `_nav`, `_cost`, `_turnover`, `_transform`, `_attribution`.
+- `_cost_model.py` — the two independent cost models (per-unit, turnover-bps).
+- `_stats/` — metric mixins (`_basic`, `_basic_core`, `_performance`, `_reporting`,
+  `_montecarlo`).
+- `_plots/` — Plotly chart builders (portfolio + data variants).
+- `_reports/` — HTML report rendering (`_html.py`) via Jinja2 `templates/`.
+- `_utils/` — data helpers. `_protocol.py`, `_types.py`, `exceptions.py`,
+  `result.py`, `_cache.py` — shared plumbing.
+
+An optional FastAPI service lives in `api/` (installed via the `[web]` extra).
+
+## Rhiza template split
+
+This repo mixes **locally-owned** source with files **synced from
+`jebel-quant/rhiza`**. The synced set is enumerated in `.rhiza/template.lock`
+(`files:` block) and includes `.github/workflows/rhiza_*.yml`, `.rhiza/`,
+`docs/mkdocs-base.yml`, and other tooling config.
+
+**Rule:** gaps or bugs in Rhiza-managed files are fixed **upstream** in the template
+and pulled in via a sync — do **not** patch them locally, or the next sync will
+revert your change. Everything below is locally owned and edited here:
+
+- `src/`, `tests/`, `api/`
+- `pyproject.toml`, `README.md`, `CLAUDE.md`, `Makefile`, `mkdocs.yml`
+- `docs/*.md` project documentation (but **not** `docs/mkdocs-base.yml`)
+
+## Conventions
+
+- **Coverage threshold:** `COVERAGE_FAIL_UNDER = 100` (`.rhiza/make.d/custom-env.mk`) —
+  the suite must keep 100% line coverage.
+- **Docstrings:** Google style; interrogate is expected to report 100% (`make docs-coverage`).
+- **Tests** live under `tests/`; `test_quantstats.py` validates metrics against the
+  `quantstats` reference implementation (a dev-only dependency).
+- Fully type-annotated public API (`py.typed`).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # [jQuantStats](https://jebel-quant.github.io/jquantstats): Portfolio Analytics for Quants
 
-[![PyPI version](https://badge.fury.io/py/jquantstats.svg)](https://badge.fury.io/py/jquantstats)
-[![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://pypi.org/project/jquantstats/)
-[![Downloads](https://static.pepy.tech/personalized-badge/jquantstats?period=month&units=international_system&left_color=black&right_color=orange&left_text=PyPI%20downloads%20per%20month)](https://pepy.tech/project/jquantstats)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/jebel-quant/jquantstats/blob/main/LICENSE)
-[![CodeFactor](https://www.codefactor.io/repository/github/jebel-quant/jquantstats/badge)](https://www.codefactor.io/repository/github/jebel-quant/jquantstats)
-[![Rhiza](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fjebel-quant%2Fjquantstats%2Fmain%2F.rhiza%2Ftemplate.yml&query=%24.ref&label=rhiza)](https://github.com/jebel-quant/rhiza)
+[![PyPI version](https://badge.fury.io/py/jquantstats.svg)](https://pypi.org/project/jquantstats/)
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![Python versions](https://img.shields.io/badge/Python-3.11%20•%203.12%20•%203.13%20•%203.14-blue?logo=python)](https://www.python.org/)
+[![CI](https://github.com/jebel-quant/jquantstats/actions/workflows/rhiza_ci.yml/badge.svg?event=push)](https://github.com/jebel-quant/jquantstats/actions/workflows/rhiza_ci.yml)
 [![Coverage](https://jebel-quant.github.io/jquantstats/coverage-badge.svg)](https://jebel-quant.github.io/jquantstats/reports/html-coverage/)
+[![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg?logo=ruff)](https://github.com/astral-sh/ruff)
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![CodeFactor](https://www.codefactor.io/repository/github/jebel-quant/jquantstats/badge)](https://www.codefactor.io/repository/github/jebel-quant/jquantstats)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jebel-quant/jquantstats/badge)](https://scorecard.dev/viewer/?uri=github.com/jebel-quant/jquantstats)
+[![Rhiza](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fjebel-quant%2Fjquantstats%2Fmain%2F.rhiza%2Ftemplate.yml&query=%24.ref&label=rhiza)](https://github.com/jebel-quant/rhiza)
+[![Downloads](https://static.pepy.tech/personalized-badge/jquantstats?period=month&units=international_system&left_color=black&right_color=orange&left_text=PyPI%20downloads%20per%20month)](https://pepy.tech/project/jquantstats)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jebel-quant/jquantstats)
 
 [![Paper](https://img.shields.io/badge/paper-jquantstats.pdf-red?logo=adobeacrobatreader)](https://github.com/jebel-quant/jquantstats/blob/paper/jquantstats.pdf)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "License :: OSI Approved :: MIT License",
 ]
 


### PR DESCRIPTION
## Summary
- **Support Python 3.14** — add the `Programming Language :: Python :: 3.14` classifier. The CI matrix is generated from classifiers, so 3.14 is now tested automatically (`make version-matrix` → `["3.11","3.12","3.13","3.14"]`). `requires-python` already had no upper bound and `uv.lock` already carries 3.14 resolution markers, so nothing was actually blocking it — it was just undeclared and untested.
- **Refresh README badges** to the standard rhiza set: adds CI (`rhiza_ci.yml`), ruff, uv, OpenSSF Scorecard, and Codespaces; keeps PyPI, Downloads, Rhiza template, and Paper. Python-versions badge extended to include 3.14.
- **Add `CLAUDE.md`** — commands (real `make` targets), architecture (`Portfolio`/`Data` entry points, module layering), and the locally-owned vs. Rhiza-synced split.

## Verification
- Pre-commit hooks pass, including "Check Python version consistency".
- ⚠️ The test suite was **not** run on 3.14 locally (this machine pins 3.12). The green/red signal for 3.14 comes from CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)