### PR TITLE
feat(plugin): shared portfolio context, plus analysis, diagnostics and robustness skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,12 +11,17 @@
     {
       "name": "jquantstats",
       "source": "./plugin",
-      "description": "Write correct jquantstats code and migrate off QuantStats",
+      "description": "Analyse portfolios with jquantstats: shared portfolio context, analysis, diagnostics, robustness, QuantStats migration",
       "homepage": "https://jebel-quant.github.io/jquantstats/",
       "repository": "https://github.com/jebel-quant/jquantstats",
       "license": "MIT",
       "category": "finance",
-      "tags": ["quant", "portfolio-analytics", "polars", "quantstats"]
+      "tags": [
+        "quant",
+        "portfolio-analytics",
+        "polars",
+        "quantstats"
+      ]
     }
   ]
 }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "jquantstats",
   "displayName": "jquantstats",
-  "description": "Write correct jquantstats code and migrate off QuantStats",
-  "version": "0.1.0",
+  "description": "Analyse portfolios with jquantstats: shared portfolio context, analysis, diagnostics, robustness, QuantStats migration",
+  "version": "0.2.0",
   "author": {
     "name": "Thomas Schmelzer",
     "email": "thomas.schmelzer@gmail.com"
@@ -11,5 +11,11 @@
   "homepage": "https://jebel-quant.github.io/jquantstats/",
   "repository": "https://github.com/jebel-quant/jquantstats",
   "license": "MIT",
-  "keywords": ["quant", "portfolio-analytics", "polars", "plotly", "quantstats"]
+  "keywords": [
+    "quant",
+    "portfolio-analytics",
+    "polars",
+    "plotly",
+    "quantstats"
+  ]
 }

--- a/plugin/commands/load.md
+++ b/plugin/commands/load.md
@@ -1,0 +1,50 @@
+---
+description: Build the shared jquantstats portfolio context from data files, or show the existing one
+argument-hint: "[--prices data/prices.csv --cash-position data/pos.csv --aum 1e6] | show | list | check"
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+Manage the portfolio context that every jquantstats skill reads.
+
+Arguments: `$ARGUMENTS`
+
+Follow `${CLAUDE_PLUGIN_ROOT}/reference/portfolio-context.md`.
+
+## With arguments
+
+Pass them straight through, choosing the subcommand from what was given —
+`portfolio` when a position file is named, `data` for a return or price series,
+or the bare subcommand when the user typed `show`, `list`, `check` or
+`activate`:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_load.py <subcommand> $ARGUMENTS
+```
+
+Then relay the digest, leading with any `WARNING` lines — those change which
+answers are correct later, so they must not be buried.
+
+## With no arguments
+
+If `.jquantstats/context.json` exists, just show it:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_load.py show
+```
+
+Otherwise discover candidates rather than guessing. Look for price, position,
+return and benchmark files (`*.csv`, `*.parquet` under `data/`, `input/`,
+the repo root), read the header row of each to see its date column and asset
+columns, then **propose** a concrete command and confirm before running it.
+
+Two things must not be invented:
+
+- **`--aum`** is unrecoverable from the data. Ask for it.
+- **Which position flag applies** — `--cash-position` (currency),
+  `--position` (share counts), `--risk-position` (risk units) — changes every
+  number downstream. Ask if the file's units are not obvious from its
+  magnitudes and column names.
+
+If only returns or prices are available with no positions, build a `Data`
+context instead, and mention that turnover, cost and lag analysis need
+positions.

--- a/plugin/commands/review.md
+++ b/plugin/commands/review.md
@@ -1,0 +1,48 @@
+---
+description: Full review of the active jquantstats portfolio — performance, risk, robustness, and what would break it
+argument-hint: "[context name] [focus, e.g. costs | drawdowns | benchmark]"
+allowed-tools: Bash, Read, Glob, Grep, Write
+---
+
+Review the portfolio in the shared context. Arguments: `$ARGUMENTS`
+
+Treat any argument as a context name if it matches one from `jqs_load.py list`,
+otherwise as a focus area to weight the review toward.
+
+## Sequence
+
+**1. Load and validate.** Follow
+`${CLAUDE_PLUGIN_ROOT}/reference/portfolio-context.md`:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_load.py show
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_load.py check
+```
+
+If the digest carries warnings or `check` reports `STALE`, resolve that first —
+use the `portfolio-diagnostics` skill. Do not report metrics computed over a
+known-broken sample; a plausible wrong number is worse than a delay.
+
+**2. Performance and risk.** Use the `portfolio-analysis` skill. One Python
+snippet, not one per metric: `summary()`, drawdown depth and duration, tail
+measures, and — if the context has a benchmark — alpha, beta and capture.
+
+**3. Robustness.** Use the `portfolio-robustness` skill. For a `Portfolio`
+context always cover execution delay and cost sensitivity; both are cheap and
+both kill more strategies than anything in step 2 reveals. Add autocorrelation
+and sample-significance checks when the history is short.
+
+**4. Charts.** Write figures to `_analysis/` and give the user the paths — a
+`go.Figure` cannot render in a terminal. `pf.report.to_html(path=...)` for a full
+document.
+
+## Reporting
+
+- Open with the two or three findings that would change a decision, not with a
+  metric dump. The digest and the report already hold the full table.
+- Quote the periodicity behind any annualised figure, and the sample length
+  behind any Sharpe.
+- Give breaking points where you have them: the bps at which the edge vanishes,
+  the lag at which it dies, the percentile the observed drawdown occupies.
+- State what you did **not** test. An unqualified clean bill of health from a
+  short backtest is the least useful thing this review can produce.

--- a/plugin/reference/portfolio-context.md
+++ b/plugin/reference/portfolio-context.md
@@ -1,0 +1,146 @@
+# The portfolio context
+
+Shared protocol for every jquantstats skill. One portfolio, many ways of
+reasoning about it — the skills differ, the object does not.
+
+## Why a recipe rather than a live object
+
+Each Bash call is a fresh Python process, so no `Portfolio` instance survives
+between tool calls. What survives is a **recipe**: the paths and constructor
+arguments needed to rebuild it. Rebuilding is not approximating — the same
+inputs through the same recorded constructor give a bit-identical object, lag
+and costs included.
+
+Two files under `.jquantstats/`:
+
+| File | Contents | Lifecycle |
+|---|---|---|
+| `context.json` | the recipe: entry point, constructor, input paths, args, post-transforms | authoritative, commit it |
+| `digest.json` | derived facts: shape, nulls, anchor metrics, warnings, input fingerprints | regenerable, gitignore it |
+
+## Getting the portfolio
+
+Everything runs through the wrapper, which finds a Python that can import the
+library (active venv → repo `.venv` → `python3` → `uv run --with jquantstats`):
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_load.py show
+```
+
+**If `.jquantstats/context.json` already exists**, that is the portfolio. Do not
+ask the user to re-specify it, and do not build a different one. `show` rebuilds
+it and reprints the digest.
+
+**If it does not exist**, create it once:
+
+```bash
+# prices + positions: unlocks turnover, costs, execution delay, attribution
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_load.py portfolio \
+    --prices data/prices.csv --cash-position data/pos.csv --aum 1e6 --cost-bps 5
+
+# a return or price series: the QuantStats-equivalent route
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_load.py data \
+    --returns data/returns.csv --benchmark data/spy.csv --null-strategy drop
+```
+
+Position input picks the constructor: `--cash-position` (currency),
+`--position` (share counts), `--risk-position` (risk units, with `--vola`).
+Never guess `--aum`: it is unrecoverable from the data, so ask.
+
+## Using it in analysis
+
+Every snippet starts the same way. Read the recipe, never re-derive it:
+
+```python
+import os, sys
+sys.path.insert(0, os.path.join(os.environ["CLAUDE_PLUGIN_ROOT"], "scripts"))
+from jqs_context import load
+
+pf = load()              # the active context
+pf = load("lag1")        # a named variant
+```
+
+## Variants
+
+Comparisons are first-class here — lag sweeps, cost sweeps, sub-periods. Record
+each as its own named context rather than juggling ad-hoc objects:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_load.py portfolio \
+    --prices data/prices.csv --cash-position data/pos.csv --aum 1e6 \
+    --lag 1 --name lag1
+```
+
+`jqs_load.py list` shows them all (`*` marks the active one); `activate <name>`
+switches. Each keeps its own digest and its own fingerprints.
+
+## Staleness
+
+`digest.json` stores a SHA-256 of every input. Before quoting any number from
+it, confirm it still describes the files on disk:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_load.py check
+```
+
+`STALE` means the inputs changed after the digest was written. Recompute; do not
+quote the stored value. The digest's `anchors` block exists as a tripwire, not a
+cache: if a fresh computation disagrees with it, something in the rebuild is
+wrong and that is worth investigating before reporting anything.
+
+## Recipe schema
+
+Hand-editable, and the fields are not optional decoration:
+
+```json
+{
+  "schema": 1,
+  "active": "base",
+  "contexts": {
+    "base": {
+      "name": "base",
+      "entry_point": "Portfolio",
+      "constructor": "from_cash_position",
+      "inputs": {
+        "prices":        { "path": "data/prices.csv", "date_col": "Date" },
+        "cash_position": { "path": "data/pos.csv" }
+      },
+      "args": { "aum": 1000000.0, "cost_bps": 5.0 },
+      "post": [{ "op": "lag", "n": 1 }]
+    }
+  }
+}
+```
+
+- `entry_point` / `constructor` — `Portfolio` and `Data` expose different
+  accessors, so which one is held changes every downstream call.
+- `date_col` — omitted means "the first column".
+- `args` — `aum` is required for Portfolio. Cost args change every return
+  downstream, so a cost-free rebuild silently disagrees with earlier answers.
+- `post` — the transform replay, in order (`lag`, `truncate`, `resample`). **The
+  one people forget.** A `lag(1)` study rebuilt unlagged looks entirely
+  plausible and is wrong.
+
+An input can also name a repo-owned function instead of a file, for positions
+that come from an expression, a query, or a model:
+
+```json
+"cash_position": { "script": "analysis/build.py", "callable": "positions" }
+```
+
+The function takes no arguments and returns a `pl.DataFrame`. Logic stays in a
+reviewable `.py` file rather than as source embedded in JSON.
+
+## Checking the API before you use it
+
+The library's surface moves and its short aliases do not exist. Confirm a symbol
+rather than recalling it:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_api.py --show sharpe
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_api.py --grep drawdown
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_api.py stats
+```
+
+`--show` on a missing name says so. That means it was renamed to a canonical
+form or never ported — report that, do not write a wrapper to paper over it.

--- a/plugin/scripts/.ruff.toml
+++ b/plugin/scripts/.ruff.toml
@@ -1,0 +1,15 @@
+# Scoped lint override for the plugin's CLI scripts.
+#
+# The repo-root `ruff.toml` is Rhiza-managed (see CLAUDE.md: gaps in synced files
+# are fixed upstream, never patched locally), so a per-file-ignore cannot live
+# there. Ruff resolves configuration hierarchically, so this file applies to
+# plugin/scripts/ only and leaves src/ and tests/ under the repo-wide rules.
+extend = "../../ruff.toml"
+
+[lint]
+# TRY003 — `src/` follows the typed-exception pattern in `exceptions.py`, where
+# each error class builds its own message. These are argv-driven CLI scripts
+# whose entire job is to fail legibly: "input file not found: data/prices.csv"
+# belongs at the raise site, and ~20 subclasses of one ContextError would make
+# the failures harder to read, not easier.
+extend-ignore = ["TRY003"]

--- a/plugin/scripts/jqs.sh
+++ b/plugin/scripts/jqs.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Run a jquantstats plugin script under the first Python that can import the library.
+#
+# Resolution order: the active virtualenv, a repo-local .venv, whatever `python3`
+# resolves to, then `uv run --with jquantstats` as a last resort. Without this the
+# plugin only works from inside a repo that already has jquantstats installed.
+#
+# Usage: jqs.sh jqs_load.py portfolio --prices ... | jqs.sh jqs_api.py --show sharpe
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+name="${1:-}"
+if [[ -z "${name}" ]]; then
+    echo "usage: jqs.sh <jqs_load.py|jqs_api.py> [args...]" >&2
+    exit 64
+fi
+shift
+
+target="${here}/${name}"
+if [[ ! -f "${target}" ]]; then
+    echo "no such plugin script: ${name}" >&2
+    exit 66
+fi
+
+can_import() {
+    "$1" -c 'import jquantstats, polars' >/dev/null 2>&1
+}
+
+candidates=()
+[[ -n "${VIRTUAL_ENV:-}" ]] && candidates+=("${VIRTUAL_ENV}/bin/python")
+candidates+=("./.venv/bin/python" "python3" "python")
+
+for candidate in "${candidates[@]}"; do
+    if command -v "${candidate}" >/dev/null 2>&1 && can_import "${candidate}"; then
+        exec "${candidate}" "${target}" "$@"
+    fi
+done
+
+if command -v uv >/dev/null 2>&1; then
+    exec uv run --quiet --with jquantstats --with polars python "${target}" "$@"
+fi
+
+echo "no Python with jquantstats available — install jquantstats, or install uv" >&2
+exit 69

--- a/plugin/scripts/jqs_api.py
+++ b/plugin/scripts/jqs_api.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Report the jquantstats API surface as it actually is in the installed version.
+
+The library's metric names move, and hand-maintained mapping tables drift out of
+date silently — an invented method that "looks right" is the most expensive kind
+of mistake here. Ask this script instead of recalling.
+
+Examples::
+
+    jqs_api.py                       # section counts
+    jqs_api.py stats                 # every Stats method
+    jqs_api.py --grep drawdown       # find a name across the whole surface
+    jqs_api.py --show sharpe         # signature and docstring
+    jqs_api.py --show conditional_value_at_risk
+    jqs_api.py constructors          # how to build a Portfolio or Data
+"""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import json
+from typing import Any
+
+SECTION_ORDER = ("stats", "data-plots", "portfolio-plots", "portfolio", "data", "constructors")
+
+
+def _sections() -> dict[str, Any]:
+    """Map section names to the classes they describe.
+
+    Returns:
+        Mapping of section name to class object.
+    """
+    from jquantstats import Data, Portfolio
+    from jquantstats._plots import DataPlots, PortfolioPlots
+    from jquantstats._stats._stats import Stats
+
+    return {
+        "stats": Stats,
+        "data-plots": DataPlots,
+        "portfolio-plots": PortfolioPlots,
+        "portfolio": Portfolio,
+        "data": Data,
+    }
+
+
+def _public(cls: type) -> list[str]:
+    """List the public attribute names of *cls*.
+
+    Args:
+        cls: Class to inspect.
+
+    Returns:
+        Sorted public names.
+    """
+    return sorted(name for name in dir(cls) if not name.startswith("_"))
+
+
+def _signature(cls: type, name: str) -> str:
+    """Render a member's call signature, or mark it as a property.
+
+    The stats methods are declared taking a ``series`` argument but the accessor
+    applies them per column and returns a dict, so that first parameter is
+    dropped here to show the shape a caller actually uses.
+
+    Args:
+        cls: Owning class.
+        name: Member name.
+
+    Returns:
+        A display string.
+    """
+    member = inspect.getattr_static(cls, name, None)
+    if isinstance(member, property):
+        return "  (property)"
+    try:
+        signature = inspect.signature(getattr(cls, name))
+    except (TypeError, ValueError):
+        return ""
+    params = [p for p in signature.parameters.values() if p.name not in {"self", "series"}]
+    rendered = ", ".join(str(p) for p in params)
+    return f"({rendered})"
+
+
+def _first_paragraph(doc: str | None) -> str:
+    """Extract the summary line of a docstring.
+
+    Args:
+        doc: Raw docstring.
+
+    Returns:
+        The first non-empty line, or an empty string.
+    """
+    for line in (doc or "").strip().splitlines():
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def _constructors() -> list[tuple[str, str]]:
+    """Collect the public constructor signatures.
+
+    Returns:
+        ``(qualified name, signature)`` pairs.
+    """
+    from jquantstats import Data, Portfolio
+
+    out = []
+    for cls, names in (
+        (Portfolio, ("from_cash_position", "from_position", "from_risk_position")),
+        (Data, ("from_returns", "from_prices")),
+    ):
+        for name in names:
+            func = getattr(cls, name, None)
+            if func is not None:
+                out.append((f"{cls.__name__}.{name}", str(inspect.signature(func))))
+    return out
+
+
+def _matches(name: str, pattern: str | None) -> bool:
+    """Test a name against a case-insensitive substring filter.
+
+    Args:
+        name: Candidate name.
+        pattern: Substring, or None to match everything.
+
+    Returns:
+        Whether the name matches.
+    """
+    return pattern is None or pattern.lower() in name.lower()
+
+
+def _show(name: str) -> int:
+    """Print the signature and docstring of every member with this name.
+
+    Args:
+        name: Member name to look up.
+
+    Returns:
+        A process exit code.
+    """
+    found = False
+    for section, cls in _sections().items():
+        if name in _public(cls):
+            found = True
+            print(f"{section}:{cls.__name__}.{name}{_signature(cls, name)}")
+            doc = inspect.getdoc(getattr(cls, name, None))
+            if doc:
+                print("\n".join(f"    {line}" for line in doc.splitlines()))
+            print()
+    if not found:
+        print(f"{name!r} is not on any public surface.")
+        print("It was either renamed to a canonical form or never ported — do not wrap it.")
+        print("Try: jqs_api.py --grep <part of the name>")
+        return 1
+    return 0
+
+
+def _dump_json(sections: dict[str, Any], pattern: str | None) -> None:
+    """Emit the whole surface as JSON.
+
+    Args:
+        sections: Section-to-class mapping.
+        pattern: Optional substring filter.
+    """
+    payload: dict[str, Any] = {
+        section: {name: _signature(cls, name) for name in _public(cls) if _matches(name, pattern)}
+        for section, cls in sections.items()
+    }
+    payload["constructors"] = dict(_constructors())
+    print(json.dumps(payload, indent=2))
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the CLI.
+
+    Args:
+        argv: Argument vector. Defaults to ``sys.argv[1:]``.
+
+    Returns:
+        A process exit code.
+    """
+    parser = argparse.ArgumentParser(prog="jqs_api.py", description=__doc__.splitlines()[0])
+    parser.add_argument("section", nargs="?", choices=[*SECTION_ORDER, "all"], help="surface to list")
+    parser.add_argument("--grep", help="case-insensitive substring filter on member names")
+    parser.add_argument("--show", help="print the signature and docstring of one member")
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    args = parser.parse_args(argv)
+
+    sections = _sections()
+
+    if args.show:
+        return _show(args.show)
+    if args.json:
+        _dump_json(sections, args.grep)
+        return 0
+
+    wanted = SECTION_ORDER if args.section in (None, "all") else (args.section,)
+    listing = args.section is not None or args.grep is not None
+
+    for section in wanted:
+        if section == "constructors":
+            pairs = [(n, s) for n, s in _constructors() if _matches(n, args.grep)]
+            if not pairs:
+                continue
+            print(f"constructors ({len(pairs)})")
+            for name, signature in pairs:
+                print(f"  {name}{signature}")
+            print()
+            continue
+
+        cls = sections[section]
+        names = [n for n in _public(cls) if _matches(n, args.grep)]
+        if not names:
+            continue
+        print(f"{section} — {cls.__name__} ({len(names)}{'' if args.grep is None else ' matching'})")
+        if listing:
+            for name in names:
+                summary = _first_paragraph(inspect.getdoc(getattr(cls, name, None)))
+                print(f"  {name}{_signature(cls, name)}")
+                if summary:
+                    print(f"      {summary}")
+        print()
+
+    if not listing:
+        print("pass a section name, --grep, or --show to see members")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugin/scripts/jqs_context.py
+++ b/plugin/scripts/jqs_context.py
@@ -477,6 +477,106 @@ def _require(obj: Any, attr: str, op: str) -> Any:
     return method
 
 
+def _build_portfolio(
+    ctor: str,
+    inputs: dict[str, Any],
+    args: dict[str, Any],
+    root: Path,
+    frames: dict[str, pl.DataFrame],
+    notes: list[str],
+) -> Any:
+    """Construct a Portfolio, normalising the date axis of both inputs.
+
+    Args:
+        ctor: Constructor name.
+        inputs: The recipe's ``inputs`` block.
+        args: The recipe's ``args`` block.
+        root: Project root.
+        frames: Collects the materialised inputs, keyed by role.
+        notes: Collects normalisation notes.
+
+    Returns:
+        The Portfolio.
+
+    Raises:
+        ContextError: If the constructor or inputs do not line up.
+    """
+    from jquantstats import Portfolio
+
+    if ctor not in PORTFOLIO_CONSTRUCTORS:
+        raise ContextError(f"unknown Portfolio constructor {ctor!r} ({', '.join(PORTFOLIO_CONSTRUCTORS)})")
+    pos_role = PORTFOLIO_CONSTRUCTORS[ctor]
+
+    for role in ("prices", pos_role):
+        if role not in inputs:
+            raise ContextError(f"{ctor} needs an input named {role!r}")
+        frame, renamed = _put_date_first(
+            read_input(inputs[role], root), inputs[role].get("date_col"), PORTFOLIO_DATE_COL
+        )
+        if renamed:
+            notes.append(
+                f"{role}: date column {renamed!r} renamed to 'date' — the Portfolio/Data bridge "
+                f"keeps the date axis only under that name"
+            )
+        frames[role] = frame
+
+    kwargs: dict[str, Any] = {"aum": float(args["aum"])}
+    if ctor == "from_risk_position":
+        if "vola" in args:
+            kwargs["vola"] = args["vola"]
+        if args.get("vol_cap") is not None:
+            kwargs["vol_cap"] = float(args["vol_cap"])
+    kwargs.update(_cost_kwargs(args))
+    return getattr(Portfolio, ctor)(prices=frames["prices"], **{pos_role: frames[pos_role]}, **kwargs)
+
+
+def _build_data(
+    ctor: str,
+    inputs: dict[str, Any],
+    args: dict[str, Any],
+    root: Path,
+    frames: dict[str, pl.DataFrame],
+) -> Any:
+    """Construct a Data, wiring up the benchmark and risk-free inputs.
+
+    Args:
+        ctor: Constructor name.
+        inputs: The recipe's ``inputs`` block.
+        args: The recipe's ``args`` block.
+        root: Project root.
+        frames: Collects the materialised inputs, keyed by role.
+
+    Returns:
+        The Data instance.
+
+    Raises:
+        ContextError: If the constructor or inputs do not line up.
+    """
+    from jquantstats import Data
+
+    if ctor not in DATA_CONSTRUCTORS:
+        raise ContextError(f"unknown Data constructor {ctor!r} ({', '.join(DATA_CONSTRUCTORS)})")
+    role = DATA_CONSTRUCTORS[ctor]
+    if role not in inputs:
+        raise ContextError(f"{ctor} needs an input named {role!r}")
+
+    frames[role] = read_input(inputs[role], root)
+    kwargs: dict[str, Any] = {"date_col": inputs[role].get("date_col") or frames[role].columns[0]}
+    if args.get("null_strategy"):
+        kwargs["null_strategy"] = args["null_strategy"]
+    if "benchmark" in inputs:
+        frames["benchmark"] = read_input(inputs["benchmark"], root)
+        kwargs["benchmark"] = frames["benchmark"]
+
+    rf = args.get("rf")
+    if isinstance(rf, dict):
+        frames["rf"] = read_input(rf, root)
+        kwargs["rf"] = frames["rf"]
+    elif rf is not None:
+        kwargs["rf"] = float(rf)
+    return getattr(Data, ctor)(**{role: frames[role]}, **kwargs)
+
+
 def build_detailed(recipe: dict[str, Any], root: Path) -> tuple[Any, dict[str, pl.DataFrame], list[str]]:
     """Rebuild the object and keep the raw inputs for inspection.
 
@@ -499,57 +599,12 @@ def build_detailed(recipe: dict[str, Any], root: Path) -> tuple[Any, dict[str, p
     notes: list[str] = []
     frames: dict[str, pl.DataFrame] = {}
 
+    if not isinstance(ctor, str):
+        raise ContextError(f"recipe {recipe.get('name')!r} names no 'constructor'")
     if entry == "Portfolio":
-        from jquantstats import Portfolio
-
-        if ctor not in PORTFOLIO_CONSTRUCTORS:
-            raise ContextError(f"unknown Portfolio constructor {ctor!r} ({', '.join(PORTFOLIO_CONSTRUCTORS)})")
-        pos_role = PORTFOLIO_CONSTRUCTORS[ctor]
-        for role in ("prices", pos_role):
-            if role not in inputs:
-                raise ContextError(f"{ctor} needs an input named {role!r}")
-            frame, renamed = _put_date_first(
-                read_input(inputs[role], root), inputs[role].get("date_col"), PORTFOLIO_DATE_COL
-            )
-            if renamed:
-                notes.append(
-                    f"{role}: date column {renamed!r} renamed to 'date' — the Portfolio/Data bridge "
-                    f"keeps the date axis only under that name"
-                )
-            frames[role] = frame
-        kwargs: dict[str, Any] = {"aum": float(args["aum"])}
-        if ctor == "from_risk_position":
-            if "vola" in args:
-                kwargs["vola"] = args["vola"]
-            if args.get("vol_cap") is not None:
-                kwargs["vol_cap"] = float(args["vol_cap"])
-        kwargs.update(_cost_kwargs(args))
-        obj = getattr(Portfolio, ctor)(prices=frames["prices"], **{pos_role: frames[pos_role]}, **kwargs)
-
+        obj = _build_portfolio(ctor, inputs, args, root, frames, notes)
     elif entry == "Data":
-        from jquantstats import Data
-
-        if ctor not in DATA_CONSTRUCTORS:
-            raise ContextError(f"unknown Data constructor {ctor!r} ({', '.join(DATA_CONSTRUCTORS)})")
-        role = DATA_CONSTRUCTORS[ctor]
-        if role not in inputs:
-            raise ContextError(f"{ctor} needs an input named {role!r}")
-        frames[role] = read_input(inputs[role], root)
-        date_col = inputs[role].get("date_col") or frames[role].columns[0]
-        kwargs = {"date_col": date_col}
-        if args.get("null_strategy"):
-            kwargs["null_strategy"] = args["null_strategy"]
-        if "benchmark" in inputs:
-            frames["benchmark"] = read_input(inputs["benchmark"], root)
-            kwargs["benchmark"] = frames["benchmark"]
-        rf = args.get("rf")
-        if isinstance(rf, dict):
-            frames["rf"] = read_input(rf, root)
-            kwargs["rf"] = frames["rf"]
-        elif rf is not None:
-            kwargs["rf"] = float(rf)
-        obj = getattr(Data, ctor)(**{role: frames[role]}, **kwargs)
-
+        obj = _build_data(ctor, inputs, args, root, frames)
     else:
         raise ContextError(f"entry_point must be 'Portfolio' or 'Data', got {entry!r}")
 

--- a/plugin/scripts/jqs_context.py
+++ b/plugin/scripts/jqs_context.py
@@ -1,0 +1,879 @@
+"""Recipe-backed portfolio context for the jquantstats Claude plugin.
+
+There is no live Python process shared between tool calls, so a portfolio
+cannot be handed from one skill invocation to the next. What travels instead is
+a *recipe*: the paths and constructor arguments needed to rebuild the object
+deterministically, stored in ``.jquantstats/context.json``.
+
+Two files, deliberately split by lifecycle:
+
+* ``.jquantstats/context.json`` — the recipe. Authoritative, tiny,
+  hand-editable, worth committing.
+* ``.jquantstats/digest.json`` — derived facts (shape, nulls, anchor metrics,
+  warnings) plus content fingerprints of every input. Regenerable, and stale
+  the moment an input file changes, so it is gitignored and fingerprint-checked
+  before its numbers are quoted.
+
+Typical use from an analysis snippet::
+
+    import sys; sys.path.insert(0, os.environ["CLAUDE_PLUGIN_ROOT"] + "/scripts")
+    from jqs_context import load
+
+    pf = load()          # active context
+    pf = load("lag1")    # a named variant
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import importlib.util
+import json
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+SCHEMA = 1
+"""Version of the on-disk recipe/digest format."""
+
+CONTEXT_DIRNAME = ".jquantstats"
+CONTEXT_FILENAME = "context.json"
+DIGEST_FILENAME = "digest.json"
+
+PORTFOLIO_CONSTRUCTORS = {
+    "from_cash_position": "cash_position",
+    "from_position": "position",
+    "from_risk_position": "risk_position",
+}
+"""Portfolio constructor -> the name of its position input."""
+
+DATA_CONSTRUCTORS = {"from_returns": "returns", "from_prices": "prices"}
+"""Data constructor -> the name of its primary input."""
+
+# The Portfolio -> Data bridge keeps the date axis only when the price frame's
+# date column is literally named "date"; any other name is silently dropped and
+# replaced by a positional integer index, which changes every annualised metric.
+# All Portfolio inputs are therefore normalised to this name.
+PORTFOLIO_DATE_COL = "date"
+
+_ANCHOR_METRICS = ("comp", "cagr", "sharpe", "volatility", "max_drawdown")
+
+
+class ContextError(RuntimeError):
+    """A recipe could not be read, validated, or rebuilt."""
+
+
+# ── locating the context ──────────────────────────────────────────────────────
+
+
+def find_root(start: Path | str | None = None) -> Path:
+    """Locate the directory that owns (or should own) the context files.
+
+    Walks upward looking for an existing ``.jquantstats`` directory first, then
+    for a repository marker, so the same context is found from any subdirectory.
+
+    Args:
+        start: Directory to search from. Defaults to the current directory.
+
+    Returns:
+        The resolved project root.
+    """
+    here = Path(start).resolve() if start is not None else Path.cwd().resolve()
+    candidates = [here, *here.parents]
+    for parent in candidates:
+        if (parent / CONTEXT_DIRNAME / CONTEXT_FILENAME).exists():
+            return parent
+    for parent in candidates:
+        if (parent / ".git").exists() or (parent / "pyproject.toml").exists():
+            return parent
+    return here
+
+
+def context_path(root: Path) -> Path:
+    """Return the path of the recipe file under *root*."""
+    return root / CONTEXT_DIRNAME / CONTEXT_FILENAME
+
+
+def digest_path(root: Path) -> Path:
+    """Return the path of the digest file under *root*."""
+    return root / CONTEXT_DIRNAME / DIGEST_FILENAME
+
+
+# ── reading and writing the recipe ────────────────────────────────────────────
+
+
+def _ensure_dir(root: Path) -> Path:
+    """Create ``.jquantstats/`` and mark the derived files as not-for-commit.
+
+    The recipe is worth committing; the digest is derived and goes stale the
+    moment an input changes. A self-contained ignore file keeps that distinction
+    without needing to edit the host project's ``.gitignore``.
+
+    Args:
+        root: Project root.
+
+    Returns:
+        The context directory.
+    """
+    directory = root / CONTEXT_DIRNAME
+    directory.mkdir(parents=True, exist_ok=True)
+    ignore = directory / ".gitignore"
+    if not ignore.exists():
+        ignore.write_text(
+            f"# Derived from context.json and the input files — regenerate, don't commit.\n{DIGEST_FILENAME}\n",
+            encoding="utf-8",
+        )
+    return directory
+
+
+def read_container(root: Path) -> dict[str, Any]:
+    """Read the whole recipe file, which may hold several named contexts.
+
+    Args:
+        root: Project root holding ``.jquantstats/``.
+
+    Returns:
+        A mapping with ``schema``, ``active`` and ``contexts`` keys.
+
+    Raises:
+        ContextError: If the file is missing, malformed, or a newer schema.
+    """
+    path = context_path(root)
+    if not path.exists():
+        raise ContextError(f"no context at {path} — run jqs_load.py to create one")
+    try:
+        container = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ContextError(f"{path} is not valid JSON: {exc}") from exc
+    if not isinstance(container, dict) or "contexts" not in container:
+        raise ContextError(f"{path} has no 'contexts' block")
+    schema = container.get("schema", 0)
+    if schema > SCHEMA:
+        raise ContextError(f"{path} uses schema {schema}; this plugin understands {SCHEMA}")
+    return container
+
+
+def resolve(root: Path, name: str | None = None) -> tuple[str, dict[str, Any]]:
+    """Pick one recipe out of the container.
+
+    Args:
+        root: Project root.
+        name: Context name. Defaults to the container's ``active`` entry.
+
+    Returns:
+        The ``(name, recipe)`` pair.
+
+    Raises:
+        ContextError: If the requested name is not present.
+    """
+    container = read_container(root)
+    contexts = container["contexts"]
+    chosen = name or container.get("active")
+    if chosen is None and len(contexts) == 1:
+        chosen = next(iter(contexts))
+    if not isinstance(chosen, str) or chosen not in contexts:
+        known = ", ".join(sorted(contexts)) or "none"
+        raise ContextError(f"unknown context {chosen!r} (known: {known})")
+    return chosen, contexts[chosen]
+
+
+def upsert(root: Path, recipe: dict[str, Any], *, activate: bool = True) -> Path:
+    """Write *recipe* into the container under its own name.
+
+    Args:
+        root: Project root.
+        recipe: A recipe carrying a ``name`` key.
+        activate: Whether to make it the active context.
+
+    Returns:
+        The path written.
+    """
+    path = context_path(root)
+    _ensure_dir(root)
+    container: dict[str, Any] = {"schema": SCHEMA, "active": None, "contexts": {}}
+    if path.exists():
+        # a corrupt file is replaced rather than blocking a fresh load
+        with contextlib.suppress(ContextError):
+            container = read_container(root)
+    name = recipe["name"]
+    container["schema"] = SCHEMA
+    container["contexts"][name] = recipe
+    if activate or container.get("active") is None:
+        container["active"] = name
+    path.write_text(json.dumps(container, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+    return path
+
+
+def read_digests(root: Path) -> dict[str, dict[str, Any]]:
+    """Read every stored digest, keyed by context name.
+
+    Args:
+        root: Project root.
+
+    Returns:
+        Mapping of context name to digest, empty when no digest file exists.
+    """
+    path = digest_path(root)
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8")).get("digests", {})
+    except json.JSONDecodeError:
+        return {}
+
+
+def write_digest(root: Path, payload: dict[str, Any]) -> Path:
+    """Merge a digest into the digest file under its context's name.
+
+    Keyed by context so building a variant cannot overwrite — and silently
+    invalidate the freshness check of — a sibling context's fingerprints.
+
+    Args:
+        root: Project root.
+        payload: The digest mapping, carrying a ``context`` key.
+
+    Returns:
+        The path written.
+    """
+    path = digest_path(root)
+    _ensure_dir(root)
+    digests = read_digests(root)
+    digests[payload.get("context") or "base"] = payload
+    path.write_text(json.dumps({"schema": SCHEMA, "digests": digests}, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+# ── inputs ────────────────────────────────────────────────────────────────────
+
+
+def _read_table(path: Path) -> pl.DataFrame:
+    """Read a tabular file, dispatching on its suffix.
+
+    Args:
+        path: File to read.
+
+    Returns:
+        The frame.
+
+    Raises:
+        ContextError: If the suffix is not a supported table format.
+    """
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return pl.read_csv(path, try_parse_dates=True)
+    if suffix in {".parquet", ".pq"}:
+        return pl.read_parquet(path)
+    if suffix in {".ipc", ".arrow", ".feather"}:
+        return pl.read_ipc(path)
+    if suffix == ".ndjson":
+        return pl.read_ndjson(path)
+    if suffix == ".json":
+        return pl.read_json(path)
+    raise ContextError(f"unsupported table format {suffix!r} for {path}")
+
+
+def _from_script(spec: dict[str, Any], root: Path) -> pl.DataFrame:
+    """Build a frame by calling a function in a repo-owned Python file.
+
+    This is the escape hatch for inputs a path cannot express — positions
+    derived from an expression, a query, or a model. The logic stays in a
+    normal reviewable ``.py`` file rather than as source embedded in JSON.
+
+    Args:
+        spec: Input spec with ``script`` and optional ``callable`` keys.
+        root: Project root that ``script`` is relative to.
+
+    Returns:
+        The frame returned by the callable.
+
+    Raises:
+        ContextError: If the module, callable, or return type is wrong.
+    """
+    script = (root / spec["script"]).resolve()
+    func_name = spec.get("callable", "build")
+    if not script.exists():
+        raise ContextError(f"builder script not found: {script}")
+    module_spec = importlib.util.spec_from_file_location(f"_jqs_builder_{script.stem}", script)
+    if module_spec is None or module_spec.loader is None:
+        raise ContextError(f"cannot import builder script: {script}")
+    module = importlib.util.module_from_spec(module_spec)
+    module_spec.loader.exec_module(module)
+    func = getattr(module, func_name, None)
+    if func is None:
+        raise ContextError(f"{script} has no callable named {func_name!r}")
+    frame = func()
+    if not isinstance(frame, pl.DataFrame):
+        raise ContextError(f"{script}:{func_name} returned {type(frame).__name__}, expected pl.DataFrame")
+    return frame
+
+
+def read_input(spec: dict[str, Any], root: Path) -> pl.DataFrame:
+    """Materialise one recipe input.
+
+    Args:
+        spec: Input spec — either ``{"path": ...}`` or
+            ``{"script": ..., "callable": ...}``, optionally with ``columns``.
+        root: Project root that relative paths resolve against.
+
+    Returns:
+        The frame, restricted to ``columns`` when given.
+
+    Raises:
+        ContextError: If the spec names neither a path nor a script.
+    """
+    if "path" in spec:
+        path = (root / spec["path"]).resolve()
+        if not path.exists():
+            raise ContextError(f"input file not found: {path}")
+        frame = _read_table(path)
+    elif "script" in spec:
+        frame = _from_script(spec, root)
+    else:
+        raise ContextError(f"input spec needs a 'path' or a 'script': {spec}")
+
+    columns = spec.get("columns")
+    if columns:
+        date_col = spec.get("date_col") or frame.columns[0]
+        keep = [date_col, *[c for c in columns if c != date_col]]
+        missing = [c for c in keep if c not in frame.columns]
+        if missing:
+            raise ContextError(f"columns {missing} not in {spec} (have {frame.columns})")
+        frame = frame.select(keep)
+    return frame
+
+
+def _put_date_first(frame: pl.DataFrame, date_col: str | None, target: str) -> tuple[pl.DataFrame, str | None]:
+    """Move the date column to position 0 and rename it to *target*.
+
+    Args:
+        frame: Source frame.
+        date_col: Name of the date column, or None to use the first column.
+        target: Name the date column must end up with.
+
+    Returns:
+        The reshaped frame and the original column name if it was renamed,
+        otherwise None.
+    """
+    source = date_col or frame.columns[0]
+    if source not in frame.columns:
+        raise ContextError(f"date column {source!r} not in {frame.columns}")
+    ordered = frame.select([source, *[c for c in frame.columns if c != source]])
+    if source == target:
+        return ordered, None
+    return ordered.rename({source: target}), source
+
+
+# ── building ──────────────────────────────────────────────────────────────────
+
+
+def _cost_kwargs(args: dict[str, Any]) -> dict[str, Any]:
+    """Translate recipe cost arguments into constructor keywords.
+
+    ``cost_model`` is recorded declaratively as ``{"kind": ..., "value": ...}``
+    because the object itself is not a dataclass field on Portfolio.
+
+    Args:
+        args: The recipe's ``args`` block.
+
+    Returns:
+        Keyword arguments for a Portfolio constructor.
+    """
+    from jquantstats import CostModel
+
+    out: dict[str, Any] = {}
+    for key in ("cost_per_unit", "cost_bps", "annual_fee"):
+        if key in args:
+            out[key] = float(args[key])
+    model = args.get("cost_model")
+    if model:
+        kind, value = model["kind"], float(model["value"])
+        if kind == "per_unit":
+            out["cost_model"] = CostModel.per_unit(value)
+        elif kind == "turnover_bps":
+            out["cost_model"] = CostModel.turnover_bps(value)
+        else:
+            raise ContextError(f"unknown cost_model kind {kind!r} (per_unit | turnover_bps)")
+    return out
+
+
+def _coerce_bound(value: Any) -> Any:
+    """Turn a JSON truncate bound into something the library accepts.
+
+    ``truncate`` advertises ``str`` in its signature but compares the bound
+    against a temporal column without parsing it, so an ISO string raises
+    ``InvalidOperationError``. JSON has no date type, so the conversion has to
+    happen here.
+
+    Args:
+        value: A row index, an ISO date/datetime string, or None.
+
+    Returns:
+        An int, a ``date``, a ``datetime``, or None.
+
+    Raises:
+        ContextError: If a string is not ISO-8601.
+    """
+    if value is None or (isinstance(value, int) and not isinstance(value, bool)):
+        return value
+    if isinstance(value, str):
+        for parse in (date.fromisoformat, datetime.fromisoformat):
+            try:
+                return parse(value)
+            except ValueError:
+                continue
+        raise ContextError(f"truncate bound {value!r} is not an ISO-8601 date, datetime, or row index")
+    return value
+
+
+def _apply_post(obj: Any, post: list[dict[str, Any]]) -> Any:
+    """Replay the recorded post-construction transforms, in order.
+
+    Without this a rebuild silently produces a *different* portfolio — a
+    ``lag(1)`` study reconstructed unlagged looks entirely plausible.
+
+    Args:
+        obj: The freshly constructed Portfolio or Data.
+        post: Ordered list of ``{"op": ..., ...}`` transforms.
+
+    Returns:
+        The transformed object.
+
+    Raises:
+        ContextError: If an op is unknown or unsupported for this type.
+    """
+    for step in post:
+        op = step.get("op")
+        if op == "lag":
+            obj = _require(obj, "lag", op)(int(step["n"]))
+        elif op == "truncate":
+            method = _require(obj, "truncate", op)
+            obj = method(start=_coerce_bound(step.get("start")), end=_coerce_bound(step.get("end")))
+        elif op == "resample":
+            obj = _require(obj, "resample", op)(step.get("every", "1mo"))
+        else:
+            raise ContextError(f"unknown post op {op!r} (lag | truncate | resample)")
+    return obj
+
+
+def _require(obj: Any, attr: str, op: str) -> Any:
+    """Fetch a transform method, with a message naming the type that lacks it.
+
+    Args:
+        obj: Object to look on.
+        attr: Method name.
+        op: The recipe op requesting it.
+
+    Returns:
+        The bound method.
+
+    Raises:
+        ContextError: If the object has no such method.
+    """
+    method = getattr(obj, attr, None)
+    if method is None:
+        raise ContextError(f"post op {op!r} is not supported by {type(obj).__name__}")
+    return method
+
+
+def build_detailed(recipe: dict[str, Any], root: Path) -> tuple[Any, dict[str, pl.DataFrame], list[str]]:
+    """Rebuild the object and keep the raw inputs for inspection.
+
+    Args:
+        recipe: A single recipe.
+        root: Project root that relative paths resolve against.
+
+    Returns:
+        A ``(object, frames, notes)`` triple: the Portfolio or Data, the input
+        frames keyed by role, and human-readable notes about any normalisation
+        applied on the way in.
+
+    Raises:
+        ContextError: If the recipe is inconsistent with the library API.
+    """
+    entry = recipe.get("entry_point")
+    ctor = recipe.get("constructor")
+    inputs = recipe.get("inputs", {})
+    args = dict(recipe.get("args", {}))
+    notes: list[str] = []
+    frames: dict[str, pl.DataFrame] = {}
+
+    if entry == "Portfolio":
+        from jquantstats import Portfolio
+
+        if ctor not in PORTFOLIO_CONSTRUCTORS:
+            raise ContextError(f"unknown Portfolio constructor {ctor!r} ({', '.join(PORTFOLIO_CONSTRUCTORS)})")
+        pos_role = PORTFOLIO_CONSTRUCTORS[ctor]
+        for role in ("prices", pos_role):
+            if role not in inputs:
+                raise ContextError(f"{ctor} needs an input named {role!r}")
+            frame, renamed = _put_date_first(
+                read_input(inputs[role], root), inputs[role].get("date_col"), PORTFOLIO_DATE_COL
+            )
+            if renamed:
+                notes.append(
+                    f"{role}: date column {renamed!r} renamed to 'date' — the Portfolio/Data bridge "
+                    f"keeps the date axis only under that name"
+                )
+            frames[role] = frame
+        kwargs: dict[str, Any] = {"aum": float(args["aum"])}
+        if ctor == "from_risk_position":
+            if "vola" in args:
+                kwargs["vola"] = args["vola"]
+            if args.get("vol_cap") is not None:
+                kwargs["vol_cap"] = float(args["vol_cap"])
+        kwargs.update(_cost_kwargs(args))
+        obj = getattr(Portfolio, ctor)(prices=frames["prices"], **{pos_role: frames[pos_role]}, **kwargs)
+
+    elif entry == "Data":
+        from jquantstats import Data
+
+        if ctor not in DATA_CONSTRUCTORS:
+            raise ContextError(f"unknown Data constructor {ctor!r} ({', '.join(DATA_CONSTRUCTORS)})")
+        role = DATA_CONSTRUCTORS[ctor]
+        if role not in inputs:
+            raise ContextError(f"{ctor} needs an input named {role!r}")
+        frames[role] = read_input(inputs[role], root)
+        date_col = inputs[role].get("date_col") or frames[role].columns[0]
+        kwargs = {"date_col": date_col}
+        if args.get("null_strategy"):
+            kwargs["null_strategy"] = args["null_strategy"]
+        if "benchmark" in inputs:
+            frames["benchmark"] = read_input(inputs["benchmark"], root)
+            kwargs["benchmark"] = frames["benchmark"]
+        rf = args.get("rf")
+        if isinstance(rf, dict):
+            frames["rf"] = read_input(rf, root)
+            kwargs["rf"] = frames["rf"]
+        elif rf is not None:
+            kwargs["rf"] = float(rf)
+        obj = getattr(Data, ctor)(**{role: frames[role]}, **kwargs)
+
+    else:
+        raise ContextError(f"entry_point must be 'Portfolio' or 'Data', got {entry!r}")
+
+    return _apply_post(obj, recipe.get("post", [])), frames, notes
+
+
+def build(recipe: dict[str, Any], root: Path | None = None) -> Any:
+    """Rebuild the object described by *recipe*.
+
+    Args:
+        recipe: A single recipe.
+        root: Project root. Defaults to :func:`find_root`.
+
+    Returns:
+        The Portfolio or Data instance.
+    """
+    obj, _, _ = build_detailed(recipe, root or find_root())
+    return obj
+
+
+def load(name: str | None = None, root: Path | str | None = None) -> Any:
+    """Rebuild the active (or named) context from disk.
+
+    This is the entry point analysis snippets should use.
+
+    Args:
+        name: Context name. Defaults to the active one.
+        root: Project root. Defaults to :func:`find_root`.
+
+    Returns:
+        The Portfolio or Data instance.
+    """
+    resolved = find_root(root)
+    _, recipe = resolve(resolved, name)
+    return build(recipe, resolved)
+
+
+# ── fingerprints ──────────────────────────────────────────────────────────────
+
+
+def fingerprint(path: Path) -> dict[str, Any]:
+    """Hash a file so a digest can tell whether its inputs still match.
+
+    Args:
+        path: File to hash.
+
+    Returns:
+        A mapping with ``sha256`` and ``bytes``.
+    """
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+            size += len(chunk)
+    return {"sha256": digest.hexdigest(), "bytes": size}
+
+
+def fingerprints(recipe: dict[str, Any], root: Path) -> dict[str, dict[str, Any]]:
+    """Fingerprint every file-backed input of *recipe*.
+
+    Args:
+        recipe: A single recipe.
+        root: Project root.
+
+    Returns:
+        Mapping of relative path to fingerprint.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    specs = list(recipe.get("inputs", {}).values())
+    rf = recipe.get("args", {}).get("rf")
+    if isinstance(rf, dict):
+        specs.append(rf)
+    for spec in specs:
+        for key in ("path", "script"):
+            rel = spec.get(key)
+            if rel:
+                path = (root / rel).resolve()
+                if path.exists():
+                    out[rel] = fingerprint(path)
+    return out
+
+
+def stale_inputs(root: Path | str | None = None, name: str | None = None) -> list[str]:
+    """List inputs whose content no longer matches a stored digest.
+
+    A non-empty result means that digest's numbers must not be quoted;
+    recompute instead.
+
+    Args:
+        root: Project root. Defaults to :func:`find_root`.
+        name: Context to check. Defaults to the active one.
+
+    Returns:
+        Relative paths that changed or went missing.
+    """
+    resolved = find_root(root)
+    digests = read_digests(resolved)
+    if not digests:
+        return []
+    chosen = name or read_container(resolved).get("active")
+    if not isinstance(chosen, str):
+        return []
+    stored = digests.get(chosen, {}).get("fingerprints", {})
+    changed = []
+    for rel, expected in stored.items():
+        candidate = (resolved / rel).resolve()
+        if not candidate.exists() or fingerprint(candidate) != expected:
+            changed.append(rel)
+    return changed
+
+
+# ── digest ────────────────────────────────────────────────────────────────────
+
+
+def _stats_of(obj: Any) -> Any:
+    """Return the stats accessor for a Portfolio or Data."""
+    return obj.stats
+
+
+def _index_frame(obj: Any) -> pl.DataFrame:
+    """Return the date/index frame behind a Portfolio or Data."""
+    return obj.data.index if hasattr(obj, "cashposition") else obj.index
+
+
+def _describe_rows(obj: Any) -> list[dict[str, Any]]:
+    """Convert ``describe()`` into JSON-safe rows.
+
+    Args:
+        obj: Portfolio or Data.
+
+    Returns:
+        One dict per asset, with dates stringified.
+    """
+    rows = obj.describe().to_dicts()
+    return [{k: (str(v) if hasattr(v, "isoformat") else v) for k, v in row.items()} for row in rows]
+
+
+def _null_counts(frames: dict[str, pl.DataFrame]) -> tuple[dict[str, dict[str, int]], dict[str, dict[str, int]]]:
+    """Count nulls and NaNs per column of every input frame.
+
+    Polars keeps ``null`` (missing) and ``NaN`` (IEEE-754) distinct, and
+    ``null_strategy`` acts on nulls only — so the two are reported separately.
+
+    Args:
+        frames: Input frames keyed by role.
+
+    Returns:
+        A ``(nulls, nans)`` pair, each mapping role to non-zero column counts.
+    """
+    nulls: dict[str, dict[str, int]] = {}
+    nans: dict[str, dict[str, int]] = {}
+    for role, frame in frames.items():
+        counts = {c: int(n) for c, n in zip(frame.columns, frame.null_count().row(0), strict=True) if n}
+        if counts:
+            nulls[role] = counts
+        nan_counts = {}
+        for name, dtype in zip(frame.columns, frame.dtypes, strict=True):
+            if dtype.is_float():
+                total = int(frame[name].is_nan().sum() or 0)
+                if total:
+                    nan_counts[name] = total
+        if nan_counts:
+            nans[role] = nan_counts
+    return nulls, nans
+
+
+def _anchor_metrics(obj: Any) -> dict[str, Any]:
+    """Compute a handful of metrics as a tripwire for later mistakes.
+
+    These are not a cache: they are five numbers cheap to re-derive, so a
+    rebuild that disagrees with them is visibly wrong.
+
+    Args:
+        obj: Portfolio or Data.
+
+    Returns:
+        Mapping of metric name to its per-column result, or to an error string.
+    """
+    stats = _stats_of(obj)
+    out: dict[str, Any] = {}
+    for name in _ANCHOR_METRICS:
+        try:
+            value = getattr(stats, name)()
+        except Exception as exc:  # a null-poisoned frame must not abort the digest
+            out[name] = f"error: {type(exc).__name__}: {exc}"
+            continue
+        out[name] = {k: (round(v, 6) if isinstance(v, float) else v) for k, v in value.items()}
+    return out
+
+
+def _empirical_periods_per_year(index: pl.DataFrame, rows: int) -> float | None:
+    """Estimate observations per year from the calendar span.
+
+    Uses rows-per-year rather than the median step, so business-daily (252),
+    weekly (52) and monthly (12) data are all estimated correctly.
+
+    Args:
+        index: The date/index frame.
+        rows: Number of observations.
+
+    Returns:
+        The estimate, or None if the axis is not temporal or spans too little.
+    """
+    column = index.columns[0]
+    if not index[column].dtype.is_temporal() or rows < 2:
+        return None
+    first, last = index[column].min(), index[column].max()
+    # is_temporal() also covers Time and Duration, which do not subtract into days
+    if not isinstance(first, date) or not isinstance(last, date) or type(first) is not type(last):
+        return None
+    days = (last - first).days
+    if days < 180:
+        return None
+    return rows / (days / 365.25)
+
+
+def _warnings(obj: Any, frames: dict[str, pl.DataFrame], recipe: dict[str, Any], shape: dict[str, Any]) -> list[str]:
+    """Derive the findings a diagnostics pass would otherwise have to rediscover.
+
+    Args:
+        obj: Portfolio or Data.
+        frames: Input frames keyed by role.
+        recipe: The recipe used.
+        shape: The digest's ``shape`` block.
+
+    Returns:
+        Human-readable warnings, most consequential first.
+    """
+    out: list[str] = []
+    nulls, nans = _null_counts(frames)
+    if nulls and not recipe.get("args", {}).get("null_strategy"):
+        detail = "; ".join(f"{role}.{col}={n}" for role, cols in nulls.items() for col, n in cols.items())
+        out.append(
+            f"nulls present ({detail}) and null_strategy is unset — handling then varies by metric: "
+            f"aggregations skip nulls (shrinking the effective sample silently) while cumulative and "
+            f"rolling paths can propagate them. Set null_strategy='drop' to make the sample explicit "
+            f"and to match pandas."
+        )
+    if nans:
+        detail = "; ".join(f"{role}.{col}={n}" for role, cols in nans.items() for col, n in cols.items())
+        out.append(f"NaN values present ({detail}) — null_strategy does not touch NaN, only null")
+
+    if not shape.get("date_axis_temporal", True):
+        out.append(
+            "the object's index is positional, not temporal — annualised metrics fall back to a "
+            "default periods_per_year and date-axis plots lose their x-axis"
+        )
+
+    reported, empirical = shape.get("periods_per_year"), shape.get("periods_per_year_empirical")
+    if reported and empirical and not 0.8 <= reported / empirical <= 1.25:
+        out.append(
+            f"periods_per_year is {reported:g} but the data spans {empirical:.1f} observations per year — "
+            f"sharpe, sortino and volatility are annualised by the former and may be off by "
+            f"~{(reported / empirical) ** 0.5:.2f}x"
+        )
+
+    benchmark = shape.get("benchmark")
+    if benchmark and benchmark.get("overlap_rows") is not None:
+        rows = shape.get("rows") or 0
+        if benchmark["overlap_rows"] < rows:
+            out.append(
+                f"benchmark overlaps only {benchmark['overlap_rows']} of {rows} rows — "
+                f"beta, alpha, r_squared and capture ratios use the overlap only"
+            )
+    return out
+
+
+def digest(recipe: dict[str, Any], root: Path | None = None) -> dict[str, Any]:
+    """Rebuild the context and describe what was built.
+
+    Args:
+        recipe: A single recipe.
+        root: Project root. Defaults to :func:`find_root`.
+
+    Returns:
+        The digest mapping: fingerprints, shape, nulls, anchors, warnings.
+    """
+    resolved = root or find_root()
+    obj, frames, notes = build_detailed(recipe, resolved)
+    index = _index_frame(obj)
+    rows = index.height
+    stats = _stats_of(obj)
+    try:
+        reported = float(stats.periods_per_year)
+    except Exception:  # inference can fail on a degenerate axis
+        reported = None
+
+    date_column = index.columns[0]
+    temporal = index[date_column].dtype.is_temporal()
+    shape: dict[str, Any] = {
+        "assets": list(obj.assets),
+        "rows": rows,
+        "date_column": date_column,
+        "date_axis_temporal": temporal,
+        "start": str(index[date_column].min()) if rows else None,
+        "end": str(index[date_column].max()) if rows else None,
+        "periods_per_year": reported,
+        "periods_per_year_empirical": _empirical_periods_per_year(index, rows),
+        "per_asset": _describe_rows(obj),
+    }
+    if getattr(obj, "benchmark", None) is not None:
+        bench = obj.benchmark
+        shape["benchmark"] = {"columns": list(bench.columns), "overlap_rows": bench.height}
+
+    nulls, nans = _null_counts(frames)
+    anchors = _anchor_metrics(obj)
+    if hasattr(obj, "turnover_summary"):
+        anchors["turnover"] = {
+            row["metric"]: round(float(row["value"]), 6)
+            for row in obj.turnover_summary().to_dicts()
+            if row["value"] is not None
+        }
+
+    return {
+        "schema": SCHEMA,
+        "context": recipe.get("name"),
+        "built": f"{recipe.get('entry_point')}.{recipe.get('constructor')}",
+        "post": recipe.get("post", []),
+        "fingerprints": fingerprints(recipe, resolved),
+        "shape": shape,
+        "nulls": nulls,
+        "nans": nans,
+        "anchors": anchors,
+        "notes": notes,
+        "warnings": _warnings(obj, frames, recipe, shape),
+    }

--- a/plugin/scripts/jqs_load.py
+++ b/plugin/scripts/jqs_load.py
@@ -170,20 +170,25 @@ def _input_spec(path: str | None, date_col: str | None, columns: list[str] | Non
 
 
 def _relative(path: str, root: Path) -> str:
-    """Make *path* relative to *root* when it lives inside it.
+    r"""Make *path* relative to *root* when it lives inside it.
+
+    Always POSIX-separated. The recipe is meant to be committed and read on
+    other machines, and a Windows-authored ``data\prices.csv`` would neither
+    resolve elsewhere nor read cleanly in JSON, which escapes the backslash.
+    Forward slashes are accepted by pathlib on every platform.
 
     Args:
         path: A user-supplied path.
         root: Project root.
 
     Returns:
-        A root-relative path where possible, else the resolved absolute path.
+        A root-relative POSIX path where possible, else the resolved absolute one.
     """
     resolved = Path(path).resolve()
     try:
-        return str(resolved.relative_to(root))
+        return resolved.relative_to(root).as_posix()
     except ValueError:
-        return str(resolved)
+        return resolved.as_posix()
 
 
 def _post_ops(args: argparse.Namespace) -> list[dict[str, Any]]:

--- a/plugin/scripts/jqs_load.py
+++ b/plugin/scripts/jqs_load.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""Build a jquantstats portfolio context from the command line.
+
+Records a *recipe* in ``.jquantstats/context.json`` and prints a digest of what
+was built, so later analysis snippets rebuild the same object with
+``from jqs_context import load``.
+
+Examples::
+
+    # Portfolio from prices + cash positions, 5bp turnover cost, one-day delay
+    jqs_load.py portfolio --prices data/prices.csv --cash-position data/pos.csv \
+        --aum 1e6 --cost-bps 5 --lag 1
+
+    # A return series with a benchmark, matching pandas null handling
+    jqs_load.py data --returns data/returns.csv --benchmark data/spy.csv \
+        --null-strategy drop
+
+    jqs_load.py show          # rebuild the active context and re-print the digest
+    jqs_load.py list          # every recorded context
+    jqs_load.py check         # do the stored digest's numbers still hold?
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from jqs_context import (
+    ContextError,
+    digest,
+    find_root,
+    read_container,
+    read_digests,
+    resolve,
+    stale_inputs,
+    upsert,
+    write_digest,
+)
+
+
+def _fmt(value: Any) -> str:
+    """Format a scalar for the text digest.
+
+    Args:
+        value: Any digest value.
+
+    Returns:
+        A compact string.
+    """
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            return str(value)
+        if abs(value) >= 1000:
+            return f"{value:,.2f}"
+        return f"{value:.4g}"
+    return str(value)
+
+
+def _render_anchors(anchors: dict[str, Any]) -> list[str]:
+    """Render the anchor metrics, inline for one series and as a table for many.
+
+    Args:
+        anchors: The digest's ``anchors`` block.
+
+    Returns:
+        Lines of output.
+    """
+    lines: list[str] = []
+    columns: list[str] = []
+    for value in anchors.values():
+        if isinstance(value, dict):
+            columns = [c for c in value if c not in columns] or columns
+            break
+    for name, value in anchors.items():
+        if isinstance(value, str):
+            lines.append(f"  {name:<24} {value}")
+        elif len(value) == 1:
+            lines.append(f"  {name:<24} {_fmt(next(iter(value.values())))}")
+        else:
+            cells = "  ".join(f"{k}={_fmt(v)}" for k, v in value.items())
+            lines.append(f"  {name:<24} {cells}")
+    return lines
+
+
+def render(name: str, recipe: dict[str, Any], payload: dict[str, Any], root: Path) -> str:
+    """Render the digest as the compact text block that lands in the transcript.
+
+    Args:
+        name: Context name.
+        recipe: The recipe used.
+        payload: The computed digest.
+        root: Project root, shown so paths are unambiguous.
+
+    Returns:
+        The rendered block.
+    """
+    shape = payload["shape"]
+    lines = [
+        f"context     {name}",
+        f"built       {payload['built']}",
+        f"root        {root}",
+    ]
+
+    for role, spec in recipe.get("inputs", {}).items():
+        source = spec.get("path") or f"{spec.get('script')}:{spec.get('callable', 'build')}"
+        suffix = f"  (date_col={spec['date_col']})" if spec.get("date_col") else ""
+        lines.append(f"  {role:<24} {source}{suffix}")
+
+    args = recipe.get("args", {})
+    if args:
+        lines.append("args        " + "  ".join(f"{k}={_fmt(v)}" for k, v in args.items() if v is not None))
+    if recipe.get("post"):
+        steps = "  ".join(
+            f"{s['op']}({', '.join(f'{k}={v}' for k, v in s.items() if k != 'op')})" for s in recipe["post"]
+        )
+        lines.append(f"post        {steps}")
+
+    assets = shape["assets"]
+    shown = ", ".join(assets[:8]) + (f", … (+{len(assets) - 8})" if len(assets) > 8 else "")
+    lines.append(f"assets      {len(assets)}  [{shown}]")
+    axis = shape["date_column"] if shape["date_axis_temporal"] else f"{shape['date_column']} (positional!)"
+    lines.append(f"span        {shape['start']} → {shape['end']}   {shape['rows']} rows   on '{axis}'")
+    ppy, empirical = shape["periods_per_year"], shape["periods_per_year_empirical"]
+    ppy_line = f"periods/yr  {_fmt(ppy)}"
+    if empirical:
+        ppy_line += f"   (empirical {_fmt(empirical)})"
+    lines.append(ppy_line)
+    if shape.get("benchmark"):
+        bench = shape["benchmark"]
+        lines.append(f"benchmark   {', '.join(bench['columns'])}   {bench['overlap_rows']} rows")
+
+    for label, block in (("nulls", payload["nulls"]), ("NaNs", payload["nans"])):
+        if block:
+            detail = "  ".join(f"{role}.{col}={n}" for role, cols in block.items() for col, n in cols.items())
+            lines.append(f"{label:<11} {detail}")
+
+    lines.append("anchors")
+    lines.extend(_render_anchors(payload["anchors"]))
+
+    for note in payload.get("notes", []):
+        lines.append(f"note        {note}")
+    for warning in payload.get("warnings", []):
+        lines.append(f"WARNING     {warning}")
+
+    return "\n".join(lines)
+
+
+def _input_spec(path: str | None, date_col: str | None, columns: list[str] | None) -> dict[str, Any]:
+    """Assemble one recipe input spec.
+
+    Args:
+        path: File path, relative to the project root when possible.
+        date_col: Explicit date column name, or None to use the first column.
+        columns: Subset of asset columns to keep, or None for all.
+
+    Returns:
+        The spec mapping.
+    """
+    spec: dict[str, Any] = {"path": path}
+    if date_col:
+        spec["date_col"] = date_col
+    if columns:
+        spec["columns"] = columns
+    return spec
+
+
+def _relative(path: str, root: Path) -> str:
+    """Make *path* relative to *root* when it lives inside it.
+
+    Args:
+        path: A user-supplied path.
+        root: Project root.
+
+    Returns:
+        A root-relative path where possible, else the resolved absolute path.
+    """
+    resolved = Path(path).resolve()
+    try:
+        return str(resolved.relative_to(root))
+    except ValueError:
+        return str(resolved)
+
+
+def _post_ops(args: argparse.Namespace) -> list[dict[str, Any]]:
+    """Collect post-construction transforms from the parsed arguments.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        Ordered transform steps.
+    """
+    post: list[dict[str, Any]] = []
+    if getattr(args, "lag", None):
+        post.append({"op": "lag", "n": args.lag})
+    if getattr(args, "start", None) or getattr(args, "end", None):
+        step: dict[str, Any] = {"op": "truncate"}
+        if args.start:
+            step["start"] = args.start
+        if args.end:
+            step["end"] = args.end
+        post.append(step)
+    if getattr(args, "resample", None):
+        post.append({"op": "resample", "every": args.resample})
+    return post
+
+
+def _portfolio_recipe(args: argparse.Namespace, root: Path) -> dict[str, Any]:
+    """Build a Portfolio recipe from the parsed arguments.
+
+    Args:
+        args: Parsed CLI arguments.
+        root: Project root.
+
+    Returns:
+        The recipe.
+
+    Raises:
+        SystemExit: If no position input was given.
+    """
+    pairs = [
+        ("from_cash_position", "cash_position", args.cash_position),
+        ("from_position", "position", args.position),
+        ("from_risk_position", "risk_position", args.risk_position),
+    ]
+    chosen = [(c, role, path) for c, role, path in pairs if path]
+    if len(chosen) != 1:
+        raise SystemExit("give exactly one of --cash-position / --position / --risk-position")
+    ctor, role, path = chosen[0]
+
+    recipe_args: dict[str, Any] = {"aum": args.aum}
+    if ctor == "from_risk_position":
+        recipe_args["vola"] = args.vola
+        if args.vol_cap is not None:
+            recipe_args["vol_cap"] = args.vol_cap
+    for key in ("cost_per_unit", "cost_bps", "annual_fee"):
+        value = getattr(args, key)
+        if value:
+            recipe_args[key] = value
+
+    return {
+        "name": args.name,
+        "entry_point": "Portfolio",
+        "constructor": ctor,
+        "inputs": {
+            "prices": _input_spec(_relative(args.prices, root), args.date_col, args.columns),
+            role: _input_spec(_relative(path, root), args.date_col, args.columns),
+        },
+        "args": recipe_args,
+        "post": _post_ops(args),
+    }
+
+
+def _data_recipe(args: argparse.Namespace, root: Path) -> dict[str, Any]:
+    """Build a Data recipe from the parsed arguments.
+
+    Args:
+        args: Parsed CLI arguments.
+        root: Project root.
+
+    Returns:
+        The recipe.
+
+    Raises:
+        SystemExit: If neither or both of --returns/--prices were given.
+    """
+    if bool(args.returns) == bool(args.prices):
+        raise SystemExit("give exactly one of --returns / --prices")
+    ctor = "from_returns" if args.returns else "from_prices"
+    role = "returns" if args.returns else "prices"
+    source = args.returns or args.prices
+
+    inputs = {role: _input_spec(_relative(source, root), args.date_col, args.columns)}
+    if args.benchmark:
+        inputs["benchmark"] = _input_spec(_relative(args.benchmark, root), args.date_col, None)
+
+    recipe_args: dict[str, Any] = {}
+    if args.null_strategy:
+        recipe_args["null_strategy"] = args.null_strategy
+    if args.rf:
+        try:
+            recipe_args["rf"] = float(args.rf)
+        except ValueError:
+            recipe_args["rf"] = _input_spec(_relative(args.rf, root), args.date_col, None)
+
+    return {
+        "name": args.name,
+        "entry_point": "Data",
+        "constructor": ctor,
+        "inputs": inputs,
+        "args": recipe_args,
+        "post": _post_ops(args),
+    }
+
+
+def _emit(name: str, recipe: dict[str, Any], root: Path, args: argparse.Namespace) -> int:
+    """Compute the digest, print it, and persist both files.
+
+    Args:
+        name: Context name.
+        recipe: The recipe.
+        root: Project root.
+        args: Parsed CLI arguments (for ``--json`` / ``--no-write``).
+
+    Returns:
+        A process exit code.
+    """
+    payload = digest(recipe, root)
+    if args.json:
+        print(json.dumps({"context": name, "recipe": recipe, "digest": payload}, indent=2))
+    else:
+        print(render(name, recipe, payload, root))
+    if not args.no_write:
+        written = [upsert(root, recipe), write_digest(root, payload)]
+        if not args.json:
+            print("wrote       " + ", ".join(str(p.relative_to(root)) for p in written))
+    return 1 if payload["warnings"] else 0
+
+
+def _add_common(parser: argparse.ArgumentParser) -> None:
+    """Attach arguments shared by the build subcommands.
+
+    Args:
+        parser: The subparser to extend.
+    """
+    parser.add_argument("--name", default="base", help="context name, for keeping variants side by side")
+    parser.add_argument("--date-col", help="date column name (default: the first column)")
+    parser.add_argument("--columns", nargs="+", help="restrict to these asset columns")
+    parser.add_argument("--start", help="truncate from this date")
+    parser.add_argument("--end", help="truncate to this date")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of the text digest")
+    parser.add_argument("--no-write", action="store_true", help="print only; do not touch .jquantstats/")
+    parser.add_argument("--root", help="project root (default: nearest .jquantstats/, .git or pyproject.toml)")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the argument parser.
+
+    Returns:
+        The parser.
+    """
+    parser = argparse.ArgumentParser(prog="jqs_load.py", description=__doc__.splitlines()[0])
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    portfolio = subparsers.add_parser("portfolio", help="prices + positions (turnover, costs, lag, attribution)")
+    portfolio.add_argument("--prices", required=True, help="price frame")
+    portfolio.add_argument("--cash-position", help="positions in currency")
+    portfolio.add_argument("--position", help="positions in share counts")
+    portfolio.add_argument("--risk-position", help="positions in risk units")
+    portfolio.add_argument("--aum", type=float, required=True, help="assets under management")
+    portfolio.add_argument("--vola", type=int, default=32, help="EWMA lookback in periods (--risk-position only)")
+    portfolio.add_argument("--vol-cap", type=float, help="volatility cap (--risk-position only)")
+    portfolio.add_argument("--cost-per-unit", type=float, default=0.0, help="currency cost per unit traded")
+    portfolio.add_argument("--cost-bps", type=float, default=0.0, help="bps of AUM turnover")
+    portfolio.add_argument("--annual-fee", type=float, default=0.0, help="annual management fee")
+    portfolio.add_argument("--lag", type=int, help="shift positions by n periods (execution delay)")
+    _add_common(portfolio)
+
+    data = subparsers.add_parser("data", help="a return or price series (the QuantStats-equivalent route)")
+    data.add_argument("--returns", help="return frame")
+    data.add_argument("--prices", help="price frame")
+    data.add_argument("--benchmark", help="benchmark frame, passed once at construction")
+    data.add_argument("--rf", help="risk-free rate: a number, or a path to a frame")
+    data.add_argument("--null-strategy", choices=["raise", "drop", "forward_fill"], help="use 'drop' to match pandas")
+    data.add_argument("--resample", help="resample the series, e.g. 1mo")
+    _add_common(data)
+
+    show = subparsers.add_parser("show", help="rebuild a recorded context and re-print its digest")
+    show.add_argument("--name", help="context name (default: the active one)")
+    show.add_argument("--json", action="store_true", help="emit JSON")
+    show.add_argument("--no-write", action="store_true", help="do not refresh digest.json")
+    show.add_argument("--root", help="project root")
+
+    listing = subparsers.add_parser("list", help="list recorded contexts")
+    listing.add_argument("--root", help="project root")
+
+    activate = subparsers.add_parser("activate", help="make a recorded context the active one")
+    activate.add_argument("name", help="context to activate")
+    activate.add_argument("--root", help="project root")
+
+    check = subparsers.add_parser("check", help="report inputs that changed since the digest was written")
+    check.add_argument("--root", help="project root")
+    return parser
+
+
+def _check(root: Path) -> int:
+    """Report, per recorded context, whether its inputs still match its digest.
+
+    Args:
+        root: Project root.
+
+    Returns:
+        0 when everything is fresh, 1 when any context is stale.
+    """
+    digests = read_digests(root)
+    if not digests:
+        print("no digest recorded yet — run 'portfolio', 'data' or 'show' first")
+        return 0
+    stale_names = []
+    for name in digests:
+        stale = stale_inputs(root, name)
+        if stale:
+            stale_names.append(name)
+            print(f"STALE   {name:<16} {', '.join(stale)}")
+        else:
+            print(f"fresh   {name:<16} inputs match the recorded fingerprints")
+    if stale_names:
+        print("recompute the stale contexts before quoting any number from their digests")
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the CLI.
+
+    Args:
+        argv: Argument vector. Defaults to ``sys.argv[1:]``.
+
+    Returns:
+        A process exit code: 0 clean, 1 built with warnings, 2 on error.
+    """
+    args = build_parser().parse_args(argv)
+    root = find_root(args.root)
+
+    try:
+        if args.command == "portfolio":
+            recipe = _portfolio_recipe(args, root)
+            return _emit(recipe["name"], recipe, root, args)
+        if args.command == "data":
+            recipe = _data_recipe(args, root)
+            return _emit(recipe["name"], recipe, root, args)
+        if args.command == "show":
+            name, recipe = resolve(root, args.name)
+            return _emit(name, recipe, root, args)
+        if args.command == "list":
+            container = read_container(root)
+            active = container.get("active")
+            for name, recipe in container["contexts"].items():
+                marker = "*" if name == active else " "
+                post = ",".join(step["op"] for step in recipe.get("post", [])) or "-"
+                print(f"{marker} {name:<16} {recipe['entry_point']}.{recipe['constructor']:<20} post={post}")
+            return 0
+        if args.command == "activate":
+            name, recipe = resolve(root, args.name)
+            upsert(root, recipe, activate=True)
+            print(f"active context is now {name}")
+            return 0
+        return _check(root)
+    except ContextError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except (KeyError, ValueError, TypeError) as exc:
+        print(f"error: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugin/skills/portfolio-analysis/SKILL.md
+++ b/plugin/skills/portfolio-analysis/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: portfolio-analysis
+description: Analyse a jquantstats Portfolio or Data object — pick the right metric or chart for the question, and get the call shape right. Use when asked about performance, risk-adjusted returns, drawdowns, benchmark comparison, turnover, trading costs, execution delay, tilt/timing attribution, or for a tearsheet or report from prices, positions or a return series.
+---
+
+# Analysing a portfolio
+
+## First: get the object, don't invent one
+
+Read `${CLAUDE_PLUGIN_ROOT}/reference/portfolio-context.md` and follow it. In
+short: if `.jquantstats/context.json` exists, that *is* the portfolio — rebuild
+it with `load()` rather than asking the user to re-specify anything.
+
+```python
+import os, sys
+sys.path.insert(0, os.path.join(os.environ["CLAUDE_PLUGIN_ROOT"], "scripts"))
+from jqs_context import load
+
+pf = load()
+```
+
+If no context exists, build one first — the digest it prints tells you the asset
+count, span, inferred periodicity and null situation, all of which change which
+answer is correct.
+
+## The call shape
+
+Three rules cover most mistakes:
+
+**1. Metrics return a dict keyed by column, never a scalar.**
+
+```python
+pf.stats.sharpe()                  # {'returns': 2.13}   — Portfolio aggregates to one series
+data.stats.sharpe()                # {'GOOG': 1.15, 'AAPL': 1.75}
+```
+
+A `Portfolio`'s series is always named `returns`. Multi-asset lives on `Data`.
+
+**2. Half of `Portfolio` is properties, not methods.** Adding `()` raises.
+
+| Access | Members |
+|---|---|
+| No parens (properties) | `turnover`, `turnover_weekly`, `tilt`, `timing`, `tilt_timing_decomp`, `drawdown`, `highwater`, `monthly`, `profit`, `profits`, `nav_accumulated`, `nav_compounded`, `net_cost_nav`, `position_delta_costs`, `all`, `assets`, `cost_model`, `returns` |
+| No parens (dataclass fields) | `prices`, `cashposition`, `aum`, `cost_per_unit`, `cost_bps`, `annual_fee` |
+| Call them | `lag(n)`, `truncate(start, end)`, `smoothed_holding(n)`, `turnover_summary()`, `trading_cost_impact(max_bps)`, `cost_adjusted_returns(cost_bps)`, `deduct_management_fee(annual_fee)`, `correlation(frame)`, `describe()` |
+
+On `Data`: `assets`, `date_col`, `all` are properties; `returns`, `index`,
+`benchmark` are fields; `head`, `tail`, `items`, `copy`, `resample`,
+`truncate`, `describe` are methods.
+
+**3. Periodicity kwargs are not uniformly named.** `sharpe`, `sortino`,
+`volatility`, `omega`, `treynor_ratio` take `periods`; `information_ratio`,
+`greeks`, `rolling_greeks`, `montecarlo_sharpe`, `montecarlo_cagr` take
+`periods_per_year`. Both default to `None` → inferred. Check the digest's
+`periods_per_year` before trusting any annualised number.
+
+## Which tool for which question
+
+| The question | The call |
+|---|---|
+| Headline numbers | `pf.stats.summary()` → `pl.DataFrame`; `data.reports.metrics(mode="basic"\|"full")` |
+| Risk-adjusted return | `sharpe`, `sortino`, `adjusted_sortino`, `calmar`, `omega`, `rar`, `risk_return_ratio` |
+| Drawdowns | `max_drawdown`, `drawdown_details` (episode table), `avg_drawdown`, `max_drawdown_duration`, `ulcer_index`, `ulcer_performance_index`, `recovery_factor`, `serenity_index` |
+| Tails | `value_at_risk(alpha=0.05)`, `conditional_value_at_risk(confidence=0.95)`, `tail_ratio`, `worst_n_periods(n)`, `outliers`, `outlier_win_ratio` |
+| Distribution shape | `skew`, `kurtosis`, `distribution`, `geometric_mean`, `expected_return`, `hhi_positive`, `hhi_negative` |
+| Win/loss behaviour | `win_rate`, `monthly_win_rate`, `payoff_ratio`, `profit_factor`, `profit_ratio`, `gain_to_pain_ratio`, `consecutive_wins`, `consecutive_losses`, `kelly_criterion`, `risk_of_ruin` |
+| Versus a benchmark | `greeks` (alpha/beta), `rolling_greeks(rolling_period)`, `information_ratio`, `r_squared`, `treynor_ratio`, `up_capture`, `down_capture` |
+| Calendar breakdown | `monthly_returns`, `annual_breakdown`, `compare(aggregate="ME")` |
+| Trading behaviour | `pf.turnover`, `pf.turnover_weekly`, `pf.turnover_summary()`, `stats.exposure()` |
+| Cost sensitivity | `pf.trading_cost_impact(max_bps=20)`, `pf.cost_adjusted_returns(cost_bps)`, `pf.net_cost_nav`, `pf.deduct_management_fee(annual_fee)` |
+| Execution delay | `pf.lag(n)`, `pf.plots.lagged_performance_plot(lags=[...])`, `pf.plots.lead_lag_ir_plot(start, end)` |
+| Allocation vs timing skill | `pf.tilt`, `pf.timing`, `pf.tilt_timing_decomp` |
+| Position smoothing | `pf.smoothed_holding(n)`, `pf.plots.smoothed_holdings_performance_plot(windows=[...])` |
+
+A benchmark must be passed **at construction** (`Data.from_returns(..., benchmark=...)`),
+not per call — so benchmark-relative metrics need a `Data` context that has one.
+`greeks`, `information_ratio`, `rolling_greeks` and `treynor_ratio` take a
+`benchmark=` *column name*; `up_capture` and `down_capture` are the odd ones out,
+taking a `pl.Series`.
+
+## The accessor asymmetry
+
+`Portfolio` and `Data` are not symmetric, and this is the most common error:
+
+| | `Data` | `Portfolio` |
+|---|---|---|
+| Stats | `data.stats` | `pf.stats` |
+| Plots | `data.plots` — 20 charts | `pf.plots` — 10 charts, mostly different ones |
+| Reports | `data.reports` → `.metrics()`, `.full()` | `pf.report` → `.to_html()` |
+
+Note the singular/plural: **`Data.reports`, `Portfolio.report`**.
+
+`PortfolioPlots` is not a superset. It offers exactly `snapshot`,
+`correlation_heatmap`, `monthly_returns_heatmap`, `rolling_sharpe_plot`,
+`rolling_volatility_plot`, `annual_sharpe_plot`, `lead_lag_ir_plot`,
+`lagged_performance_plot`, `smoothed_holdings_performance_plot`,
+`trading_cost_impact_plot`.
+
+For anything else — `drawdown()`, `histogram()`, `monthly_heatmap()`,
+`drawdowns_periods()`, `rolling_beta()`, `distribution()` — drop to the returns
+view, which is always available and shares the same underlying series:
+
+```python
+pf.data.plots.drawdown()
+pf.data.stats.calmar()
+```
+
+## Charts
+
+Plots return a Plotly `go.Figure`, which a terminal cannot render. Write it out
+and tell the user the path:
+
+```python
+fig = pf.plots.snapshot()
+fig.write_html("_analysis/snapshot.html")        # interactive
+fig.write_image("_analysis/snapshot.png")        # static; needs kaleido
+```
+
+For a full document: `pf.report.to_html(title=..., path=...)` returns a `Path`
+when `path` is given, otherwise the HTML string. On the `Data` side,
+`data.reports.full(title=...)` returns a self-contained HTML string.
+
+## Reporting numbers
+
+- Say which context produced them when more than one exists.
+- State the periodicity actually used when quoting anything annualised.
+- `information_ratio` is raw (non-annualised) by default, matching QuantStats;
+  pass `annualise=True` for the √periods-scaled version.
+- `volatility` annualises by default (`annualize=True` — note the *z*, unlike
+  `information_ratio`'s `annualise`).
+- If the digest carried warnings, resolve or repeat them alongside the numbers
+  rather than quoting past them. Nulls and a misinferred `periods_per_year` both
+  produce plausible-looking wrong answers.
+
+## Before writing an unfamiliar call
+
+Confirm the symbol exists — invented method names are the expensive failure here:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_api.py --show sortino
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_api.py --grep capture
+```

--- a/plugin/skills/portfolio-diagnostics/SKILL.md
+++ b/plugin/skills/portfolio-diagnostics/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: portfolio-diagnostics
+description: Diagnose wrong, null or surprising jquantstats results — null propagation, a misinferred periods_per_year, a lost date axis, benchmark misalignment, or a raised JQuantStatsError. Use when a metric returns null or NaN, when numbers disagree with QuantStats or another tool, when a Sharpe or volatility looks implausible, or when construction fails.
+---
+
+# Diagnosing a portfolio
+
+Metrics here fail *quietly* more often than loudly. A wrong number that looks
+plausible is the failure mode to hunt.
+
+## Start with the digest, not the metric
+
+Read `${CLAUDE_PLUGIN_ROOT}/reference/portfolio-context.md`, then rebuild and
+re-read the digest — it already carries the evidence:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_load.py show
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_load.py check   # inputs still match?
+```
+
+`check` reporting `STALE` explains a whole class of "the number changed" reports:
+the inputs moved after the digest was written. Work through the digest's
+`warnings`, `nulls`, `nans` and `shape` blocks before touching the metric that
+was complained about.
+
+## The five silent failures
+
+### 1. Nulls — inconsistent, not uniform
+
+Polars keeps `null` (missing) and `NaN` (IEEE-754) distinct, and
+`null_strategy` acts on **null only**. Handling then varies by metric:
+aggregations skip nulls, which shrinks the effective sample without saying so,
+while cumulative and rolling paths can propagate them.
+
+```python
+frame.null_count()                            # nulls per column
+frame.select(pl.col(c).is_nan().sum() for c in numeric)   # NaNs are separate
+```
+
+Fix by making the sample explicit at construction:
+`Data.from_returns(..., null_strategy="drop")`. Options are `None` (default,
+pass through), `"drop"`, `"forward_fill"`, `"raise"`. Use `"raise"` while
+debugging — turning a silent failure loud is usually the fastest route. When
+reproducing QuantStats numbers, `"drop"` is what matches pandas.
+
+`NullsInReturnsError` is the loud version of this, raised where a null cannot be
+tolerated at all.
+
+### 2. A lost date axis — the `date` naming trap
+
+The `Portfolio` → `Data` bridge keeps the date column **only when it is named
+exactly `date`** (lowercase). Under any other name the dates are dropped and
+replaced by a positional integer index. Nothing is raised.
+
+The consequences are not cosmetic: `periods_per_year` falls back to a default
+instead of being inferred, so every annualised metric shifts, and date-axis
+charts lose their x-axis. On identical data, renaming `date` → `Date` moved
+Sharpe from 100.33 to 83.36 in testing.
+
+```python
+pf.data.index.columns        # ['date'] good — ['index'] means the axis was dropped
+```
+
+The plugin's loader normalises Portfolio inputs to `date` and reports having
+done so. If a portfolio was built by hand, check this first.
+
+### 3. `periods_per_year` inferred wrongly
+
+Annualisation of `sharpe`, `sortino` and `volatility` runs off this number.
+
+```python
+pf.stats.periods_per_year                        # what the library will use
+```
+
+The digest also reports `periods_per_year_empirical` — observations per calendar
+year measured from the span. A mismatch means the annualisation is wrong by
+roughly its square root: business-daily should land near 252, weekly near 52,
+monthly near 12. If the inference is off, pass `periods=` (or
+`periods_per_year=`, depending on the metric — the two kwarg names are not used
+consistently) explicitly rather than accepting the default.
+
+### 4. Benchmark misalignment
+
+The benchmark is passed once at construction and aligned to the returns.
+`BenchmarkAlignmentWarning` is emitted when that alignment drops rows — do not
+suppress it. `beta`, `alpha`, `r_squared`, `information_ratio` and the capture
+ratios then describe only the overlap, which may be much shorter than the
+portfolio.
+
+```python
+data.benchmark.height, data.returns.height       # compare
+```
+
+`NoBenchmarkError` means a benchmark-dependent statistic was requested on a
+context built without one — rebuild with `--benchmark`, don't work around it.
+
+### 5. The right name, different semantics
+
+Same metric name, different convention from QuantStats:
+
+- `conditional_value_at_risk` accepts `confidence=0.95` *or* `alpha=0.05`, never
+  both (that raises `ValueError`); omitting both gives `alpha=0.05`.
+- `value_at_risk` takes `alpha` only — no `confidence` parameter, on the same
+  object as its CVaR sibling that has one.
+- `information_ratio` is raw and non-annualised by default; pass
+  `annualise=True` to scale it.
+- `volatility` annualises by default — and spells it `annualize`, with a *z*.
+
+## When construction raises
+
+The library uses typed domain errors, so the class names the problem:
+
+| Exception | Cause |
+|---|---|
+| `MissingDateColumnError` | no date column where one is required — check `date_col` |
+| `InvalidPricesTypeError`, `InvalidCashPositionTypeError` | a pandas object or Series was passed; both must be `pl.DataFrame` |
+| `RowCountMismatchError` | prices and positions have different row counts — align before constructing, don't truncate blindly |
+| `NonPositiveAumError` | `aum` must be strictly positive |
+| `NoAssetColumnsError` | no numeric asset columns — usually the date column was not excluded, or everything parsed as string |
+| `PositionExprColumnError` | a position expression names columns absent from prices |
+| `NegativeCostBpsError`, `NegativeAnnualFeeError`, `InvalidMaxBpsError` | invalid cost inputs |
+| `UncleanSeriesError` | a derived series hit null or non-finite values — trace back to the input nulls |
+| `NonPositiveWindowError`, `NonPositivePeriodsPerYearError` | invalid rolling window or annualisation factor |
+| `IntegerIndexBoundError` | `truncate` received a non-integer where a row index was expected |
+
+All subclass `JQuantStatsError`, so `except JQuantStatsError` catches the domain
+set without swallowing real bugs.
+
+## Reconciling against QuantStats
+
+When numbers disagree with a QuantStats reference, work in this order — the
+common cause is upstream of the metric:
+
+1. **Sample.** `null_strategy="drop"` to match pandas' silent `NaN` dropping.
+2. **Periodicity.** Confirm `periods_per_year` matches what the other tool assumed.
+3. **Date axis.** Confirm the index is temporal, not positional.
+4. **Convention.** Check the tail spelling, the annualisation flag, and whether
+   the alias you are comparing against maps to a different canonical metric.
+5. **Only then** compare the metric itself.
+
+The repo's own `tests/test_jquantstats/test_migration/` validates metrics against
+the `quantstats` reference implementation and is the authority on which
+differences are intentional.
+
+## Verify names before concluding a metric is broken
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_api.py --show value_at_risk
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_api.py --grep sortino
+```
+
+A missing name is usually a QuantStats alias that was never ported (`cvar`,
+`ror`, `upi`, `r2`, `ghpr`, `win_loss_ratio`). Report that rather than wrapping it.

--- a/plugin/skills/portfolio-robustness/SKILL.md
+++ b/plugin/skills/portfolio-robustness/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: portfolio-robustness
+description: Stress-test a jquantstats result rather than just computing it — is this Sharpe real, does it survive execution delay, trading costs, autocorrelation, outliers, or a different sub-period? Use when asked whether a backtest holds up, how sensitive it is to costs or lag, whether performance is luck, or for Monte Carlo, probabilistic Sharpe, or lead/lag analysis.
+---
+
+# Is the result real?
+
+Computing a Sharpe and asking whether it means anything are different jobs. This
+skill is the second one.
+
+Start from the shared context — read
+`${CLAUDE_PLUGIN_ROOT}/reference/portfolio-context.md`, then:
+
+```python
+import os, sys
+sys.path.insert(0, os.path.join(os.environ["CLAUDE_PLUGIN_ROOT"], "scripts"))
+from jqs_context import load
+
+pf = load()
+```
+
+Record each stress case as its own **named context** so the comparison is
+reproducible rather than a one-off object (`jqs_load.py ... --name lag1`).
+
+## Six ways a good backtest dies
+
+Work down this list; the early entries kill more strategies than the late ones.
+
+### 1. Execution delay
+
+If the edge disappears when positions are shifted by a period, it was reading
+the future. This is a `Portfolio`-only test — a return series cannot express it.
+
+```python
+{n: pf.lag(n).stats.sharpe()["returns"] for n in range(4)}
+
+pf.plots.lead_lag_ir_plot(start=-10, end=19)        # IR across the lag spectrum
+pf.plots.lagged_performance_plot(lags=[0, 1, 2, 5])
+```
+
+A peak at lag 0 that falls off a cliff at lag 1 is the signature to report. The
+lead side (negative lags) matters too: information ratio that is strong *ahead*
+of the trade is a look-ahead artefact, not skill.
+
+### 2. Trading costs
+
+```python
+pf.trading_cost_impact(max_bps=20)          # pl.DataFrame — a cost sweep
+pf.plots.trading_cost_impact_plot(max_bps=20)
+pf.cost_adjusted_returns(cost_bps=5)
+pf.turnover_summary()                       # what the sweep is actually charging for
+```
+
+Report the bps level at which the edge reaches zero — that number is far more
+useful than a Sharpe at one assumed cost. Pair it with turnover: high turnover
+plus cost sensitivity is the common way a paper result fails in production.
+
+### 3. Autocorrelation inflating the Sharpe
+
+Serially correlated returns understate risk, so the Sharpe flatters.
+
+```python
+pf.stats.autocorr(lag=1)
+pf.stats.acf(nlags=20)
+pf.stats.autocorr_penalty()
+pf.stats.smart_sharpe()      # sharpe / autocorr_penalty
+pf.stats.smart_sortino()
+```
+
+A large gap between `sharpe` and `smart_sharpe` is the finding. Illiquid or
+smoothed holdings are the usual cause.
+
+### 4. Statistical significance
+
+A Sharpe from a short sample is barely an estimate.
+
+```python
+pf.stats.sharpe_variance()                  # sampling variance of the estimate
+pf.stats.probabilistic_sharpe_ratio()       # P(true Sharpe > benchmark Sharpe)
+pf.stats.probabilistic_sortino_ratio()
+pf.stats.probabilistic_adjusted_sortino_ratio()
+pf.stats.probabilistic_ratio(base="sharpe") # or pass a callable
+```
+
+`probabilistic_sharpe_ratio` returns NaN when the standard deviation or the
+higher moments are unusable, or when estimated Sharpe variance is non-positive —
+treat NaN as "the sample cannot support this claim", not as an error to route
+around.
+
+### 5. Path dependence — Monte Carlo
+
+Block bootstrap, so serial structure is partly preserved:
+
+```python
+pf.stats.montecarlo(n=1000, period=252)           # pl.DataFrame (n, n_assets) terminal returns
+pf.stats.montecarlo_sharpe(n=1000, period=252)
+pf.stats.montecarlo_cagr(n=1000, period=252)
+pf.stats.montecarlo_drawdown(n=1000, period=252)  # the distribution that sizing depends on
+
+pf.data.plots.montecarlo(n=100, period=252)               # fan chart
+pf.data.plots.montecarlo_distribution(n=1000, period=252)
+```
+
+Report where the *observed* result sits in the simulated distribution. The
+drawdown distribution is usually the decision-relevant one: a strategy whose
+95th-percentile simulated drawdown exceeds the risk budget is not viable at that
+size regardless of its Sharpe.
+
+### 6. Concentration — a few days carrying everything
+
+```python
+pf.stats.worst_n_periods(n=5)
+pf.stats.outliers(quantile=0.95)
+pf.stats.remove_outliers(quantile=0.95)     # recompute metrics on the trimmed series
+pf.stats.outlier_win_ratio(), pf.stats.outlier_loss_ratio()
+pf.stats.hhi_positive(), pf.stats.hhi_negative()   # concentration of gains / losses
+```
+
+If the Sharpe collapses once the top 5% of days are removed, the result rests on
+a handful of observations. Say so explicitly.
+
+## Stability through time
+
+Full-sample metrics hide regime dependence.
+
+```python
+pf.stats.rolling_sharpe(rolling_period=126)
+pf.stats.rolling_volatility()
+pf.stats.annual_breakdown()
+pf.stats.pct_rank(window=60)
+pf.plots.annual_sharpe_plot()
+
+pf.truncate(start="2018-01-01", end="2020-12-31").stats.sharpe()
+```
+
+Record sub-periods as named contexts (`--start` / `--end`) rather than inline
+truncation when the comparison is the deliverable.
+
+## Position smoothing
+
+Whether the signal needs its exact timing, or works held longer:
+
+```python
+pf.smoothed_holding(5).stats.sharpe()
+pf.plots.smoothed_holdings_performance_plot(windows=[1, 5, 10, 20])
+```
+
+Performance that improves under smoothing usually means the raw signal is noisy
+and turnover is being wasted.
+
+## Ruin and sizing
+
+```python
+pf.stats.risk_of_ruin()
+pf.stats.kelly_criterion()
+pf.stats.ulcer_index(), pf.stats.serenity_index()
+pf.stats.max_drawdown_duration()      # calendar days underwater
+pf.stats.recovery_factor()
+```
+
+## How to report
+
+- Lead with what **failed**, not what passed. A robustness pass whose findings
+  are all reassuring is usually a pass that did not test hard enough.
+- Give the breaking point, not a verdict: the bps at which the edge vanishes,
+  the lag at which IR crosses zero, the percentile the observed result occupies.
+- Name the sample. A 320-row backtest cannot support strong claims regardless of
+  the metric, and `sharpe_variance` / `probabilistic_sharpe_ratio` should be
+  quoted alongside any headline Sharpe from a short history.
+- Carry the digest's warnings through. Nulls, a positional date axis, or a
+  misinferred `periods_per_year` invalidate a robustness conclusion exactly as
+  they invalidate the underlying metric — if any are outstanding, use
+  `portfolio-diagnostics` first.

--- a/plugin/skills/quantstats-migration/SKILL.md
+++ b/plugin/skills/quantstats-migration/SKILL.md
@@ -167,25 +167,46 @@ composite stats table is `data.stats.summary()` → `pl.DataFrame`.
 This mapping is a summary of a moving API. Before finalising code, confirm the
 symbols exist rather than trusting memory:
 
-```python
-from jquantstats._stats._stats import Stats
-sorted(m for m in dir(Stats) if not m.startswith("_"))
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_api.py --show sharpe
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_api.py --grep drawdown
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_api.py stats
 ```
 
-Same for `jquantstats._plots.DataPlots` / `PortfolioPlots`. If a name is
-missing, it was either renamed to its canonical form (see the table above) or
-never ported — say so rather than inventing a wrapper.
+`--show` reports signature and docstring from the installed version, and says so
+plainly when a name is absent. A missing name was either renamed to its
+canonical form (see the table above) or never ported — say so rather than
+inventing a wrapper.
+
+## Step 6 — record the context once
+
+Ported code that rebuilds its own portfolio in every script drifts. Record the
+construction once so later analysis shares one object:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/jqs.sh" jqs_load.py data \
+    --returns data/returns.csv --benchmark data/spy.csv --null-strategy drop
+```
+
+See `${CLAUDE_PLUGIN_ROOT}/reference/portfolio-context.md`. Subsequent snippets
+then use `load()` instead of repeating the constructor, and the digest it prints
+surfaces the null and periodicity problems that make ported numbers disagree
+with QuantStats.
 
 ## Portfolio-only capabilities
 
 Reach for these when the request goes beyond what a return series can express;
 none have a QuantStats counterpart.
 
+Mind which of these are properties: only `lag`, `turnover_summary`,
+`trading_cost_impact`, `smoothed_holding` and `truncate` take parentheses.
+
 ```python
 pf.lag(1)                       # shift positions — execution-delay study
 pf.plots.lead_lag_ir_plot()     # IR across lags
 pf.tilt, pf.timing, pf.tilt_timing_decomp   # allocation vs timing skill
-pf.turnover, pf.turnover_weekly(), pf.turnover_summary()
+pf.turnover, pf.turnover_weekly             # properties — no parentheses
+pf.turnover_summary()                       # a method
 pf.trading_cost_impact(...)     # cost sensitivity sweep
 
 from jquantstats import CostModel

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -175,8 +175,10 @@ def test_truncate_post_op(project):
 def test_truncate_bounds_are_coerced(project):
     """An ISO string bound reaches the library as a date object.
 
-    JSON has no date type, and `truncate` rejects strings despite advertising
-    `str` in its signature — so the recipe layer converts.
+    JSON has no date type, so a recipe can only ever carry a string. The library
+    parses ISO strings itself since #926, but the recipe layer still converts, to
+    reject an unparseable bound as a `ContextError` naming the recipe rather than
+    as a library error from deep inside a rebuild.
     """
     from_recipe = jqs_context.build(_portfolio_recipe(post=[{"op": "truncate", "start": "2020-01-11"}]), project)
     direct = jqs_context.build(_portfolio_recipe(), project).truncate(start=date(2020, 1, 11))
@@ -186,15 +188,18 @@ def test_truncate_bounds_are_coerced(project):
         jqs_context.build(_portfolio_recipe(post=[{"op": "truncate", "start": "last tuesday"}]), project)
 
 
-def test_integer_truncate_bound_is_a_library_noop(project):
-    """Pins current library behaviour: an int bound on a temporal axis truncates nothing.
+def test_integer_truncate_bound_slices_positionally(project):
+    """An int bound in a recipe is a row index, even on a temporal axis.
 
-    `truncate` accepts `int` as a row index, but routes on the index dtype, so a
-    temporal axis silently ignores it. Kept as a test so a future fix is visible
-    here rather than surprising a recipe that used a row index.
+    This pinned the pre-fix no-op until #927 landed; it now pins the fixed
+    behaviour, so a recipe using a row index truncates as written. Row 10 of the
+    fixture is 2020-01-11, so the two spellings must agree.
     """
-    obj = jqs_context.build(_portfolio_recipe(post=[{"op": "truncate", "start": 10}]), project)
-    assert obj.prices.height == 80
+    by_row = jqs_context.build(_portfolio_recipe(post=[{"op": "truncate", "start": 10}]), project)
+    by_date = jqs_context.build(_portfolio_recipe(post=[{"op": "truncate", "start": "2020-01-11"}]), project)
+
+    assert by_row.prices.height == 70
+    assert by_row.prices.equals(by_date.prices)
 
 
 def test_resample_post_op(project):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -489,6 +489,36 @@ def test_cli_portfolio_writes_context(project, capsys):
     assert jqs_context.digest_path(project).exists()
 
 
+def test_recipe_paths_are_posix(project, prices_frame):
+    r"""Recipe paths use forward slashes on every platform, so a recipe travels.
+
+    A Windows-authored `data\prices.csv` would not resolve on another machine,
+    and the recipe is meant to be committed and shared.
+    """
+    nested = project / "data" / "nested"
+    nested.mkdir()
+    prices_frame.write_csv(nested / "prices.csv")
+    prices_frame.select(pl.col("date"), pl.lit(1e5).alias("A"), pl.lit(1e5).alias("B")).write_csv(nested / "pos.csv")
+
+    jqs_load.main(
+        [
+            "portfolio",
+            "--prices",
+            str(nested / "prices.csv"),
+            "--cash-position",
+            str(nested / "pos.csv"),
+            "--aum",
+            "1e6",
+            "--root",
+            str(project),
+        ]
+    )
+    recipe = jqs_context.read_container(project)["contexts"]["base"]
+    assert recipe["inputs"]["prices"]["path"] == "data/nested/prices.csv"
+    assert "\\" not in json.dumps(recipe)
+    assert jqs_context.load(root=project).assets == ["A", "B"]  # and it still rebuilds
+
+
 def test_cli_data_warns_and_exits_nonzero(project, capsys):
     """Building over nulls without a strategy is reported and flagged in the code."""
     code = jqs_load.main(["data", "--returns", str(project / "data" / "returns.csv"), "--root", str(project)])

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,665 @@
+"""Tests for the bundled Claude Code plugin.
+
+The plugin's scripts are not part of the shipped package (they live under
+``plugin/`` and are excluded from coverage), but a broken loader breaks every
+skill that reads the shared portfolio context — so the recipe round-trip, the
+digest, and the manifest wiring are all covered here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent / "plugin"
+SCRIPTS = PLUGIN_ROOT / "scripts"
+
+
+def _import(name: str):
+    """Import a plugin script by file path, since ``plugin/`` is not a package."""
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+jqs_context = _import("jqs_context")
+jqs_load = _import("jqs_load")
+jqs_api = _import("jqs_api")
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def prices_frame():
+    """Sixty business days of two rising assets."""
+    days = pl.date_range(date(2020, 1, 1), date(2020, 3, 20), interval="1d", eager=True).cast(pl.Date)
+    return pl.DataFrame(
+        {
+            "date": days,
+            "A": [100.0 + i for i in range(len(days))],
+            "B": [200.0 - 0.5 * i for i in range(len(days))],
+        }
+    )
+
+
+@pytest.fixture
+def project(tmp_path, prices_frame):
+    """A throwaway project directory holding prices, positions and returns."""
+    data = tmp_path / "data"
+    data.mkdir()
+    prices_frame.write_csv(data / "prices.csv")
+    prices_frame.select(
+        pl.col("date"),
+        pl.lit(500_000.0).alias("A"),
+        pl.lit(300_000.0).alias("B"),
+    ).write_csv(data / "pos.csv")
+    prices_frame.select(
+        pl.col("date").alias("Date"),
+        pl.col("A").pct_change().alias("A"),
+    ).write_csv(data / "returns.csv")
+    return tmp_path
+
+
+def _portfolio_recipe(name="base", post=None, prices="data/prices.csv", position="data/pos.csv"):
+    """Build a Portfolio recipe dict."""
+    return {
+        "name": name,
+        "entry_point": "Portfolio",
+        "constructor": "from_cash_position",
+        "inputs": {"prices": {"path": prices}, "cash_position": {"path": position}},
+        "args": {"aum": 1e6},
+        "post": post or [],
+    }
+
+
+def _data_recipe(name="ret", **args):
+    """Build a Data recipe dict."""
+    return {
+        "name": name,
+        "entry_point": "Data",
+        "constructor": "from_returns",
+        "inputs": {"returns": {"path": "data/returns.csv", "date_col": "Date"}},
+        "args": args,
+        "post": [],
+    }
+
+
+# ── manifest and skill wiring ─────────────────────────────────────────────────
+
+
+def test_plugin_manifest_matches_marketplace():
+    """The marketplace entry and the plugin manifest agree on name and description."""
+    manifest = json.loads((PLUGIN_ROOT / ".claude-plugin" / "plugin.json").read_text())
+    marketplace = json.loads((PLUGIN_ROOT.parent / ".claude-plugin" / "marketplace.json").read_text())
+    entry = next(p for p in marketplace["plugins"] if p["name"] == manifest["name"])
+    assert entry["source"] == "./plugin"
+    assert entry["description"] == manifest["description"]
+
+
+@pytest.mark.parametrize(
+    "skill",
+    ["quantstats-migration", "portfolio-analysis", "portfolio-diagnostics", "portfolio-robustness"],
+)
+def test_skill_frontmatter(skill):
+    """Every skill declares a name matching its directory, and a description."""
+    text = (PLUGIN_ROOT / "skills" / skill / "SKILL.md").read_text()
+    assert text.startswith("---\n")
+    front = text.split("---", 2)[1]
+    assert f"name: {skill}\n" in front
+    description = next(line for line in front.splitlines() if line.startswith("description:"))
+    assert len(description) > len("description: ") + 40
+
+
+@pytest.mark.parametrize("command", ["load", "review"])
+def test_command_frontmatter(command):
+    """Every slash command declares a description."""
+    front = (PLUGIN_ROOT / "commands" / f"{command}.md").read_text().split("---", 2)[1]
+    assert "description:" in front
+
+
+def test_referenced_plugin_paths_exist():
+    """Every ${CLAUDE_PLUGIN_ROOT} path named in the docs resolves to a real file."""
+    referenced = set()
+    for path in PLUGIN_ROOT.rglob("*.md"):
+        for token in path.read_text().split():
+            if "CLAUDE_PLUGIN_ROOT}/" in token:
+                referenced.add(token.split("CLAUDE_PLUGIN_ROOT}/", 1)[1].strip('"`,.:;)'))
+    assert referenced, "no plugin-root references found — the docs lost their wiring"
+    missing = [rel for rel in referenced if not (PLUGIN_ROOT / rel).exists()]
+    assert not missing, f"dangling plugin references: {missing}"
+
+
+# ── recipe round-trip ─────────────────────────────────────────────────────────
+
+
+def test_build_and_load_round_trip(project):
+    """A recipe written to disk rebuilds an object identical to the one measured."""
+    recipe = _portfolio_recipe()
+    payload = jqs_context.digest(recipe, project)
+    jqs_context.upsert(project, recipe)
+
+    rebuilt = jqs_context.load(root=project)
+    assert type(rebuilt).__name__ == "Portfolio"
+    # abs=1e-6 because the digest rounds its anchors to six decimals
+    assert rebuilt.stats.sharpe()["returns"] == pytest.approx(payload["anchors"]["sharpe"]["returns"], abs=1e-6)
+
+
+def test_post_ops_are_replayed(project):
+    """A recorded lag survives the round-trip — an unlagged rebuild would differ."""
+    plain = jqs_context.build(_portfolio_recipe(), project)
+    lagged_recipe = _portfolio_recipe(name="lag1", post=[{"op": "lag", "n": 1}])
+    jqs_context.upsert(project, lagged_recipe)
+
+    lagged = jqs_context.load("lag1", root=project)
+    assert lagged.returns.height == plain.returns.height
+    assert lagged.stats.sharpe()["returns"] != pytest.approx(plain.stats.sharpe()["returns"])
+
+
+def test_truncate_post_op(project):
+    """A truncate transform narrows the rebuilt span."""
+    recipe = _portfolio_recipe(post=[{"op": "truncate", "start": "2020-02-01"}])
+    obj = jqs_context.build(recipe, project)
+    assert obj.prices["date"].min() >= date(2020, 2, 1)
+
+
+def test_truncate_bounds_are_coerced(project):
+    """An ISO string bound reaches the library as a date object.
+
+    JSON has no date type, and `truncate` rejects strings despite advertising
+    `str` in its signature — so the recipe layer converts.
+    """
+    from_recipe = jqs_context.build(_portfolio_recipe(post=[{"op": "truncate", "start": "2020-01-11"}]), project)
+    direct = jqs_context.build(_portfolio_recipe(), project).truncate(start=date(2020, 1, 11))
+    assert from_recipe.prices.height == direct.prices.height < 80
+
+    with pytest.raises(jqs_context.ContextError, match="not an ISO-8601 date"):
+        jqs_context.build(_portfolio_recipe(post=[{"op": "truncate", "start": "last tuesday"}]), project)
+
+
+def test_integer_truncate_bound_is_a_library_noop(project):
+    """Pins current library behaviour: an int bound on a temporal axis truncates nothing.
+
+    `truncate` accepts `int` as a row index, but routes on the index dtype, so a
+    temporal axis silently ignores it. Kept as a test so a future fix is visible
+    here rather than surprising a recipe that used a row index.
+    """
+    obj = jqs_context.build(_portfolio_recipe(post=[{"op": "truncate", "start": 10}]), project)
+    assert obj.prices.height == 80
+
+
+def test_resample_post_op(project):
+    """Data supports resample; Portfolio does not, and says so."""
+    resampled = jqs_context.build(_data_recipe(post=[]) | {"post": [{"op": "resample", "every": "1mo"}]}, project)
+    assert resampled.returns.height < 60
+
+    with pytest.raises(jqs_context.ContextError, match="not supported by Portfolio"):
+        jqs_context.build(_portfolio_recipe(post=[{"op": "resample", "every": "1mo"}]), project)
+
+
+def test_named_contexts_are_independent(project):
+    """Activating and resolving named contexts keeps each recipe intact."""
+    jqs_context.upsert(project, _portfolio_recipe("base"))
+    jqs_context.upsert(project, _portfolio_recipe("lag1", post=[{"op": "lag", "n": 1}]))
+
+    container = jqs_context.read_container(project)
+    assert container["active"] == "lag1"
+    assert set(container["contexts"]) == {"base", "lag1"}
+
+    name, recipe = jqs_context.resolve(project, "base")
+    assert (name, recipe["post"]) == ("base", [])
+
+
+# ── digest ────────────────────────────────────────────────────────────────────
+
+
+def test_digest_reports_shape(project):
+    """The digest carries the facts an analysis needs before choosing a metric."""
+    payload = jqs_context.digest(_portfolio_recipe(), project)
+    shape = payload["shape"]
+    assert shape["assets"] == ["A", "B"]
+    assert shape["date_axis_temporal"] is True
+    assert shape["date_column"] == "date"
+    assert shape["periods_per_year"] > 0
+    assert payload["built"] == "Portfolio.from_cash_position"
+    assert {row["asset"] for row in shape["per_asset"]} == {"A", "B"}
+    assert "turnover" in payload["anchors"]
+
+
+def test_digest_warns_about_nulls(project):
+    """Unset null_strategy on a frame with nulls is surfaced, not silently accepted."""
+    payload = jqs_context.digest(_data_recipe(), project)
+    assert payload["nulls"]["returns"]["A"] == 1
+    assert any("null_strategy" in w for w in payload["warnings"])
+
+
+def test_null_strategy_silences_the_warning(project):
+    """Declaring the strategy resolves the finding."""
+    payload = jqs_context.digest(_data_recipe(null_strategy="drop"), project)
+    assert not any("null_strategy" in w for w in payload["warnings"])
+
+
+def test_digest_warns_about_positional_index(project, prices_frame):
+    """A non-temporal axis is reported, since it silently changes annualisation."""
+    frame = prices_frame.with_row_index("i").drop("date")
+    frame.write_csv(project / "data" / "int_returns.csv")
+    recipe = {
+        "name": "positional",
+        "entry_point": "Data",
+        "constructor": "from_returns",
+        "inputs": {"returns": {"path": "data/int_returns.csv", "date_col": "i"}},
+        "args": {},
+        "post": [],
+    }
+    payload = jqs_context.digest(recipe, project)
+    assert payload["shape"]["date_axis_temporal"] is False
+    assert any("positional" in w for w in payload["warnings"])
+
+
+def test_date_column_is_normalised_for_portfolio(project, prices_frame):
+    """A 'Date' price column is renamed, because the bridge only keeps 'date'."""
+    prices_frame.rename({"date": "Date"}).write_csv(project / "data" / "prices_upper.csv")
+    prices_frame.select(pl.col("date").alias("Date"), pl.lit(1e5).alias("A"), pl.lit(1e5).alias("B")).write_csv(
+        project / "data" / "pos_upper.csv"
+    )
+    recipe = _portfolio_recipe(prices="data/prices_upper.csv", position="data/pos_upper.csv")
+    obj, _, notes = jqs_context.build_detailed(recipe, project)
+
+    assert obj.data.index.columns == ["date"]
+    assert any("renamed to 'date'" in note for note in notes)
+
+
+# ── fingerprints ──────────────────────────────────────────────────────────────
+
+
+def test_staleness_is_detected(project):
+    """Changing an input after the digest is written invalidates it."""
+    recipe = _portfolio_recipe()
+    jqs_context.upsert(project, recipe)
+    jqs_context.write_digest(project, jqs_context.digest(recipe, project))
+    assert jqs_context.stale_inputs(project) == []
+
+    target = project / "data" / "prices.csv"
+    target.write_text(target.read_text() + "2020-04-01,999.0,999.0\n")
+    assert jqs_context.stale_inputs(project) == ["data/prices.csv"]
+
+
+def test_digests_are_keyed_by_context(project):
+    """Writing one context's digest must not invalidate a sibling's fingerprints."""
+    base, other = _portfolio_recipe("base"), _data_recipe("ret")
+    for recipe in (base, other):
+        jqs_context.upsert(project, recipe)
+        jqs_context.write_digest(project, jqs_context.digest(recipe, project))
+
+    assert set(jqs_context.read_digests(project)) == {"base", "ret"}
+
+    target = project / "data" / "returns.csv"
+    target.write_text(target.read_text() + "2020-04-01,0.01\n")
+    assert jqs_context.stale_inputs(project, "base") == []
+    assert jqs_context.stale_inputs(project, "ret") == ["data/returns.csv"]
+
+
+def test_context_dir_ignores_the_derived_digest(project):
+    """The context directory ignores its own derived file, host .gitignore untouched."""
+    jqs_context.upsert(project, _portfolio_recipe())
+    ignore = project / jqs_context.CONTEXT_DIRNAME / ".gitignore"
+    assert ignore.exists()
+    patterns = [line for line in ignore.read_text().splitlines() if line and not line.startswith("#")]
+    assert patterns == [jqs_context.DIGEST_FILENAME]  # the recipe stays committable
+
+
+def test_stale_inputs_without_a_digest(project):
+    """No digest yet means nothing to invalidate."""
+    jqs_context.upsert(project, _portfolio_recipe())
+    assert jqs_context.stale_inputs(project) == []
+
+
+# ── script-backed inputs ──────────────────────────────────────────────────────
+
+
+def test_script_backed_input(project):
+    """Positions can come from a repo-owned function instead of a file."""
+    (project / "build_pos.py").write_text(
+        "import pathlib\n"
+        "import polars as pl\n"
+        "def positions():\n"
+        "    here = pathlib.Path(__file__).parent\n"
+        "    frame = pl.read_csv(here / 'data' / 'prices.csv', try_parse_dates=True)\n"
+        "    return frame.select(pl.col('date'), pl.lit(4e5).alias('A'), pl.lit(4e5).alias('B'))\n"
+    )
+    recipe = _portfolio_recipe()
+    recipe["inputs"]["cash_position"] = {"script": "build_pos.py", "callable": "positions"}
+    obj = jqs_context.build(recipe, project)
+    assert obj.assets == ["A", "B"]
+    assert "build_pos.py" in jqs_context.fingerprints(recipe, project)
+
+
+def test_script_backed_input_errors(project):
+    """A missing script, callable, or wrong return type each fail loudly."""
+    recipe = _portfolio_recipe()
+    recipe["inputs"]["cash_position"] = {"script": "nope.py"}
+    with pytest.raises(jqs_context.ContextError, match="builder script not found"):
+        jqs_context.build(recipe, project)
+
+    (project / "bad.py").write_text("def other():\n    return 1\n")
+    recipe["inputs"]["cash_position"] = {"script": "bad.py", "callable": "missing"}
+    with pytest.raises(jqs_context.ContextError, match="no callable named"):
+        jqs_context.build(recipe, project)
+
+    recipe["inputs"]["cash_position"] = {"script": "bad.py", "callable": "other"}
+    with pytest.raises(jqs_context.ContextError, match=r"expected pl\.DataFrame"):
+        jqs_context.build(recipe, project)
+
+
+# ── error paths ───────────────────────────────────────────────────────────────
+
+
+def test_missing_context_file(tmp_path):
+    """Reading a context that was never created explains how to make one."""
+    with pytest.raises(jqs_context.ContextError, match=r"run jqs_load\.py"):
+        jqs_context.read_container(tmp_path)
+
+
+def test_malformed_context_file(tmp_path):
+    """A corrupt recipe file is reported as such, not as a KeyError later on."""
+    (tmp_path / jqs_context.CONTEXT_DIRNAME).mkdir()
+    jqs_context.context_path(tmp_path).write_text("{not json")
+    with pytest.raises(jqs_context.ContextError, match="not valid JSON"):
+        jqs_context.read_container(tmp_path)
+
+
+def test_future_schema_is_refused(tmp_path):
+    """A newer on-disk schema is refused rather than half-understood."""
+    (tmp_path / jqs_context.CONTEXT_DIRNAME).mkdir()
+    jqs_context.context_path(tmp_path).write_text(json.dumps({"schema": 99, "contexts": {}}))
+    with pytest.raises(jqs_context.ContextError, match="schema 99"):
+        jqs_context.read_container(tmp_path)
+
+
+def test_unknown_context_name(project):
+    """Resolving an unknown name lists the ones that exist."""
+    jqs_context.upsert(project, _portfolio_recipe("base"))
+    with pytest.raises(jqs_context.ContextError, match="known: base"):
+        jqs_context.resolve(project, "nope")
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    [
+        ({"entry_point": "Nope"}, "entry_point must be"),
+        ({"constructor": "from_magic"}, "unknown Portfolio constructor"),
+        ({"inputs": {"prices": {"path": "data/prices.csv"}}}, "needs an input named"),
+        ({"post": [{"op": "warp"}]}, "unknown post op"),
+    ],
+)
+def test_invalid_recipes(project, mutation, match):
+    """Each way a recipe can be wrong raises ContextError with a usable message."""
+    recipe = _portfolio_recipe() | mutation
+    with pytest.raises(jqs_context.ContextError, match=match):
+        jqs_context.build(recipe, project)
+
+
+def test_missing_input_file(project):
+    """A recipe pointing at a deleted file names the path."""
+    recipe = _portfolio_recipe(prices="data/gone.csv")
+    with pytest.raises(jqs_context.ContextError, match="input file not found"):
+        jqs_context.build(recipe, project)
+
+
+def test_unsupported_format(project):
+    """An unreadable suffix is refused before polars guesses at it."""
+    (project / "data" / "prices.xlsx").write_text("nope")
+    with pytest.raises(jqs_context.ContextError, match="unsupported table format"):
+        jqs_context.build(_portfolio_recipe(prices="data/prices.xlsx"), project)
+
+
+def test_input_spec_without_source(project):
+    """An input naming neither a path nor a script is rejected."""
+    recipe = _portfolio_recipe()
+    recipe["inputs"]["prices"] = {"date_col": "date"}
+    with pytest.raises(jqs_context.ContextError, match="needs a 'path' or a 'script'"):
+        jqs_context.build(recipe, project)
+
+
+def test_unknown_columns(project):
+    """Restricting to absent columns fails with the available ones listed."""
+    recipe = _portfolio_recipe()
+    recipe["inputs"]["prices"] = {"path": "data/prices.csv", "columns": ["ZZZ"]}
+    with pytest.raises(jqs_context.ContextError, match="columns"):
+        jqs_context.build(recipe, project)
+
+
+def test_unknown_cost_model(project):
+    """A cost model kind outside the two supported forms is refused."""
+    recipe = _portfolio_recipe()
+    recipe["args"]["cost_model"] = {"kind": "gut_feel", "value": 1}
+    with pytest.raises(jqs_context.ContextError, match="unknown cost_model kind"):
+        jqs_context.build(recipe, project)
+
+
+@pytest.mark.parametrize("kind", ["per_unit", "turnover_bps"])
+def test_cost_models(project, kind):
+    """Both declarative cost models reach the constructor."""
+    recipe = _portfolio_recipe()
+    recipe["args"]["cost_model"] = {"kind": kind, "value": 2.0}
+    assert jqs_context.build(recipe, project).cost_model is not None
+
+
+# ── the loader CLI ────────────────────────────────────────────────────────────
+
+
+def test_cli_portfolio_writes_context(project, capsys):
+    """The portfolio subcommand prints a digest and records both files."""
+    code = jqs_load.main(
+        [
+            "portfolio",
+            "--prices",
+            str(project / "data" / "prices.csv"),
+            "--cash-position",
+            str(project / "data" / "pos.csv"),
+            "--aum",
+            "1e6",
+            "--cost-bps",
+            "5",
+            "--lag",
+            "1",
+            "--root",
+            str(project),
+        ]
+    )
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "Portfolio.from_cash_position" in out
+    assert "lag(n=1)" in out
+
+    container = jqs_context.read_container(project)
+    recipe = container["contexts"]["base"]
+    assert recipe["post"] == [{"op": "lag", "n": 1}]
+    assert recipe["args"]["cost_bps"] == 5.0
+    assert recipe["inputs"]["prices"]["path"] == "data/prices.csv"
+    assert jqs_context.digest_path(project).exists()
+
+
+def test_cli_data_warns_and_exits_nonzero(project, capsys):
+    """Building over nulls without a strategy is reported and flagged in the code."""
+    code = jqs_load.main(["data", "--returns", str(project / "data" / "returns.csv"), "--root", str(project)])
+    assert code == 1
+    assert "WARNING" in capsys.readouterr().out
+
+
+def test_cli_requires_one_position_flag(project):
+    """Zero or several position flags is a usage error, not a guess."""
+    args = ["portfolio", "--prices", str(project / "data" / "prices.csv"), "--aum", "1e6", "--root", str(project)]
+    with pytest.raises(SystemExit, match="exactly one of"):
+        jqs_load.main(args)
+    with pytest.raises(SystemExit, match="exactly one of"):
+        jqs_load.main([*args, "--cash-position", "a.csv", "--position", "b.csv"])
+
+
+def test_cli_data_requires_one_source(project):
+    """Data needs exactly one of returns or prices."""
+    with pytest.raises(SystemExit, match="exactly one of"):
+        jqs_load.main(["data", "--root", str(project)])
+
+
+def test_cli_show_list_activate_and_check(project, capsys):
+    """The read-only subcommands report the recorded contexts."""
+    common = ["--prices", str(project / "data" / "prices.csv"), "--root", str(project)]
+    jqs_load.main(["portfolio", *common, "--cash-position", str(project / "data" / "pos.csv"), "--aum", "1e6"])
+    jqs_load.main(
+        [
+            "portfolio",
+            *common,
+            "--cash-position",
+            str(project / "data" / "pos.csv"),
+            "--aum",
+            "1e6",
+            "--lag",
+            "1",
+            "--name",
+            "lag1",
+        ]
+    )
+    capsys.readouterr()
+
+    assert jqs_load.main(["list", "--root", str(project)]) == 0
+    listing = capsys.readouterr().out
+    assert "* lag1" in listing
+    assert "  base" in listing
+
+    assert jqs_load.main(["activate", "base", "--root", str(project)]) == 0
+    assert "base" in capsys.readouterr().out
+
+    assert jqs_load.main(["show", "--root", str(project)]) == 0
+    assert "Portfolio.from_cash_position" in capsys.readouterr().out
+
+    assert jqs_load.main(["check", "--root", str(project)]) == 0
+    assert "fresh" in capsys.readouterr().out
+
+
+def test_cli_check_reports_stale(project, capsys):
+    """A mutated input makes check fail loudly."""
+    jqs_load.main(
+        [
+            "portfolio",
+            "--prices",
+            str(project / "data" / "prices.csv"),
+            "--cash-position",
+            str(project / "data" / "pos.csv"),
+            "--aum",
+            "1e6",
+            "--root",
+            str(project),
+        ]
+    )
+    target = project / "data" / "pos.csv"
+    target.write_text(target.read_text() + "2020-04-01,1.0,1.0\n")
+    capsys.readouterr()
+
+    assert jqs_load.main(["check", "--root", str(project)]) == 1
+    assert "STALE" in capsys.readouterr().out
+
+
+def test_cli_check_without_digest(project, capsys):
+    """Checking before anything was built explains what to do."""
+    assert jqs_load.main(["check", "--root", str(project)]) == 0
+    assert "no digest recorded yet" in capsys.readouterr().out
+
+
+def test_cli_json_output(project, capsys):
+    """--json emits the recipe and digest for programmatic use."""
+    code = jqs_load.main(
+        [
+            "data",
+            "--returns",
+            str(project / "data" / "returns.csv"),
+            "--null-strategy",
+            "drop",
+            "--json",
+            "--no-write",
+            "--root",
+            str(project),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["recipe"]["args"]["null_strategy"] == "drop"
+    assert payload["digest"]["shape"]["assets"] == ["A"]
+    assert not jqs_context.context_path(project).exists()
+
+
+def test_cli_rf_as_scalar_and_path(project):
+    """--rf takes a number or a frame path, and records which it was."""
+    common = ["data", "--returns", str(project / "data" / "returns.csv"), "--no-write", "--root", str(project)]
+    jqs_load.main([*common, "--rf", "0.01"])
+    recipe = jqs_load._data_recipe(
+        jqs_load.build_parser().parse_args([*common, "--rf", "0.01"]),
+        project,
+    )
+    assert recipe["args"]["rf"] == 0.01
+
+    path_recipe = jqs_load._data_recipe(
+        jqs_load.build_parser().parse_args([*common, "--rf", str(project / "data" / "returns.csv")]),
+        project,
+    )
+    assert path_recipe["args"]["rf"]["path"] == "data/returns.csv"
+
+
+def test_cli_reports_context_errors(project, capsys):
+    """A broken recipe surfaces as a message and exit code 2, not a traceback."""
+    jqs_context.upsert(project, _portfolio_recipe(prices="data/gone.csv"))
+    assert jqs_load.main(["show", "--root", str(project)]) == 2
+    assert "input file not found" in capsys.readouterr().err
+
+
+# ── the API introspection script ──────────────────────────────────────────────
+
+
+def test_api_sections(capsys):
+    """The bare listing reports every section it knows about."""
+    assert jqs_api.main([]) == 0
+    out = capsys.readouterr().out
+    for section in ("stats", "data-plots", "portfolio-plots", "constructors"):
+        assert section in out
+
+
+def test_api_show_existing(capsys):
+    """--show prints the signature and docstring of a real member."""
+    assert jqs_api.main(["--show", "conditional_value_at_risk"]) == 0
+    out = capsys.readouterr().out
+    assert "confidence" in out
+    assert "alpha" in out
+
+
+def test_api_show_missing(capsys):
+    """--show on a QuantStats alias reports absence instead of implying a wrapper."""
+    assert jqs_api.main(["--show", "cvar"]) == 1
+    assert "not on any public surface" in capsys.readouterr().out
+
+
+def test_api_grep_and_json(capsys):
+    """--grep filters names; --json emits the whole surface."""
+    assert jqs_api.main(["--grep", "drawdown"]) == 0
+    assert "max_drawdown" in capsys.readouterr().out
+
+    assert jqs_api.main(["--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "sharpe" in payload["stats"]
+    assert "Portfolio.from_cash_position" in payload["constructors"]
+
+
+def test_api_section_listing(capsys):
+    """Naming a section lists its members with summaries."""
+    assert jqs_api.main(["portfolio-plots"]) == 0
+    out = capsys.readouterr().out
+    assert "lead_lag_ir_plot" in out
+    assert "snapshot" in out


### PR DESCRIPTION
## The problem

The plugin taught Claude how to *write* jquantstats code. It had no way to reach an actual portfolio, so every skill had to re-derive one from prose.

Skills are prompts, and every Bash call is a fresh Python process — no live object survives between invocations. What travels instead is a **recipe**: the paths and constructor arguments needed to rebuild the object. Rebuilding is not approximating; the same inputs through the same recorded constructor give a bit-identical object, lag and costs included. One portfolio, several skills reasoning about it.

## The two files

| File | Contents | Lifecycle |
|---|---|---|
| `.jquantstats/context.json` | the recipe: entry point, constructor, input paths, args, post-transforms | authoritative, committable |
| `.jquantstats/digest.json` | derived shape, nulls, anchor metrics, warnings, and a SHA-256 per input | regenerable, gitignored |

Split by lifecycle on purpose: storing derived numbers next to the inputs that produce them is how you end up quoting last week's Sharpe. `check` compares fingerprints and refuses to vouch for stale anchors.

Recorded `post` transforms are the piece that is easy to miss — a `lag(1)` study rebuilt unlagged looks entirely plausible and is wrong.

## What's added

```
plugin/
  reference/portfolio-context.md   the shared protocol, one source for all skills
  scripts/jqs_context.py           recipe read/write, build, digest, fingerprints, load()
          jqs_load.py              portfolio | data | show | list | activate | check
          jqs_api.py               live API surface — 91 Stats, 20+10 plots, constructors
          jqs.sh                   finds a Python that can import jquantstats
  commands/load.md, review.md      /jquantstats:load, /jquantstats:review
  skills/portfolio-analysis        question → metric/chart routing
         portfolio-diagnostics     why a number is null, wrong, or implausible
         portfolio-robustness      is the result real
tests/test_plugin.py               56 tests
```

Named contexts make lag and cost sweeps first-class — each variant keeps its own recipe, digest and fingerprints, so comparisons are reproducible rather than one-off objects.

`jqs_api.py` replaces the migration skill's hand-maintained mapping tables with an executable check. `Stats` alone has 91 public methods; a table that drifts silently is worse than none.

## Verified

End to end through the wrapper, exactly as a skill invokes it — two contexts, then one snippet applying four lenses:

```
base sharpe 2.1421   lag1 sharpe 2.1289   smart_sharpe 2.0721   PSR 0.9922
```

`make fmt`, `make test` (1322 passed, `src/` still 100%), `make typecheck`, `make security`, `make deps` all clean; import contracts kept. The plugin scripts sit outside the repo's mypy target, so mypy was run over them separately — also clean.

## Three silent library bugs found while building this

Worked around here, but each deserves its own issue and a fix in `src/`:

1. **The `date` naming trap** (`portfolio.py:218`). The `Portfolio → Data` bridge keeps the date axis only when the price frame's date column is named exactly `date`. Any other name and dates are replaced by a positional integer index: `periods_per_year` drops from 365 to a default 252, and **Sharpe moved 100.33 → 83.36 on identical data**. Nothing raised. Anyone whose CSV says `Date` is affected. The loader normalises and reports it.
2. **`truncate` advertises `str` but rejects it.** The signature says `date | datetime | str | int | None`; `_data_reshape.py:188` does `pl.lit(start)` with no parsing, so an ISO string raises `InvalidOperationError` on both `Portfolio` and `Data`. JSON has no date type, so the recipe layer coerces.
3. **Integer `truncate` bounds are a silent no-op on a temporal axis.** `truncate(start=10)` returned all 80 rows where a date bound returned 70 — it routes on index dtype and ignores the int. Pinned in a test so a future fix surfaces there.

## Smaller fixes

- The migration skill documented `pf.turnover_weekly()`, but it's a property — the call would have raised. Corrected, and the properties-vs-methods split is now spelled out in `portfolio-analysis`.
- One bug in my own design, caught mid-build: `digest.json` was single-context, so building a variant overwrote a sibling's fingerprints and `check` validated the wrong files. Now keyed by context, with a test.
- Since `.gitignore` is Rhiza-managed, the loader writes `.jquantstats/.gitignore` itself — the derived digest is ignored, the recipe stays committable.
- `plugin/scripts/.ruff.toml` scopes a TRY003 exemption to the CLI scripts, whose raise-site messages are the diagnostic product. The repo-root `ruff.toml` is Rhiza-managed and untouched.

## Considered and deferred

An MCP server holding a live portfolio was the alternative. It buys a warm cache and reach outside a shell, but costs composition: 181 public methods across the surface means either 181 tool schemas loaded in every session, or one generic `call(method, kwargs)` that reimplements `python -c` with worse errors. And in-memory state dies with the process, so a recipe is still needed underneath. If build cost ever becomes the constraint, an MCP layer can read `context.json` on startup and cache — no rework here.

A `Portfolio` serializer was the other option. `Portfolio` is a dataclass of two frames and four floats, so it's cheap to add — but a snapshot ages silently, duplicates data, and hides the derivation. Worth having on its own merits (bug reports, slow builds, handing one to a colleague); not a prerequisite, and best as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
