### PR TITLE
fix(portfolio): normalise the date column at construction

### DIFF
--- a/src/jquantstats/_portfolio_constructors.py
+++ b/src/jquantstats/_portfolio_constructors.py
@@ -118,7 +118,8 @@ class PortfolioConstructorMixin(_PortfolioMembers):
         derived from the corresponding price series.
 
         Args:
-            prices: Price levels per asset over time (may include a date column).
+            prices: Price levels per asset over time.  A temporal column is
+                normalised to ``'date'`` at construction, whatever it was named.
             risk_position: Risk units per asset aligned with prices.
             vola: EWMA lookback (span-equivalent) used to estimate volatility.
                 Pass an ``int`` to apply the same span to every asset, or a
@@ -208,7 +209,8 @@ class PortfolioConstructorMixin(_PortfolioMembers):
         :py`from_cash_position`.
 
         Args:
-            prices: Price levels per asset over time (may include a date column).
+            prices: Price levels per asset over time.  A temporal column is
+                normalised to ``'date'`` at construction, whatever it was named.
             position: Number of units held per asset over time, aligned with
                 *prices*.  Non-numeric columns (e.g. ``'date'``) are passed
                 through unchanged.

--- a/src/jquantstats/portfolio.py
+++ b/src/jquantstats/portfolio.py
@@ -67,6 +67,42 @@ _CACHE_SLOTS = (
     "_turnover_cache",
 )
 
+# The canonical name of the date column throughout the Portfolio internals. Every
+# _portfolio_* mixin tests for this exact name to decide whether it has a temporal
+# axis, so inputs are normalised to it once at construction rather than each site
+# having to cope with an arbitrary caller-chosen name.
+_DATE_COLUMN = "date"
+
+
+def _normalise_date_column(frame: pl.DataFrame) -> pl.DataFrame:
+    """Rename *frame*'s temporal column to ``'date'``.
+
+    The Portfolio internals identify the date axis by name, so a frame whose
+    dates live under any other label (``'Date'``, ``'timestamp'``, …) would be
+    treated as having no temporal axis at all — silently falling back to a
+    positional index and a default ``periods_per_year``.  Renaming here makes
+    that impossible.
+
+    A frame that already has a ``'date'`` column is returned untouched, so this is
+    idempotent and cheap on the internal rebuild paths (`lag`, `truncate`,
+    `smoothed_holding`) where the input is already canonical.  When several
+    temporal columns are present the first one wins, matching the
+    leading-date-column convention used throughout.
+
+    Args:
+        frame: A price or cash-position frame, with or without dates.
+
+    Returns:
+        *frame* with its date column named ``'date'``, or *frame* unchanged
+        when it already has one or has no temporal column to rename.
+    """
+    if _DATE_COLUMN in frame.columns:
+        return frame
+    temporal = [name for name, dtype in frame.schema.items() if dtype.is_temporal()]
+    if not temporal:
+        return frame
+    return frame.rename({temporal[0]: _DATE_COLUMN})
+
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class Portfolio(
@@ -106,10 +142,10 @@ class Portfolio(
     - Utility: `correlation`
 
     Attributes:
-        cashposition: Polars DataFrame of positions per asset over time
-            (includes date column if present).
-        prices: Polars DataFrame of prices per asset over time (includes date
-            column if present).
+        cashposition: Polars DataFrame of positions per asset over time.  Any
+            temporal column is present as ``'date'`` — see *Date column* below.
+        prices: Polars DataFrame of prices per asset over time.  Any temporal
+            column is present as ``'date'`` — see *Date column* below.
         aum: Assets under management used as base NAV offset.
 
     Analytics facades
@@ -147,10 +183,21 @@ class Portfolio(
     To sweep a range of cost assumptions use ``trading_cost_impact(max_bps=20)`` (Model B).
     To compute a net-NAV curve set ``cost_per_unit`` at construction and read ``.net_cost_nav`` (Model A).
 
-    Date column requirement
-    -----------------------
-    Most analytics work with or without a ``date`` column. The following features require a
-    temporal ``date`` column (``pl.Date`` or ``pl.Datetime``):
+    Date column
+    -----------
+    The date axis is identified internally by the name ``date``, so a temporal column
+    (``pl.Date`` or ``pl.Datetime``) under any other label — ``'Date'``, ``'timestamp'`` —
+    is **renamed to ``date`` at construction**.  ``prices`` and ``cashposition`` therefore
+    report ``date`` rather than the caller's original name, and every date-dependent
+    feature works regardless of what the input column was called.
+
+    Only genuinely temporal columns are normalised: a date column still held as strings
+    is left as-is and the portfolio is treated as integer-indexed.  Parse it first
+    (``pl.col("Date").str.to_date()``) to get a temporal axis.  When a frame contains
+    several temporal columns and none is named ``date``, the first is renamed.
+
+    Most analytics work with or without a date column. The following features require a
+    temporal ``date`` column:
 
     - ``portfolio.plots.correlation_heatmap()``
     - ``portfolio.plots.lead_lag_ir_plot()``
@@ -208,6 +255,11 @@ class Portfolio(
         the remaining numeric columns as returns.  Used internally to populate
         ``_data_bridge`` at construction time so the ``data`` property is O(1).
 
+        The name is matched literally, which is safe because ``__post_init__``
+        normalises the inputs: the positional-index fallback below is reached
+        only by a portfolio that genuinely has no temporal column, never by one
+        whose dates simply arrived under a different name.
+
         Args:
             ret: Returns DataFrame, optionally with a leading ``'date'`` column.
 
@@ -220,11 +272,16 @@ class Portfolio(
         return Data(returns=returns_only, index=pl.DataFrame({"index": list(range(ret.height))}))
 
     def __post_init__(self) -> None:
-        """Validate input types, shapes, and parameters post-initialization."""
+        """Validate input types, shapes, and parameters, and normalise the date column."""
         if not isinstance(self.prices, pl.DataFrame):
             raise InvalidPricesTypeError(type(self.prices).__name__)
         if not isinstance(self.cashposition, pl.DataFrame):
             raise InvalidCashPositionTypeError(type(self.cashposition).__name__)
+        # Canonicalise the date axis before anything downstream looks for it; the
+        # mixins match ``'date'`` by name, so this must happen on every
+        # construction path, including a direct ``Portfolio(...)`` call.
+        object.__setattr__(self, "prices", _normalise_date_column(self.prices))
+        object.__setattr__(self, "cashposition", _normalise_date_column(self.cashposition))
         if self.cashposition.shape[0] != self.prices.shape[0]:
             raise RowCountMismatchError(self.prices.shape[0], self.cashposition.shape[0])
         if self.aum <= 0.0:
@@ -304,7 +361,8 @@ class Portfolio(
         """Create a Portfolio directly from cash positions aligned with prices.
 
         Args:
-            prices: Price levels per asset over time (may include a date column).
+            prices: Price levels per asset over time.  A temporal column is
+                normalised to ``'date'`` at construction, whatever it was named.
             cash_position: Cash exposure per asset over time, either as a
                 DataFrame or as a Polars expression evaluated against *prices*.
             aum: Assets under management used as the base NAV offset.

--- a/tests/test_jquantstats/test_portfolio/test_core.py
+++ b/tests/test_jquantstats/test_portfolio/test_core.py
@@ -91,6 +91,109 @@ def test_portfolio_post_init_requires_positive_aum(prices, positions):
         Portfolio(prices=prices, cashposition=positions, aum=-1.0)
 
 
+# ─── Date-column normalisation (issue #925) ───────────────────────────────────
+# The Portfolio internals identify the date axis by the literal name 'date'.
+# Before normalisation, a frame using any other label silently lost its temporal
+# axis: periods_per_year fell back to 252 and every annualised metric shifted by
+# sqrt(actual / 252) with nothing raised.
+
+
+@pytest.mark.parametrize("name", ["Date", "DATE", "timestamp", "Datum"])
+def test_date_column_is_normalised(prices, positions, name):
+    """A temporal column under any name is renamed to 'date' on construction."""
+    pf = Portfolio.from_cash_position(
+        prices=prices.rename({"date": name}),
+        cash_position=positions.rename({"date": name}),
+        aum=1e5,
+    )
+
+    assert pf.prices.columns == ["date", "A", "B"]
+    assert pf.cashposition.columns == ["date", "A", "B"]
+    # The temporal axis reaches the Data bridge rather than a positional index.
+    assert pf.data.index.columns == ["date"]
+
+
+@pytest.mark.parametrize("name", ["Date", "timestamp"])
+def test_renaming_the_date_column_does_not_change_any_metric(prices, positions, portfolio, name):
+    """The whole point: an arbitrary date-column name is now metric-neutral."""
+    renamed = Portfolio.from_cash_position(
+        prices=prices.rename({"date": name}),
+        cash_position=positions.rename({"date": name}),
+        aum=1e5,
+    )
+
+    assert renamed.stats.periods_per_year == portfolio.stats.periods_per_year
+    assert renamed.stats.sharpe()["returns"] == portfolio.stats.sharpe()["returns"]
+    assert renamed.returns.equals(portfolio.returns)
+    assert renamed.describe().equals(portfolio.describe())
+
+
+def test_normalisation_applies_to_direct_construction(prices, positions):
+    """Normalisation lives in __post_init__, so it covers Portfolio(...) too."""
+    pf = Portfolio(
+        prices=prices.rename({"date": "Date"}),
+        cashposition=positions.rename({"date": "Date"}),
+        aum=1e5,
+    )
+    assert pf.prices.columns[0] == "date"
+    assert pf.cashposition.columns[0] == "date"
+
+
+def test_normalisation_survives_transforms(prices, positions):
+    """Transforms rebuild through the same path, so the canonical name persists."""
+    pf = Portfolio.from_cash_position(
+        prices=prices.rename({"date": "Date"}),
+        cash_position=positions.rename({"date": "Date"}),
+        aum=1e5,
+    )
+    assert pf.lag(1).prices.columns[0] == "date"
+    assert pf.truncate(start=date(2020, 1, 2)).prices.columns[0] == "date"
+    assert pf.smoothed_holding(2).cashposition.columns[0] == "date"
+    assert pf.tilt.prices.columns[0] == "date"
+
+
+def test_an_existing_date_column_wins(prices, positions):
+    """A frame already carrying 'date' is left alone — no collision, no reorder."""
+    extra = prices.with_columns(pl.col("date").alias("Date"))
+    pf = Portfolio.from_cash_position(prices=extra, cash_position=positions, aum=1e5)
+    assert pf.prices.columns == ["date", "A", "B", "Date"]
+
+
+def test_first_temporal_column_wins(positions):
+    """With several temporal columns and no 'date', the leading one is renamed."""
+    dates = pl.date_range(start=date(2020, 1, 1), end=date(2020, 1, 3), interval="1d", eager=True).cast(pl.Date)
+    prices = pl.DataFrame(
+        {
+            "Date": dates,
+            "settled": dates,
+            "A": pl.Series([100.0, 110.0, 121.0], dtype=pl.Float64),
+            "B": pl.Series([200.0, 180.0, 198.0], dtype=pl.Float64),
+        }
+    )
+    pf = Portfolio.from_cash_position(prices=prices, cash_position=positions, aum=1e5)
+    assert pf.prices.columns == ["date", "settled", "A", "B"]
+
+
+def test_a_string_date_column_is_not_renamed(positions):
+    """Only genuinely temporal columns are normalised; unparsed strings are not."""
+    prices = pl.DataFrame(
+        {
+            "Date": ["2020-01-01", "2020-01-02", "2020-01-03"],
+            "A": pl.Series([100.0, 110.0, 121.0], dtype=pl.Float64),
+            "B": pl.Series([200.0, 180.0, 198.0], dtype=pl.Float64),
+        }
+    )
+    pf = Portfolio.from_cash_position(prices=prices, cash_position=positions.drop("date"), aum=1e5)
+    assert pf.prices.columns == ["Date", "A", "B"]
+    assert pf.data.index.columns == ["index"]
+
+
+def test_undated_portfolio_still_uses_a_positional_index(int_portfolio):
+    """A frame with no temporal column keeps the documented integer-index behaviour."""
+    assert "date" not in int_portfolio.prices.columns
+    assert int_portfolio.data.index.columns == ["index"]
+
+
 # ─── from_riskposition edge cases ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #925.

## The bug

`date` is the internal canonical name for the date axis: **over 40 sites** across
the `_portfolio_*` mixins test for that literal string to decide whether a
temporal axis exists. The constructors passed the caller's column through
unchanged, so a frame labelled `Date` or `timestamp` made every one of those
sites take its no-date-column fallback at once — the `Data` bridge substituted a
positional integer index, `periods_per_year` fell back to the 252 default, and
every annualised metric shifted by √(actual / 252).

Nothing raised, nothing warned. Same data, three column names:

| date column | `pf.data.index` | `periods_per_year` | Sharpe |
|---|---|---|---|
| `date` | `['date']` | 365 | −3.5021 |
| `Date` | `['index']` | 252 | −2.9099 |
| `timestamp` | `['index']` | 252 | −2.9099 |

−3.5021 / −2.9099 = 1.2035 against a predicted √(365/252) = 1.2036, so the whole
discrepancy was the annualisation fallback and nothing else. `Date` is the pandas
and CSV-export default, which made the affected population "everyone arriving
from a spreadsheet".

## The fix

Normalise once in `__post_init__` rather than matching the name downstream.

Two reasons that hook rather than the factories: all three `from_*` constructors
funnel through `from_cash_position`, but `Portfolio(...)` is itself a documented
construction path (it appears in the class docstring and throughout the
doctests), and `__post_init__` is the only place that catches both. It also
covers the internal rebuilds behind `lag`, `truncate` and `smoothed_holding`,
where the helper is an idempotent no-op because the frames are already canonical.

Deliberate boundaries:

- **Only genuinely temporal columns are renamed.** A date column still held as
  strings keeps the documented integer-index behaviour rather than being promoted
  to an axis that Polars comparisons would then reject — which would have traded
  this bug for #926's `InvalidOperationError`.
- **An existing `date` column always wins**, so normalisation can never collide
  with or reorder a frame that is already canonical.
- **Where several temporal columns exist and none is named `date`, the first
  wins**, matching the leading-date-column convention used throughout.

`_build_data_bridge` keeps its literal match — now safe, and its docstring says
why: the positional-index fallback is reachable only by a portfolio that
genuinely has no temporal column.

## The one visible change

`prices` and `cashposition` now report `date` rather than the caller's original
name. This is documented in a rewritten *Date column* section on the class.

Worth stating plainly: reading the old name now raises `ColumnNotFoundError`.
That is the point — a loud, one-line diagnosis replaces a silently wrong
annualised number.

## Tests

Twelve cases in `test_core.py`, the substantive one being that renaming the date
column is now **metric-neutral** — `periods_per_year`, `sharpe()`, `returns` and
`describe()` all match a canonical portfolio exactly. The rest cover the four
name variants, direct `Portfolio(...)` construction, persistence through
`lag`/`truncate`/`smoothed_holding`/`tilt`, an existing `date` winning, first
temporal column winning, strings left alone, and undated portfolios keeping
their positional index.

No existing test used a non-`date` column name, which is why the suite never
caught this.

## Gates

`make fmt`, `make test` (1275 passed, `src/` 100% coverage, import contracts
kept), `make typecheck` (ty + mypy strict), `make docs-coverage` (100%),
`make deps`, `make security`, `make book` — all clean.

## Noticed while fixing, not in scope

`Data.from_returns` defaults to `date_col="Date"` — capital D — while the
`Portfolio` internals canonicalise on lowercase `date`. The two entry points
disagree on the default name for the same concept. `Data` at least fails loudly
via `MissingDateColumnError` with a message naming the fix, so it is a
consistency wart rather than a correctness bug, and aligning them is a breaking
change that deserves its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
