### PR TITLE
fix(truncate): route on the bound type, and parse ISO-8601 string bounds

### DIFF
--- a/src/jquantstats/_data_reshape.py
+++ b/src/jquantstats/_data_reshape.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, cast
 
 import polars as pl
 
-from .exceptions import IntegerIndexBoundError
+from ._truncate import resolve_bounds
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -145,34 +145,44 @@ class _ReshapeMixin:
     ) -> Data:
         """Return a new Data object truncated to the inclusive [start, end] range.
 
-        When the index is temporal (Date/Datetime), truncation is performed by
-        comparing the date column against ``start`` and ``end`` values.
+        **The bound type picks the axis.**  A ``date``, ``datetime`` or ISO-8601
+        string is compared against the date column; an ``int`` is a 0-based row
+        index and slices positionally.  Row indices work on a temporal index too
+        — ``truncate(start=10)`` drops the first ten rows of dated data — but the
+        two kinds cannot be combined in one call.
 
-        When the index is integer-based, row slicing is used instead, and
-        ``start`` and ``end`` must be non-negative integers.  Passing
-        non-integer bounds to an integer-indexed Data raises `TypeError`.
+        An integer-indexed Data (no temporal index) accepts row indices only.
 
         Args:
-            start: Optional lower bound (inclusive).  A date/datetime value
-                when the index is temporal; a non-negative `int` row
-                index when the data has no temporal index.
-            end: Optional upper bound (inclusive).  Same type rules as
-                ``start``.
+            start: Optional inclusive lower bound.  A ``date``/``datetime``, an
+                ISO-8601 string, or an ``int`` row index; ``int`` only when the
+                index is not temporal.
+            end: Optional inclusive upper bound.  Same type rules as ``start``,
+                and must address the same axis.
 
         Returns:
             Data: A new Data object filtered to the specified range.
 
         Raises:
-            TypeError: When the index is not temporal and a non-integer bound
-                is supplied.
-
+            IntegerIndexBoundError: When the index is not temporal and a bound
+                is not an ``int``.
+            InvalidTruncateBoundError: When a bound is of an unsupported type,
+                or is a string that is not ISO-8601.
+            MixedTruncateBoundsError: When one bound is a row index and the
+                other a date.
         """
         date_column = self.index.columns[0]
+        mode, lower, upper = resolve_bounds(start, end, temporal=self.index[date_column].dtype.is_temporal())
 
-        if self.index[date_column].dtype.is_temporal():
-            new_index, new_returns, new_benchmark = self._truncate_temporal(date_column, start, end)
+        if mode == "dates":
+            new_index, new_returns, new_benchmark = self._truncate_temporal(date_column, lower, upper)
         else:
-            new_index, new_returns, new_benchmark = self._truncate_integer(start, end)
+            # "none" resolves to a full-width slice, so it needs no separate branch.
+            # The casts record what resolve_bounds guarantees for these modes but
+            # cannot express in its return type.
+            new_index, new_returns, new_benchmark = self._truncate_integer(
+                cast("int | None", lower), cast("int | None", upper)
+            )
 
         return self._rebuild(returns=new_returns, benchmark=new_benchmark, index=new_index)
 
@@ -192,33 +202,19 @@ class _ReshapeMixin:
         new_benchmark = self.benchmark.filter(mask) if self.benchmark is not None else None
         return self.index.filter(mask), self.returns.filter(mask), new_benchmark
 
-    @staticmethod
-    def _resolve_row_bound(name: str, value: date | datetime | str | int | None, default: int) -> int:
-        """Validate and resolve an integer truncation bound to a row index.
-
-        Args:
-            name: The bound's name (``"start"`` or ``"end"``) for the message.
-            value: The supplied bound; ``None`` and ``int`` are accepted.
-            default: The row index to use when *value* is ``None``.
-
-        Returns:
-            int: *value* when it is an ``int``, otherwise *default*.
-
-        Raises:
-            IntegerIndexBoundError: If *value* is neither ``None`` nor ``int``.
-        """
-        if value is not None and not isinstance(value, int):
-            raise IntegerIndexBoundError(name, type(value).__name__)
-        return value if value is not None else default
-
     def _truncate_integer(
         self,
-        start: date | datetime | str | int | None,
-        end: date | datetime | str | int | None,
+        start: int | None,
+        end: int | None,
     ) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame | None]:
-        """Truncate an integer index by row slicing; bounds must be integers."""
-        row_start = self._resolve_row_bound("start", start, 0)
-        row_end = self._resolve_row_bound("end", end, self.index.height - 1) + 1
+        """Truncate by 0-based row slicing.
+
+        Bounds arrive already validated by `resolve_bounds`, so this only
+        substitutes the open-ended defaults.  ``length`` is clamped at 0 so an
+        inverted range yields an empty frame rather than a negative slice.
+        """
+        row_start = start if start is not None else 0
+        row_end = (end if end is not None else self.index.height - 1) + 1
         length = max(0, row_end - row_start)
         new_benchmark = self.benchmark.slice(row_start, length) if self.benchmark is not None else None
         return self.index.slice(row_start, length), self.returns.slice(row_start, length), new_benchmark

--- a/src/jquantstats/_portfolio_transform.py
+++ b/src/jquantstats/_portfolio_transform.py
@@ -10,13 +10,13 @@ construction path and return the concrete ``Self`` type.
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Self, cast
 
 import polars as pl
 import polars.selectors as cs
 
 from ._portfolio_base import _PortfolioMembers
-from .exceptions import IntegerIndexBoundError
+from ._truncate import resolve_bounds
 
 
 class PortfolioTransformMixin(_PortfolioMembers):
@@ -97,15 +97,11 @@ class PortfolioTransformMixin(_PortfolioMembers):
         return cond
 
     @staticmethod
-    def _row_slice_bounds(
-        start: date | datetime | str | int | None,
-        end: date | datetime | str | int | None,
-        height: int,
-    ) -> tuple[int, int]:
-        """Resolve integer row bounds into a ``(offset, length)`` slice.
+    def _row_slice_bounds(start: int | None, end: int | None, height: int) -> tuple[int, int]:
+        """Resolve integer row bounds into an ``(offset, length)`` slice.
 
-        Used when the portfolio has no ``'date'`` column and truncation falls
-        back to 0-based row indexing.
+        Bounds arrive already validated by `resolve_bounds`, so this only
+        substitutes the open-ended defaults.
 
         Args:
             start: Optional inclusive lower row index; 0 when None.
@@ -116,16 +112,9 @@ class PortfolioTransformMixin(_PortfolioMembers):
             The ``(offset, length)`` pair to pass to ``DataFrame.slice``.
             ``length`` is clamped at 0 so an inverted range yields an empty
             frame rather than a negative slice.
-
-        Raises:
-            IntegerIndexBoundError: When a supplied bound is not an integer.
         """
-        if start is not None and not isinstance(start, int):
-            raise IntegerIndexBoundError("start", type(start).__name__)
-        if end is not None and not isinstance(end, int):
-            raise IntegerIndexBoundError("end", type(end).__name__)
-        row_start = int(start) if start is not None else 0
-        row_end = int(end) + 1 if end is not None else height
+        row_start = start if start is not None else 0
+        row_end = end + 1 if end is not None else height
         return row_start, max(0, row_end - row_start)
 
     # ── Transforms ─────────────────────────────────────────────────────────────
@@ -137,40 +126,48 @@ class PortfolioTransformMixin(_PortfolioMembers):
     ) -> Self:
         """Return a new Portfolio truncated to the inclusive [start, end] range.
 
-        When a ``'date'`` column is present in both prices and cash positions,
-        truncation is performed by comparing the ``'date'`` column against
-        ``start`` and ``end`` (which should be date/datetime values or strings
-        parseable by Polars).
+        **The bound type picks the axis.**  A ``date``, ``datetime`` or ISO-8601
+        string is compared against the ``'date'`` column; an ``int`` is a 0-based
+        row index and slices positionally.  Row indices work on a dated portfolio
+        too — ``truncate(start=10)`` drops the first ten rows — but the two kinds
+        cannot be combined in one call.
 
-        When the ``'date'`` column is absent, integer-based row slicing is
-        used instead.  In this case ``start`` and ``end`` must be non-negative
-        integers representing 0-based row indices.  Passing non-integer bounds
-        to an integer-indexed portfolio raises `TypeError`.
+        A portfolio with no ``'date'`` column accepts row indices only.
 
         In all cases the ``aum`` value is preserved.
 
         Args:
-            start: Optional lower bound (inclusive). A date/datetime or
-                Polars-parseable string when a ``'date'`` column exists; a
-                non-negative int row index when the data has no ``'date'``
-                column.
-            end: Optional upper bound (inclusive). Same type rules as
-                ``start``.
+            start: Optional inclusive lower bound.  A ``date``/``datetime``, an
+                ISO-8601 string, or an ``int`` row index; ``int`` only when there
+                is no ``'date'`` column.
+            end: Optional inclusive upper bound.  Same type rules as ``start``,
+                and must address the same axis.
 
         Returns:
             A new Portfolio instance with prices and cash positions filtered
             to the specified range.
 
         Raises:
-            TypeError: When the portfolio has no ``'date'`` column and a
-                non-integer bound is supplied.
+            IntegerIndexBoundError: When the portfolio has no ``'date'`` column
+                and a bound is not an ``int``.
+            InvalidTruncateBoundError: When a bound is of an unsupported type,
+                or is a string that is not ISO-8601.
+            MixedTruncateBoundsError: When one bound is a row index and the
+                other a date.
         """
-        if "date" in self.prices.columns:
-            cond = self._date_range_mask(start, end)
+        mode, lower, upper = resolve_bounds(start, end, temporal="date" in self.prices.columns)
+
+        if mode == "dates":
+            cond = self._date_range_mask(lower, upper)
             pr = self.prices.filter(cond)
             cp = self.cashposition.filter(cond)
         else:
-            offset, length = self._row_slice_bounds(start, end, self.prices.height)
+            # "none" resolves to a full-width slice, so it needs no separate branch.
+            # The casts record what resolve_bounds guarantees for these modes but
+            # cannot express in its return type.
+            offset, length = self._row_slice_bounds(
+                cast("int | None", lower), cast("int | None", upper), self.prices.height
+            )
             pr = self.prices.slice(offset, length)
             cp = self.cashposition.slice(offset, length)
         return self._rebuild(prices=pr, cash_position=cp)

--- a/src/jquantstats/_truncate.py
+++ b/src/jquantstats/_truncate.py
@@ -1,0 +1,122 @@
+"""Shared bound resolution for `Data.truncate` and `Portfolio.truncate`.
+
+Both entry points accept the same bound types and must agree on what they mean,
+so the classification lives here rather than being written twice.
+
+The rule is: **the bound type picks the axis, the index type says what is
+legal.** An ``int`` bound is a 0-based row index, a ``date``/``datetime``/ISO-8601
+string is a position on the temporal axis, and the two cannot be mixed. An
+object with an integer index accepts row indices only.
+
+Routing on the bound rather than on the index dtype is what makes an ``int``
+bound meaningful on dated data: the previous behaviour compared the row number
+against the date column, which Polars evaluated to an all-true mask, so
+``truncate(start=10)`` silently returned every row.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Literal
+
+from .exceptions import IntegerIndexBoundError, InvalidTruncateBoundError, MixedTruncateBoundsError
+
+#: What the resolved bounds address: nothing, row indices, or the temporal axis.
+Mode = Literal["none", "rows", "dates"]
+
+
+def _parse_iso(param: str, value: str) -> date | datetime:
+    """Parse an ISO-8601 date or datetime string.
+
+    Args:
+        param: Name of the parameter being parsed, for the error message.
+        value: The candidate string.
+
+    Returns:
+        A `datetime.date` for a plain date, a `datetime.datetime` when the
+        string carries a time component.
+
+    Raises:
+        InvalidTruncateBoundError: If *value* is not ISO-8601.
+    """
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        pass
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        raise InvalidTruncateBoundError(param, value) from None
+
+
+def _classify(param: str, value: Any) -> tuple[Mode, Any]:
+    """Classify one bound and coerce it to the form the comparison needs.
+
+    ``bool`` is rejected rather than accepted as an ``int``: ``truncate(start=True)``
+    is far more likely to be a mistake than a request for row 1.
+
+    Args:
+        param: Name of the parameter, for the error message.
+        value: The supplied bound.
+
+    Returns:
+        A ``(mode, coerced)`` pair; mode is ``"none"`` when *value* is ``None``.
+
+    Raises:
+        InvalidTruncateBoundError: If *value* is of an unsupported type, or is a
+            string that is not ISO-8601.
+    """
+    if value is None:
+        return "none", None
+    if isinstance(value, bool):
+        raise InvalidTruncateBoundError(param, value)
+    if isinstance(value, int):
+        return "rows", value
+    if isinstance(value, (date, datetime)):
+        return "dates", value
+    if isinstance(value, str):
+        return "dates", _parse_iso(param, value)
+    raise InvalidTruncateBoundError(param, value)
+
+
+def resolve_bounds(start: Any, end: Any, *, temporal: bool) -> tuple[Mode, Any, Any]:
+    """Decide which axis *start* and *end* address, and coerce them for it.
+
+    Args:
+        start: Inclusive lower bound, or ``None``.
+        end: Inclusive upper bound, or ``None``.
+        temporal: Whether the object has a temporal index.  When ``False`` the
+            only legal bound is an ``int`` row index.
+
+    Returns:
+        ``(mode, start, end)``.  ``mode`` is ``"none"`` when both bounds are
+        ``None`` (the caller should return the object unchanged), ``"rows"`` for
+        positional slicing, or ``"dates"`` for a comparison against the date
+        column.  The returned bounds are coerced — ISO strings become
+        `datetime.date` or `datetime.datetime` values.
+
+    Raises:
+        IntegerIndexBoundError: If the index is not temporal and a bound is not
+            an ``int``.
+        InvalidTruncateBoundError: If a bound is of an unsupported type, or is a
+            string that is not ISO-8601.
+        MixedTruncateBoundsError: If one bound is a row index and the other a date.
+    """
+    if not temporal:
+        # Integer index: a row number is the only thing a bound can mean, so any
+        # other type is reported against that expectation.
+        for param, value in (("start", start), ("end", end)):
+            if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
+                raise IntegerIndexBoundError(param, type(value).__name__)
+        return ("none" if start is None and end is None else "rows"), start, end
+
+    start_mode, start_value = _classify("start", start)
+    end_mode, end_value = _classify("end", end)
+
+    if start_mode == "rows" and end_mode == "dates":
+        raise MixedTruncateBoundsError("start", "end")
+    if start_mode == "dates" and end_mode == "rows":
+        raise MixedTruncateBoundsError("end", "start")
+
+    mode: Mode = start_mode if start_mode != "none" else end_mode
+    return mode, start_value, end_value

--- a/src/jquantstats/exceptions.py
+++ b/src/jquantstats/exceptions.py
@@ -160,6 +160,61 @@ class IntegerIndexBoundError(JQuantStatsError, TypeError):
         self.actual_type = actual_type
 
 
+class InvalidTruncateBoundError(JQuantStatsError, ValueError):
+    """Raised when a truncation bound is neither a row index nor a usable date.
+
+    Covers a value of an unsupported type (a float, a bool) and a string that
+    is not ISO-8601, both on an object that *has* a temporal index.  An
+    integer-indexed object raises `IntegerIndexBoundError` instead, since there
+    the only legal bound is a row index.
+
+    Args:
+        param: Name of the offending parameter (e.g. ``"start"`` or ``"end"``).
+        value: The value that was supplied.
+
+    Examples:
+        >>> raise InvalidTruncateBoundError("start", "last tuesday")
+        Traceback (most recent call last):
+            ...
+        jquantstats.exceptions.InvalidTruncateBoundError: start must be an int row index, a date/datetime, \
+or an ISO-8601 string; got 'last tuesday'.
+    """
+
+    def __init__(self, param: str, value: Any) -> None:
+        """Initialize with the parameter name and the offending value."""
+        super().__init__(f"{param} must be an int row index, a date/datetime, or an ISO-8601 string; got {value!r}.")
+        self.param = param
+        self.value = value
+
+
+class MixedTruncateBoundsError(JQuantStatsError, TypeError):
+    """Raised when ``start`` and ``end`` mix a row index with a date.
+
+    The two describe different axes, so honouring one and ignoring the other
+    would silently truncate to a range the caller never asked for.
+
+    Args:
+        row_param: Name of the parameter given as a row index.
+        date_param: Name of the parameter given as a date.
+
+    Examples:
+        >>> raise MixedTruncateBoundsError("start", "end")
+        Traceback (most recent call last):
+            ...
+        jquantstats.exceptions.MixedTruncateBoundsError: start and end must both be row indices or both be \
+dates; got start as a row index and end as a date.
+    """
+
+    def __init__(self, row_param: str, date_param: str) -> None:
+        """Initialize with the row-index and date parameter names."""
+        super().__init__(
+            f"start and end must both be row indices or both be dates; "
+            f"got {row_param} as a row index and {date_param} as a date."
+        )
+        self.row_param = row_param
+        self.date_param = date_param
+
+
 class PositionExprColumnError(JQuantStatsError, ValueError):
     """Raised when a position expression creates columns that do not exist in prices.
 

--- a/tests/test_jquantstats/test_truncate.py
+++ b/tests/test_jquantstats/test_truncate.py
@@ -1,0 +1,225 @@
+"""Tests for the shared ``truncate`` bound contract (issues #926, #927).
+
+`Data.truncate` and `Portfolio.truncate` route through the same resolver, so the
+contract is tested once against both. The rule under test: **the bound type picks
+the axis, the index type says what is legal.**
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+import polars as pl
+import pytest
+
+from jquantstats import Data, Portfolio
+from jquantstats._truncate import resolve_bounds
+from jquantstats.exceptions import (
+    IntegerIndexBoundError,
+    InvalidTruncateBoundError,
+    JQuantStatsError,
+    MixedTruncateBoundsError,
+)
+
+N = 80
+START = date(2020, 1, 1)
+DATES = [START + timedelta(days=i) for i in range(N)]
+
+# The 11th row, so a date bound and the row index 10 select the same rows.
+ROW_10_DATE = START + timedelta(days=10)
+
+
+def _prices(dated: bool = True) -> pl.DataFrame:
+    """Build a one-asset price frame, with or without a date column."""
+    cols: dict[str, object] = {"A": pl.Series([100.0 + i for i in range(N)], dtype=pl.Float64)}
+    return pl.DataFrame({"date": DATES, **cols} if dated else cols)
+
+
+def _cash(dated: bool = True) -> pl.DataFrame:
+    """Build a one-asset cash-position frame, with or without a date column."""
+    cols: dict[str, object] = {"A": pl.Series([1000.0] * N, dtype=pl.Float64)}
+    return pl.DataFrame({"date": DATES, **cols} if dated else cols)
+
+
+@pytest.fixture
+def dated_pf() -> Portfolio:
+    """An 80-row Portfolio with a temporal date column."""
+    return Portfolio.from_cash_position(prices=_prices(), cash_position=_cash(), aum=1e6)
+
+
+@pytest.fixture
+def int_pf() -> Portfolio:
+    """An 80-row Portfolio with no date column."""
+    return Portfolio.from_cash_position(prices=_prices(dated=False), cash_position=_cash(dated=False), aum=1e6)
+
+
+@pytest.fixture
+def dated_data() -> Data:
+    """An 80-row Data with a temporal index."""
+    return Data.from_returns(pl.DataFrame({"Date": DATES, "R": pl.Series([0.001] * N, dtype=pl.Float64)}))
+
+
+@pytest.fixture
+def int_data() -> Data:
+    """An 80-row Data with an integer index."""
+    return Data.from_returns(pl.DataFrame({"Date": list(range(N)), "R": pl.Series([0.001] * N, dtype=pl.Float64)}))
+
+
+# ─── #926: string bounds are parsed ───────────────────────────────────────────
+# The signature advertised `str` but `pl.lit` wrapped it unparsed, so Polars
+# refused to compare Utf8 against a temporal column.
+
+
+@pytest.mark.parametrize("bound", ["2020-01-11", "2020-01-11T00:00:00"])
+def test_iso_string_start_matches_the_equivalent_date(dated_pf, dated_data, bound):
+    """An ISO-8601 string selects exactly what the equivalent date object selects."""
+    assert dated_pf.truncate(start=bound).prices.height == dated_pf.truncate(start=ROW_10_DATE).prices.height == 70
+    assert dated_data.truncate(start=bound).returns.height == 70
+
+
+def test_iso_string_end_and_both_bounds(dated_pf):
+    """String bounds work as an upper bound and as a closed range."""
+    assert dated_pf.truncate(end="2020-01-10").prices.height == 10
+    assert dated_pf.truncate(start="2020-01-11", end="2020-01-20").prices.height == 10
+
+
+def test_unparseable_string_raises_a_typed_error(dated_pf, dated_data):
+    """A non-ISO string is reported by the library, not by Polars."""
+    with pytest.raises(InvalidTruncateBoundError, match="ISO-8601"):
+        dated_pf.truncate(start="last tuesday")
+    with pytest.raises(InvalidTruncateBoundError, match="ISO-8601"):
+        dated_data.truncate(end="not a date")
+
+
+# ─── #927: integer bounds slice positionally on a temporal axis ───────────────
+# Routing used to be on index dtype, so an int bound was compared against the
+# date column, produced an all-true mask, and truncated nothing.
+
+
+def test_integer_bound_slices_a_dated_object(dated_pf, dated_data):
+    """An int bound is a row index even when the index is temporal."""
+    assert dated_pf.truncate(start=10).prices.height == 70
+    assert dated_data.truncate(start=10).returns.height == 70
+
+
+def test_integer_bounds_agree_with_the_equivalent_dates(dated_pf):
+    """Row 10 and the date on row 10 select the same rows — the old bug's tell."""
+    by_row = dated_pf.truncate(start=10)
+    by_date = dated_pf.truncate(start=ROW_10_DATE)
+    assert by_row.prices.equals(by_date.prices)
+
+
+def test_integer_range_and_end_only(dated_pf):
+    """Row indices are inclusive on both ends."""
+    assert dated_pf.truncate(start=10, end=19).prices.height == 10
+    assert dated_pf.truncate(end=9).prices.height == 10
+
+
+def test_inverted_integer_range_is_empty_not_negative(dated_pf):
+    """An inverted range clamps to an empty frame rather than a negative slice."""
+    assert dated_pf.truncate(start=50, end=10).prices.height == 0
+
+
+# ─── Mixing the two axes is rejected ──────────────────────────────────────────
+# Previously the int was ignored and the date silently applied, so the caller got
+# a range they never asked for.
+
+
+def test_mixed_bounds_raise(dated_pf, dated_data):
+    """A row index paired with a date names two different axes."""
+    with pytest.raises(MixedTruncateBoundsError, match="start as a row index and end as a date"):
+        dated_pf.truncate(start=10, end=ROW_10_DATE)
+    with pytest.raises(MixedTruncateBoundsError, match="end as a row index and start as a date"):
+        dated_data.truncate(start=ROW_10_DATE, end=20)
+
+
+# ─── Unsupported bound types ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("bound", [3.5, object(), (1, 2)])
+def test_unsupported_type_on_a_temporal_axis_raises(dated_pf, bound):
+    """A value that is neither a row index nor a date is refused."""
+    with pytest.raises(InvalidTruncateBoundError):
+        dated_pf.truncate(start=bound)
+
+
+def test_bool_is_not_accepted_as_a_row_index(dated_pf, int_pf):
+    """``bool`` subclasses ``int``, so it would otherwise mean row 1 silently."""
+    with pytest.raises(InvalidTruncateBoundError):
+        dated_pf.truncate(start=True)
+    with pytest.raises(IntegerIndexBoundError, match="got bool"):
+        int_pf.truncate(start=True)
+
+
+# ─── Preserved: an integer-indexed object accepts row indices only ────────────
+
+
+def test_integer_indexed_rejects_non_integer_bounds(int_pf, int_data):
+    """Unchanged behaviour, including the message, for a non-temporal index."""
+    with pytest.raises(IntegerIndexBoundError, match="start must be an integer, got str"):
+        int_pf.truncate(start="2020-01-01")
+    with pytest.raises(IntegerIndexBoundError, match="end must be an integer, got float"):
+        int_pf.truncate(end=3.5)
+    with pytest.raises(IntegerIndexBoundError, match="start must be an integer, got date"):
+        int_data.truncate(start=START)
+
+
+def test_integer_indexed_slices_and_passes_through(int_pf):
+    """Row bounds and no bounds both behave as before on an integer index."""
+    assert int_pf.truncate(start=10).prices.height == 70
+    assert int_pf.truncate(start=10, end=19).prices.height == 10
+    assert int_pf.truncate().prices.height == N
+
+
+# ─── Unchanged behaviour on the date axis ─────────────────────────────────────
+
+
+def test_date_bounds_and_no_bounds(dated_pf, dated_data):
+    """Date objects and the no-bound case are untouched by the new routing."""
+    assert dated_pf.truncate().prices.height == N
+    assert dated_data.truncate().returns.height == N
+    assert dated_pf.truncate(start=START, end=START + timedelta(days=9)).prices.height == 10
+    assert dated_pf.truncate(start=datetime(2020, 1, 11)).prices.height == 70
+
+
+def test_truncate_preserves_aum_and_benchmark(dated_pf, dated_data):
+    """Truncation carries construction state across, as it always did."""
+    assert dated_pf.truncate(start=10).aum == dated_pf.aum
+    assert dated_data.truncate(start=10).benchmark is None
+
+
+# ─── The resolver in isolation ────────────────────────────────────────────────
+
+
+def test_resolve_bounds_reports_the_mode():
+    """The resolver names the axis it chose and coerces string bounds."""
+    assert resolve_bounds(None, None, temporal=True) == ("none", None, None)
+    assert resolve_bounds(None, None, temporal=False) == ("none", None, None)
+    assert resolve_bounds(5, None, temporal=True) == ("rows", 5, None)
+    assert resolve_bounds(None, 5, temporal=True) == ("rows", None, 5)
+    assert resolve_bounds("2020-01-11", None, temporal=True) == ("dates", date(2020, 1, 11), None)
+    assert resolve_bounds(None, "2020-01-11T06:30:00", temporal=True) == (
+        "dates",
+        None,
+        datetime(2020, 1, 11, 6, 30),
+    )
+
+
+def test_new_exceptions_are_part_of_the_domain_family():
+    """Both new errors are catchable via ``except JQuantStatsError``."""
+    assert issubclass(InvalidTruncateBoundError, JQuantStatsError)
+    assert issubclass(MixedTruncateBoundsError, JQuantStatsError)
+    # And keep their builtin flavours, so existing ``except ValueError`` still works.
+    assert issubclass(InvalidTruncateBoundError, ValueError)
+    assert issubclass(MixedTruncateBoundsError, TypeError)
+
+
+def test_exception_payloads_are_introspectable():
+    """The errors carry the offending parameter and value for programmatic use."""
+    err = InvalidTruncateBoundError("start", "last tuesday")
+    assert err.param == "start"
+    assert err.value == "last tuesday"
+
+    mixed = MixedTruncateBoundsError("start", "end")
+    assert mixed.row_param == "start"
+    assert mixed.date_param == "end"


### PR DESCRIPTION
Closes #926. Closes #927.

## One root cause, three symptoms

`Data.truncate` and `Portfolio.truncate` both routed on the **index dtype**: a
temporal index always took the comparison branch, an integer index always took
the row-slicing branch. The bound's own type was never consulted. Everything
below follows from that:

| Call on 80 rows of dated data | Before | After |
|---|---|---|
| `truncate(start="2020-01-11")` | `InvalidOperationError` | 70 |
| `truncate(start=10)` | **80** (silent no-op) | 70 |
| `truncate(start=10, end=<date>)` | **21** (half-applied) | raises |
| `truncate(start=<date>)` | 70 | 70 |

- **#926** — the signature has advertised `str` since it was written, but
  `_truncate_temporal` did `pl.lit(start)` with no parsing, so Polars refused to
  compare Utf8 against a temporal column and a raw `InvalidOperationError`
  escaped.
- **#927** — `pl.col("date") >= pl.lit(10)` evaluates happily and yields an
  all-true mask, so an int bound truncated nothing.
- **Not previously reported, and the worst of the three:** mixed bounds
  truncated to a range nobody asked for. With `start=10, end=<date>` the int was
  dropped and the date applied, returning 21 rows. Unlike the other two this
  produces a plausible frame, so there is nothing to notice.

## The rule

**The bound type picks the axis; the index dtype says what is legal.** An `int`
is a 0-based row index, a `date`/`datetime`/ISO-8601 string is a position on the
temporal axis, and the two cannot be combined in one call.

Row indices now work on dated data — `truncate(start=10)` drops the first ten
rows, which is what the signature always promised and a reasonable thing to want
for cutting a warm-up window. An integer-indexed object still accepts row
indices only, with its existing `IntegerIndexBoundError` and message unchanged.

I went with honouring `int` rather than rejecting it (#927 offered both) because
it matches the declared signature and the documented "non-negative `int` row
index" wording, and because rejecting it would leave dated portfolios with no way
to slice positionally at all.

## Shared, not duplicated

The classification lives in a new `_truncate.py` rather than being written twice.
That is the actual lesson here: `Data` and `Portfolio` each had their own copy of
the routing *and* their own row-bound helper (`_resolve_row_bound`,
`_row_slice_bounds`), which is how two bugs survived in both places at once. Both
helpers now only substitute open-ended defaults — validation happens once, in one
place, for both classes.

Two extras that fell out of doing it properly:

- **`bool` is rejected.** `isinstance(True, int)` is `True`, so `truncate(start=True)`
  would silently have meant row 1. On a temporal axis it previously escaped as a
  Polars `SchemaError`.
- **An unparseable string** is now `InvalidTruncateBoundError`, not a Polars error.

## New exceptions

Both under `JQuantStatsError`, so `except JQuantStatsError` still catches the
whole family, and both keep a builtin flavour so existing `except ValueError` /
`except TypeError` handlers are unaffected:

- `InvalidTruncateBoundError(ValueError)` — unsupported type, or a non-ISO string.
- `MixedTruncateBoundsError(TypeError)` — a row index paired with a date.

## Tests

New `tests/test_jquantstats/test_truncate.py` — 20 tests, run against **both**
`Data` and `Portfolio`, since the contract is now shared. The load-bearing one
asserts that `truncate(start=10)` and `truncate(start=<date on row 10>)` return
*equal frames*: that equality is exactly what was false before, and it fails if
either mode regresses.

Also covers: ISO date and datetime strings, unparseable strings, integer ranges,
inverted ranges clamping to empty, mixed bounds in both orders, unsupported
types, `bool`, and the unchanged integer-index behaviour including its exact
error messages.

## Gates

`make fmt`, `make test` (1283 passed, `src/` 100% coverage, import contracts
kept), `make typecheck` (ty + mypy strict), `make docs-coverage` (100%),
`make deps`, `make security`, `make book` — all clean. The 1263 pre-existing
tests pass untouched, including the two that pin `IntegerIndexBoundError`.

## Merge-order note

PR #924 adds `test_integer_truncate_bound_is_a_library_noop`, which deliberately
pins the #927 behaviour this PR removes — its docstring says it should be updated
"so a future fix is visible here". If #924 merges first, that test must be
inverted before or with this PR; if this merges first, #924 needs the same edit
before merging. Either way it is a two-line change, but it will break `main` if
both land untouched. Happy to make the edit on whichever branch you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
