### PR TITLE
feat(portfolio): add the share-count view — units, trades, weights

### DIFF
--- a/src/jquantstats/_portfolio_units.py
+++ b/src/jquantstats/_portfolio_units.py
@@ -1,0 +1,177 @@
+"""Units, trades and weights mixin for Portfolio.
+
+`Portfolio` stores *cash* positions, because every analytic downstream of it —
+NAV, returns, turnover, cost — is denominated in currency. The share-count view
+is the other half of the same picture, and a simulator that decides *how many
+units to hold* needs it back: how many units are held, how many changed hands
+between two rows, and what fraction of NAV each position represents.
+
+Everything here is **derived**, never stored. ``units`` is ``cashposition /
+prices``, so the whole surface is available on a portfolio built through any
+constructor — `from_cash_position`, `from_position`, or `from_risk_position` —
+rather than only on one that happened to be handed units to begin with.
+
+Trades are deliberately computed in *units*, not as a difference of cash
+positions. A cash position moves when the price moves, with no trade taking
+place at all, so ``cashposition.diff()`` would report phantom turnover on a
+buy-and-hold book. The difference is taken on the share count and only then
+converted back to currency at the traded price.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from ._portfolio_base import _PortfolioMembers
+
+
+class PortfolioUnitsMixin(_PortfolioMembers):
+    """Mixin providing the share-count view of a Portfolio: units, trades, weights."""
+
+    def _numeric_frame(self, values: pl.DataFrame) -> pl.DataFrame:
+        """Return *values* carrying the date column, if the portfolio has one.
+
+        The mixin's properties all build a frame of per-asset numbers and then
+        need the same date column re-attached. Centralising it keeps every
+        property returning a frame shaped like ``cashposition``.
+
+        Args:
+            values: Frame of per-asset columns, without a date column.
+
+        Returns:
+            *values* with the portfolio's ``'date'`` column prepended when one
+            exists, otherwise *values* unchanged.
+        """
+        if "date" not in self.prices.columns:
+            return values
+        return values.insert_column(0, self.prices["date"])
+
+    @property
+    def units(self) -> pl.DataFrame:
+        """Number of units held per asset over time.
+
+        Derived as ``cashposition / prices``. A zero price yields a null rather
+        than an infinity, so a delisted or not-yet-listed asset does not poison
+        the trade and weight frames built on top of this one.
+
+        Returns:
+            pl.DataFrame: Units per asset, with the ``'date'`` column when the
+            portfolio has one.
+
+        Examples:
+            >>> import polars as pl
+            >>> from jquantstats.portfolio import Portfolio
+            >>> prices = pl.DataFrame({"A": [100.0, 110.0, 105.0]})
+            >>> pos = pl.DataFrame({"A": [1000.0, 1100.0, 1050.0]})
+            >>> pf = Portfolio(prices=prices, cashposition=pos, aum=1e6)
+            >>> pf.units["A"].to_list()
+            [10.0, 10.0, 10.0]
+        """
+        values = pl.select(
+            pl.when(self.prices[asset] != 0.0)
+            .then(self.cashposition[asset] / self.prices[asset])
+            .otherwise(None)
+            .alias(asset)
+            for asset in self.assets
+        )
+        return self._numeric_frame(values)
+
+    @property
+    def equity(self) -> pl.DataFrame:
+        """Cash value of each position over time.
+
+        An alias for ``cashposition``, kept because "equity" is the term the
+        simulator vocabulary uses for the same quantity. Not to be confused with
+        the equity asset class.
+
+        Returns:
+            pl.DataFrame: The portfolio's cash positions, unchanged.
+        """
+        return self.cashposition
+
+    @property
+    def trades_units(self) -> pl.DataFrame:
+        """Units bought (positive) or sold (negative) at each step.
+
+        The first row is the opening position: there is no prior row to
+        difference against, and treating it as zero would hide the initial
+        trade that established the book.
+
+        Returns:
+            pl.DataFrame: Unit trades per asset, with the ``'date'`` column when
+            the portfolio has one.
+
+        Examples:
+            >>> import polars as pl
+            >>> from jquantstats.portfolio import Portfolio
+            >>> prices = pl.DataFrame({"A": [100.0, 100.0, 100.0]})
+            >>> pos = pl.DataFrame({"A": [1000.0, 1500.0, 500.0]})
+            >>> pf = Portfolio(prices=prices, cashposition=pos, aum=1e6)
+            >>> pf.trades_units["A"].to_list()
+            [10.0, 5.0, -10.0]
+        """
+        units = self.units
+
+        def _trades(asset: str) -> pl.Series:
+            """Differences of *asset*'s unit series, seeded with the opening position."""
+            held = units[asset].fill_null(0.0)
+            # `diff` leaves exactly one null, at row 0; filling it with the
+            # opening position records the trade that established the book.
+            return held.diff().fill_null(held[0]) if held.len() else held
+
+        values = pl.select(_trades(asset).alias(asset) for asset in self.assets)
+        return self._numeric_frame(values)
+
+    @property
+    def trades_currency(self) -> pl.DataFrame:
+        """Cash value of the trades at each step, priced at the traded row.
+
+        Computed as ``trades_units * prices`` rather than as a difference of
+        cash positions, so a price move on an untraded book reports zero rather
+        than phantom turnover.
+
+        Returns:
+            pl.DataFrame: Currency trades per asset, with the ``'date'`` column
+            when the portfolio has one. Positive values are buys (cash out),
+            negative values are sells (cash in).
+
+        Examples:
+            >>> import polars as pl
+            >>> from jquantstats.portfolio import Portfolio
+            >>> prices = pl.DataFrame({"A": [100.0, 200.0]})
+            >>> pos = pl.DataFrame({"A": [1000.0, 2000.0]})
+            >>> pf = Portfolio(prices=prices, cashposition=pos, aum=1e6)
+            >>> pf.trades_currency["A"].to_list()
+            [1000.0, 0.0]
+        """
+        trades = self.trades_units
+        values = pl.select((trades[asset] * self.prices[asset]).alias(asset) for asset in self.assets)
+        return self._numeric_frame(values)
+
+    @property
+    def weights(self) -> pl.DataFrame:
+        """Fraction of NAV held in each asset over time.
+
+        Each cash position divided by the accumulated NAV of the same row. For a
+        fully invested, unlevered book the weights sum to 1.0; short positions
+        are negative.
+
+        Returns:
+            pl.DataFrame: Weights per asset, with the ``'date'`` column when the
+            portfolio has one.
+
+        Examples:
+            >>> import polars as pl
+            >>> from jquantstats.portfolio import Portfolio
+            >>> prices = pl.DataFrame({"A": [100.0, 100.0]})
+            >>> pos = pl.DataFrame({"A": [100.0, 100.0]})
+            >>> pf = Portfolio(prices=prices, cashposition=pos, aum=1000.0)
+            >>> pf.weights["A"].to_list()
+            [0.1, 0.1]
+        """
+        nav = self.nav_accumulated["NAV_accumulated"]
+        values = pl.select(
+            pl.when(nav != 0.0).then(self.cashposition[asset] / nav).otherwise(None).alias(asset)
+            for asset in self.assets
+        )
+        return self._numeric_frame(values)

--- a/src/jquantstats/portfolio.py
+++ b/src/jquantstats/portfolio.py
@@ -41,6 +41,7 @@ from ._portfolio_cost import PortfolioCostMixin
 from ._portfolio_nav import PortfolioNavMixin
 from ._portfolio_transform import PortfolioTransformMixin
 from ._portfolio_turnover import PortfolioTurnoverMixin
+from ._portfolio_units import PortfolioUnitsMixin
 from ._reports import Report
 from ._stats import Stats as Stats
 from ._utils import PortfolioUtils as PortfolioUtils
@@ -111,6 +112,7 @@ class Portfolio(
     PortfolioTurnoverMixin,
     PortfolioCostMixin,
     PortfolioTransformMixin,
+    PortfolioUnitsMixin,
     PortfolioConstructorMixin,
 ):
     """Portfolio analytics class for quant finance.
@@ -137,6 +139,9 @@ class Portfolio(
     - Attribution: `tilt`, `timing`, `tilt_timing_decomp`
     - Turnover: `turnover`, `turnover_weekly`,
       `turnover_summary`
+    - Share-count view: `units`, `equity`, `trades_units`,
+      `trades_currency`, `weights` — all derived from cash positions and
+      prices, so they are available however the portfolio was constructed
     - Cost analysis: `cost_adjusted_returns`,
       `trading_cost_impact`, `deduct_management_fee`
     - Utility: `correlation`

--- a/tests/test_jquantstats/test_portfolio/test_units.py
+++ b/tests/test_jquantstats/test_portfolio/test_units.py
@@ -1,0 +1,158 @@
+"""Tests for the share-count view: units, trades, weights.
+
+The numbers here are chosen so every expectation is exact in binary floating
+point — prices are powers-of-ten multiples and positions are round — so a
+failure means the arithmetic changed, not that a tolerance drifted.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+from jquantstats import Portfolio
+
+_AUM: float = 10_000.0
+
+
+@pytest.fixture
+def units_portfolio():
+    """Three-day, one-asset portfolio with a buy, a hold and a partial sell.
+
+    Prices 100 → 110 → 105 against cash positions 1000 → 1100 → 525, i.e. a
+    constant 10 units for two days and then a sale down to 5.
+    """
+    dates = pl.date_range(start=date(2020, 1, 1), end=date(2020, 1, 3), interval="1d", eager=True).cast(pl.Date)
+    return Portfolio(
+        prices=pl.DataFrame({"date": dates, "A": pl.Series([100.0, 110.0, 105.0])}),
+        cashposition=pl.DataFrame({"date": dates, "A": pl.Series([1000.0, 1100.0, 525.0])}),
+        aum=_AUM,
+    )
+
+
+def test_units_divides_cash_by_price(units_portfolio) -> None:
+    """``units`` is cashposition / prices, per asset."""
+    assert units_portfolio.units["A"].to_list() == [10.0, 10.0, 5.0]
+
+
+def test_units_keeps_the_date_column(units_portfolio) -> None:
+    """The date axis rides along, so the frame lines up with cashposition."""
+    assert units_portfolio.units.columns == ["date", "A"]
+
+
+def test_units_on_a_date_free_portfolio(int_portfolio) -> None:
+    """An integer-indexed portfolio yields asset columns only."""
+    assert int_portfolio.units.columns == ["A", "B"]
+    assert int_portfolio.units.height == int_portfolio.prices.height
+
+
+def test_units_maps_a_zero_price_to_null() -> None:
+    """A zero price yields null rather than an infinity."""
+    pf = Portfolio(
+        prices=pl.DataFrame({"A": pl.Series([100.0, 0.0])}),
+        cashposition=pl.DataFrame({"A": pl.Series([1000.0, 500.0])}),
+        aum=_AUM,
+    )
+    assert pf.units["A"].to_list() == [10.0, None]
+
+
+def test_equity_is_the_cash_position(units_portfolio) -> None:
+    """``equity`` is an alias, not a copy with different numbers."""
+    assert units_portfolio.equity.equals(units_portfolio.cashposition)
+
+
+def test_trades_units_seeds_row_zero_with_the_opening_position(units_portfolio) -> None:
+    """Row 0 is the opening trade; later rows are differences of the unit count."""
+    assert units_portfolio.trades_units["A"].to_list() == [10.0, 0.0, -5.0]
+
+
+def test_trades_units_keeps_the_date_column(units_portfolio) -> None:
+    """The date axis rides along here too."""
+    assert units_portfolio.trades_units.columns == ["date", "A"]
+
+
+def test_trades_currency_prices_the_unit_trades(units_portfolio) -> None:
+    """Currency trades are unit trades at that row's price."""
+    assert units_portfolio.trades_currency["A"].to_list() == [1000.0, 0.0, -525.0]
+
+
+def test_trades_ignore_price_moves_on_an_untraded_book() -> None:
+    """A price move with no trade reports zero, not phantom turnover.
+
+    This is the reason trades are differenced in units rather than in cash: the
+    cash position doubles here purely because the price doubles.
+    """
+    pf = Portfolio(
+        prices=pl.DataFrame({"A": pl.Series([100.0, 200.0])}),
+        cashposition=pl.DataFrame({"A": pl.Series([1000.0, 2000.0])}),
+        aum=_AUM,
+    )
+    assert pf.trades_units["A"].to_list() == [10.0, 0.0]
+    assert pf.trades_currency["A"].to_list() == [1000.0, 0.0]
+
+
+def test_weights_divide_the_cash_position_by_nav() -> None:
+    """Weights are the fraction of accumulated NAV held in each asset."""
+    pf = Portfolio(
+        prices=pl.DataFrame({"A": pl.Series([100.0, 100.0])}),
+        cashposition=pl.DataFrame({"A": pl.Series([100.0, 100.0])}),
+        aum=1000.0,
+    )
+    assert pf.weights["A"].to_list() == [0.1, 0.1]
+
+
+def test_weights_map_a_zero_nav_to_null() -> None:
+    """A NAV that reaches exactly zero yields null rather than an infinity.
+
+    The asset halves, and the position is sized so the loss consumes the whole
+    of AUM on the second row.
+    """
+    pf = Portfolio(
+        prices=pl.DataFrame({"A": pl.Series([100.0, 50.0])}),
+        cashposition=pl.DataFrame({"A": pl.Series([2000.0, 1000.0])}),
+        aum=1000.0,
+    )
+    assert pf.nav_accumulated["NAV_accumulated"].to_list() == [1000.0, 0.0]
+    assert pf.weights["A"].to_list() == [2.0, None]
+
+
+def test_weights_keep_the_date_column(units_portfolio) -> None:
+    """The date axis rides along for weights as well."""
+    assert units_portfolio.weights.columns == ["date", "A"]
+
+
+def test_units_survive_an_empty_portfolio() -> None:
+    """A zero-row portfolio yields zero-row frames rather than an index error."""
+    pf = Portfolio(
+        prices=pl.DataFrame({"A": pl.Series([], dtype=pl.Float64)}),
+        cashposition=pl.DataFrame({"A": pl.Series([], dtype=pl.Float64)}),
+        aum=_AUM,
+    )
+    assert pf.units.height == 0
+    assert pf.trades_units.height == 0
+    assert pf.trades_currency.height == 0
+
+
+def test_from_position_round_trips_through_units() -> None:
+    """Units handed to ``from_position`` come back out of ``units`` unchanged.
+
+    ``from_position`` converts units to cash on the way in; ``units`` converts
+    back on the way out. The two must be inverses, which is what lets a
+    unit-based simulator hand its positions over and read them back.
+    """
+    prices = pl.DataFrame({"A": pl.Series([100.0, 110.0, 105.0])})
+    positions = pl.DataFrame({"A": pl.Series([10.0, 10.0, 5.0])})
+    pf = Portfolio.from_position(prices=prices, position=positions, aum=_AUM)
+    assert pf.units["A"].to_list() == [10.0, 10.0, 5.0]
+
+
+def test_multi_asset_units_and_trades(portfolio) -> None:
+    """The shared two-asset fixture resolves per asset, not just for one column."""
+    units = portfolio.units
+    assert units.columns == ["date", "A", "B"]
+    # B is bought on day 2: 0 units, then 500/180, then 500/198.
+    assert units["B"][0] == 0.0
+    assert portfolio.trades_units["B"][0] == 0.0
+    assert portfolio.trades_units["B"][1] > 0.0


### PR DESCRIPTION
`Portfolio` stores **cash** positions, because every analytic downstream of it —
NAV, returns, turnover, cost — is denominated in currency. The share-count view is
the other half of the same picture, and a simulator that decides *how many units to
hold* needs it back.

## What this adds

`PortfolioUnitsMixin`, five derived properties:

| property | definition |
| --- | --- |
| `units` | `cashposition / prices` |
| `equity` | alias for `cashposition` |
| `trades_units` | difference of `units`, row 0 seeded with the opening position |
| `trades_currency` | `trades_units * prices` |
| `weights` | `cashposition / NAV_accumulated` |

Everything is **derived, never stored**, so the whole surface is available on a
portfolio built through *any* constructor — `from_cash_position`, `from_position` or
`from_risk_position` — not only one that happened to be handed units to begin with.

`from_position` already accepts unit positions, so **no new constructor was needed**;
`units` is simply its inverse on the way out, and a test pins the round-trip.

## Two design points worth reviewing

**Trades are differenced in units, not in cash.** A cash position moves when the
*price* moves, with no trade taking place at all, so `cashposition.diff()` would
report phantom turnover on a buy-and-hold book. A regression test pins it: a book
whose price doubles with no trade reports `0.0`, not `1000.0`.

**Division is guarded.** A zero price and a zero NAV both yield `null` rather than an
infinity, so a single delisted asset cannot poison the trade and weight frames built
on top of it.

## Why now

[`cvxgrp/simulator`](https://github.com/cvxgrp/simulator) carries its own pandas
`Portfolio`. Its analytics half now duplicates this package (it already depends on
jquantstats and delegates `stats`/`plots`/`reports` through a mixin), and the units
layer was the **one piece with no counterpart here**. Closing that gap is what lets
the duplicate be deleted rather than kept in sync.

Verified against it directly — identical prices and units through both libraries:

| quantity | agreement |
| --- | --- |
| `units`, `trades_units`, `trades_currency` | identical |
| `weights` | identical to 6 dp |
| NAV over a 40-row Builder simulation | **5.8e-10** max absolute difference |
| units round-trip through `from_position` | **0.0** max difference |

## Scope note

This PR deliberately does **not** add time-varying (`pl.Series`) AUM. I built it
first, believing simulator's Builder needed it, then measured: because simulator's
`state.py` does `aum += profit` with no external flows, its AUM series is exactly
`cumsum(profit) + initial_aum`, so passing the scalar `initial_aum` reproduces NAV
exactly (the 5.8e-10 above). It was not needed.

It is also actively hazardous to ship alongside the migration: simulator's `aum` *is*
its NAV, while this package's `aum` is a capital *base*. Passing the former as the
latter double-counts profit silently — measured at **+32,041.50** on a 1,000,000
book, precisely the accumulated profit. Series-AUM is a real capability (deposits and
withdrawals), but it deserves its own PR where the `aum`-vs-NAV naming clash gets
designed properly rather than riding in on a migration.

## Gates

`fmt`, `typecheck` (ty + `mypy --strict`, 64 files), `rhiza-test` and `test` all pass.
Coverage holds at **100%** — the new module is 33 statements and 2 branches, none
missed. Both import-linter architecture contracts kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
