### PR TITLE
fix(data): auto-detect the date column and canonicalise it to 'date'

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -82,6 +82,12 @@ returns_pl = pl.DataFrame({
 })
 ```
 
+The date column is found by type, not by name: whatever you call it — `Date`,
+`timestamp`, `dt` — the first temporal column is used, and the resulting object
+exposes it as `date` (`data.index["date"]`, `data.date_col == ["date"]`). Pass
+`date_col=` only to nominate a specific column, which is required for a
+non-temporal (e.g. integer) index since there is no temporal column to find.
+
 ### Benchmarks
 
 ```python
@@ -94,7 +100,6 @@ import jquantstats as jqs
 data = jqs.Data.from_returns(
     returns=returns_pl,
     benchmark=benchmark_pl,
-    date_col="Date",
 )
 data.stats.information_ratio()   # benchmark used automatically
 ```
@@ -113,7 +118,6 @@ import jquantstats as jqs
 data = jqs.Data.from_returns(
     returns=returns_pl,     # pl.DataFrame with date + return columns
     benchmark=benchmark_pl, # optional
-    date_col="Date",
 )
 
 data.stats.sharpe()
@@ -124,7 +128,7 @@ data.reports.metrics()
 You can also construct from prices:
 
 ```python
-data = jqs.Data.from_prices(prices=prices_pl, date_col="Date")
+data = jqs.Data.from_prices(prices=prices_pl)
 ```
 
 ### `Portfolio` — prices + positions (no QuantStats equivalent)

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -103,6 +103,13 @@ renamed or removed before 1.0.  The constructors (`Portfolio.from_position`,
 points.  Changes here would be disruptive enough that they are held for the
 1.0 boundary.
 
+**The date column.**  A temporal index is exposed as `date` on every object,
+whichever entry point built it, and `Data.date_col` reports that name.  This
+was settled in 0.11: before then `Data.from_returns` defaulted to `Date` while
+`Portfolio` canonicalised on `date`, so `index.columns[0]` was not a reliable
+thing to write against.  An index nominated with `date_col=` that is *not*
+temporal — an integer row index, say — keeps its own name.
+
 **What may still move.**  Individual metric methods on `Stats` may gain
 keyword arguments, change default values, or be renamed for consistency as
 the QuantStats-parity work settles; chart signatures on `Plots` may change

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -81,6 +81,25 @@ else.
 
 ## Questions
 
+### What must my date column be called?
+
+Anything — it is found by type, not by name. Each input frame's first temporal
+column becomes the date axis, so `Date`, `timestamp` and `dt` all work, and
+returns, benchmark and risk-free frames need not agree on a label.
+
+On the resulting object the column is always `date`, whichever route built it:
+
+```python
+data.index["date"]      # Data.from_returns / from_prices
+pf.data.index["date"]   # a Portfolio's Data bridge
+data.date_col           # ['date'] — the supported way to read the name
+```
+
+Pass `date_col="…"` to nominate a column explicitly. A date-free
+(integer-indexed) frame *requires* it — there is no temporal column to detect —
+and that index keeps its own name, since calling an integer axis `date` would
+be a lie.
+
 ### What is the difference between NaN and null?
 
 - **`null`** (Polars missing value) — "no observation". Rejected at

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -243,6 +243,27 @@ positions). This is the lighter-weight path and accepts pandas DataFrames too.
     data = Data.from_returns(returns=returns_pl)
     ```
 
+### The date column
+
+The date column is identified by **type, not by name**: the first temporal
+column of each input frame is used, whether it is called `Date`, `timestamp`,
+or anything else. Returns, benchmark and risk-free frames are resolved
+independently, so they need not agree on a label.
+
+Whatever it was called on the way in, the object exposes it as `date` — the
+same name the `Portfolio` internals use, so one reader works against both
+routes:
+
+```python
+data.index["date"]      # the date series
+data.date_col           # ['date'] — the supported way to read the name
+pf.data.date_col        # ['date'] — a Portfolio's Data agrees
+```
+
+Pass `date_col="…"` to nominate a column explicitly. That is required for a
+date-free (integer-indexed) frame, since there is no temporal column to find;
+such an index keeps its own name rather than being relabelled `date`.
+
 ### Stats
 
 ```python

--- a/plugin/skills/quantstats-migration/SKILL.md
+++ b/plugin/skills/quantstats-migration/SKILL.md
@@ -44,9 +44,12 @@ returns_pl = pl.from_pandas(returns_pd.rename("MyStrategy").reset_index())
 # → columns ["Date", "MyStrategy"]
 ```
 
-The first column is the date column (`date_col="Date"` by default). Every other
-column is an asset — multi-asset is native, so port a loop over series into a
-single wide frame and one call.
+The date column is auto-detected as the first temporal column, whatever it is
+called, and is exposed as `date` on the resulting object (`data.date_col ==
+["date"]`). Pass `date_col=` only to nominate a column explicitly — required
+for a date-free, integer-indexed frame. Every other column is an asset —
+multi-asset is native, so port a loop over series into a single wide frame and
+one call.
 
 **Nulls matter.** pandas drops `NaN` silently; Polars propagates `null`, so one
 missing value turns a whole metric into `null`. To reproduce QuantStats numbers,
@@ -68,7 +71,7 @@ series.
 ```python
 import jquantstats as jqs
 
-data = jqs.Data.from_returns(returns=returns_pl, rf=0.0, benchmark=benchmark_pl, date_col="Date")
+data = jqs.Data.from_returns(returns=returns_pl, rf=0.0, benchmark=benchmark_pl)
 data = jqs.Data.from_prices(prices=prices_pl)          # same kwargs
 ```
 

--- a/src/jquantstats/_utils/_construction.py
+++ b/src/jquantstats/_utils/_construction.py
@@ -26,6 +26,12 @@ __all__ = [
     "interpolate",
 ]
 
+#: The canonical name of the date column on every `Data` object, matching the
+#: name the `Portfolio` internals already enforce. Inputs are renamed to it once
+#: at construction so that ``data.index.columns[0]`` is the same string however
+#: the object was built.
+DATE_COLUMN = "date"
+
 
 def _to_polars(df: NativeFrame) -> pl.DataFrame:
     """Convert any narwhals-compatible DataFrame to a polars DataFrame."""
@@ -195,19 +201,42 @@ def _subtract_risk_free(dframe: pl.DataFrame, rf: float | pl.DataFrame, date_col
     )
 
 
-def _require_date_col(frames: list[tuple[str, pl.DataFrame | None]], date_col: str) -> None:
-    """Verify *date_col* is present in every supplied (non-None) frame.
+def _canonicalise_date_column(frame: pl.DataFrame, frame_name: str, date_col: str | None) -> tuple[pl.DataFrame, str]:
+    """Resolve *frame*'s date column and rename a temporal one to `DATE_COLUMN`.
+
+    When *date_col* is ``None`` the date column is auto-detected as the first
+    temporal column of *frame*, matching what `Portfolio` does at construction.
+    An explicit *date_col* is used verbatim and need not be temporal, so an
+    integer or string index column can still be nominated by name — such a
+    column keeps its own name, since calling an integer axis ``'date'`` would
+    be a lie.
 
     Args:
-        frames: ``(name, frame)`` pairs; ``None`` frames are skipped.
-        date_col: The required date column name.
+        frame: A returns, prices, benchmark or risk-free frame.
+        frame_name: Descriptive name used in the error message (e.g. ``"returns"``).
+        date_col: Name of the date column, or ``None`` to auto-detect it.
+
+    Returns:
+        tuple[pl.DataFrame, str]: The frame and the name its date column now
+        carries — ``'date'`` for a temporal axis, the nominated name otherwise.
 
     Raises:
-        MissingDateColumnError: If any frame lacks *date_col*, naming that frame.
+        MissingDateColumnError: If *date_col* is not a column of *frame*, or —
+            when auto-detecting — if *frame* has no temporal column at all.
     """
-    for frame_name, frame in frames:
-        if frame is not None and date_col not in frame.columns:
-            raise MissingDateColumnError(frame_name, column=date_col, available=list(frame.columns))
+    if date_col is None:
+        temporal = [name for name, dtype in frame.schema.items() if dtype.is_temporal()]
+        if not temporal:
+            raise MissingDateColumnError(frame_name, available=list(frame.columns))
+        source = temporal[0]
+    elif date_col not in frame.columns:
+        raise MissingDateColumnError(frame_name, column=date_col, available=list(frame.columns))
+    else:
+        source = date_col
+
+    if source == DATE_COLUMN or not frame.schema[source].is_temporal():
+        return frame, source
+    return frame.rename({source: DATE_COLUMN}), DATE_COLUMN
 
 
 def _align_returns_benchmark(
@@ -249,7 +278,7 @@ def _align_returns_benchmark(
     return returns_pl, benchmark_pl
 
 
-def _prices_to_returns(frame: pl.DataFrame, date_col: str, frame_name: str) -> pl.DataFrame:
+def _prices_to_returns(frame: pl.DataFrame, date_col: str) -> pl.DataFrame:
     """Convert a price-level frame to a returns frame via percentage change.
 
     The first row is dropped because no prior price is available to compute a
@@ -257,18 +286,13 @@ def _prices_to_returns(frame: pl.DataFrame, date_col: str, frame_name: str) -> p
 
     Args:
         frame: Price-level frame with a *date_col* column and asset columns.
+            Callers canonicalise the date column first, so its presence is a
+            precondition here rather than something re-checked.
         date_col: Name of the date column (passed through unchanged).
-        frame_name: Descriptive name used in the error message when *date_col*
-            is missing (e.g. ``"prices"`` or ``"benchmark"``).
 
     Returns:
         pl.DataFrame: Returns frame with the same columns as *frame*, one row
         shorter.
-
-    Raises:
-        MissingDateColumnError: If *date_col* is not a column of *frame*.
     """
-    if date_col not in frame.columns:
-        raise MissingDateColumnError(frame_name, column=date_col, available=list(frame.columns))
     asset_cols = _value_columns(frame, date_col)
     return frame.with_columns([pl.col(c).pct_change().alias(c) for c in asset_cols]).slice(1)

--- a/src/jquantstats/data.py
+++ b/src/jquantstats/data.py
@@ -16,10 +16,11 @@ from ._stats import Stats
 from ._types import NativeFrame, NativeFrameOrScalar
 from ._utils import DataUtils
 from ._utils._construction import (
+    DATE_COLUMN,
     _align_returns_benchmark,
     _apply_null_strategy,
+    _canonicalise_date_column,
     _prices_to_returns,
-    _require_date_col,
     _subtract_risk_free,
     _to_polars,
 )
@@ -42,7 +43,15 @@ class Data(_ReshapeMixin):
         benchmark (pl.DataFrame | None): Optional benchmark returns DataFrame.
             Defaults to None.
         index (pl.DataFrame): DataFrame containing the date index for the
-            returns data.
+            returns data. A temporal index column is always named ``'date'``
+            — see *Date column* below.
+
+    Date column:
+        Whatever the input frames called it, a temporal index column ends up
+        as ``'date'``, the same name the `Portfolio` internals use. So
+        ``data.index['date']`` works on every `Data` object, however it was
+        built, and ``Data.date_col`` stays the safest way to read the name —
+        a date-free (integer-indexed) object keeps its own index column name.
 
     """
 
@@ -51,7 +60,13 @@ class Data(_ReshapeMixin):
     benchmark: pl.DataFrame | None = None
 
     def __post_init__(self) -> None:
-        """Validate the Data object after initialization."""
+        """Normalise the index column name and validate the Data object."""
+        # Canonicalise here rather than in the constructors alone, so a Data built
+        # by hand (or rebuilt by a reshape) carries the same index column name.
+        temporal = [name for name, dtype in self.index.schema.items() if dtype.is_temporal()]
+        if temporal and temporal[0] != DATE_COLUMN:
+            object.__setattr__(self, "index", self.index.rename({temporal[0]: DATE_COLUMN}))
+
         # You need at least two points
         if self.index.shape[0] < 2:
             raise ValueError("Index must contain at least two timestamps.")  # noqa: TRY003
@@ -75,7 +90,7 @@ class Data(_ReshapeMixin):
         returns: NativeFrame,
         rf: NativeFrameOrScalar = 0.0,
         benchmark: NativeFrame | None = None,
-        date_col: str = "Date",
+        date_col: str | None = None,
         null_strategy: Literal["raise", "drop", "forward_fill"] | None = None,
     ) -> Data:
         """Create a Data object from returns and optional benchmark.
@@ -96,8 +111,12 @@ class Data(_ReshapeMixin):
                 benchmark are aligned on their common dates; if either frame
                 contains dates the other lacks, those rows are dropped and a
                 `BenchmarkAlignmentWarning` is emitted.
-            date_col (str): Name of the date column in the DataFrames.
-                Defaults to ``"Date"``.
+            date_col (str | None): Name of the date column in the DataFrames.
+                Defaults to ``None``, which auto-detects the first temporal
+                column of each frame. Pass a name to nominate a column
+                explicitly — required for a non-temporal (e.g. integer) index,
+                which auto-detection will not find. Whichever column is used,
+                it is renamed to ``'date'`` on the resulting object.
             null_strategy ({"raise", "drop", "forward_fill"} | None): How to
                 handle ``null`` (missing) values in *returns* and *benchmark*.
                 Defaults to ``None`` (nulls propagate through calculations).
@@ -122,8 +141,10 @@ class Data(_ReshapeMixin):
 
         Raises:
             MissingDateColumnError: If *date_col* is not a column of
-                *returns*, *benchmark*, or a DataFrame-valued *rf*. Raised
-                before any joins so the offending frame is named explicitly.
+                *returns*, *benchmark*, or a DataFrame-valued *rf* — or, when
+                *date_col* is ``None``, if one of those frames has no temporal
+                column to auto-detect. Raised before any joins so the
+                offending frame is named explicitly.
             NullsInReturnsError: If *null_strategy* is ``"raise"`` and the
                 data contains null values.
             ValueError: If there are no overlapping dates between returns and
@@ -175,25 +196,30 @@ class Data(_ReshapeMixin):
             ```
 
         """
-        returns_pl = _to_polars(returns)
-        benchmark_pl = _to_polars(benchmark) if benchmark is not None else None
+        # Resolve the date column once, up front: a temporal axis is renamed to the
+        # canonical 'date' on every frame, so the joins below — and the resulting
+        # object — speak one column name whatever the caller's frames were labelled.
+        # A frame-valued rf carries the same date_col, so it resolves the same way.
+        returns_pl, resolved_col = _canonicalise_date_column(_to_polars(returns), "returns", date_col)
+        benchmark_pl = (
+            _canonicalise_date_column(_to_polars(benchmark), "benchmark", date_col)[0]
+            if benchmark is not None
+            else None
+        )
         # accept ints (e.g. rf=0) by coercing to float
-        rf_converted: float | pl.DataFrame = float(rf) if isinstance(rf, int | float) else _to_polars(rf)
+        rf_converted: float | pl.DataFrame = (
+            float(rf) if isinstance(rf, int | float) else _canonicalise_date_column(_to_polars(rf), "rf", date_col)[0]
+        )
 
-        frames: list[tuple[str, pl.DataFrame | None]] = [("returns", returns_pl), ("benchmark", benchmark_pl)]
-        if isinstance(rf_converted, pl.DataFrame):
-            frames.append(("rf", rf_converted))
-        _require_date_col(frames, date_col)
-
-        returns_pl = _apply_null_strategy(returns_pl, date_col, "returns", null_strategy)
+        returns_pl = _apply_null_strategy(returns_pl, resolved_col, "returns", null_strategy)
         if benchmark_pl is not None:
-            benchmark_pl = _apply_null_strategy(benchmark_pl, date_col, "benchmark", null_strategy)
-            returns_pl, benchmark_pl = _align_returns_benchmark(returns_pl, benchmark_pl, date_col)
+            benchmark_pl = _apply_null_strategy(benchmark_pl, resolved_col, "benchmark", null_strategy)
+            returns_pl, benchmark_pl = _align_returns_benchmark(returns_pl, benchmark_pl, resolved_col)
 
-        index = returns_pl.select(date_col)
-        excess_returns = _subtract_risk_free(returns_pl, rf_converted, date_col).drop(date_col)
+        index = returns_pl.select(resolved_col)
+        excess_returns = _subtract_risk_free(returns_pl, rf_converted, resolved_col).drop(resolved_col)
         excess_benchmark = (
-            _subtract_risk_free(benchmark_pl, rf_converted, date_col).drop(date_col)
+            _subtract_risk_free(benchmark_pl, rf_converted, resolved_col).drop(resolved_col)
             if benchmark_pl is not None
             else None
         )
@@ -206,7 +232,7 @@ class Data(_ReshapeMixin):
         prices: NativeFrame,
         rf: NativeFrameOrScalar = 0.0,
         benchmark: NativeFrame | None = None,
-        date_col: str = "Date",
+        date_col: str | None = None,
         null_strategy: Literal["raise", "drop", "forward_fill"] | None = None,
     ) -> Data:
         """Create a Data object from prices and optional benchmark.
@@ -218,14 +244,18 @@ class Data(_ReshapeMixin):
         Args:
             prices (NativeFrame): Price-level data. First column should be
                 the date column; remaining columns are asset prices.
-            rf (float | NativeFrame): Risk-free rate. Forwarded unchanged to
-                `from_returns`. Defaults to 0.0 (no risk-free rate
-                adjustment).
+            rf (float | NativeFrame): Risk-free rate. Forwarded to
+                `from_returns`; a frame-valued *rf* has its date column
+                canonicalised on the way, exactly as *prices* does. Defaults
+                to 0.0 (no risk-free rate adjustment).
             benchmark (NativeFrame | None): Benchmark prices. Converted to
                 returns in the same way as ``prices`` before being forwarded
                 to `from_returns`. Defaults to None (no benchmark).
-            date_col (str): Name of the date column in the DataFrames.
-                Defaults to ``"Date"``.
+            date_col (str | None): Name of the date column in the DataFrames.
+                Defaults to ``None``, which auto-detects the first temporal
+                column of each frame. Forwarded unchanged to `from_returns`;
+                whichever column is used is renamed to ``'date'`` on the
+                resulting object.
             null_strategy ({"raise", "drop", "forward_fill"} | None): How to
                 handle ``null`` (missing) values after converting prices to
                 returns. Forwarded unchanged to `from_returns`. Defaults to
@@ -250,8 +280,9 @@ class Data(_ReshapeMixin):
 
         Raises:
             MissingDateColumnError: If *date_col* is not a column of *prices*
-                or *benchmark*. Raised before returns are derived so the
-                offending frame is named explicitly.
+                or *benchmark* — or, when *date_col* is ``None``, if either
+                frame has no temporal column to auto-detect. Raised before
+                returns are derived so the offending frame is named explicitly.
 
         Examples:
             ```python
@@ -267,17 +298,27 @@ class Data(_ReshapeMixin):
             ```
 
         """
-        returns_pl = _prices_to_returns(_to_polars(prices), date_col, "prices")
+        prices_pl, resolved_col = _canonicalise_date_column(_to_polars(prices), "prices", date_col)
+        returns_pl = _prices_to_returns(prices_pl, resolved_col)
 
         benchmark_returns: NativeFrame | None = None
         if benchmark is not None:
-            benchmark_returns = _prices_to_returns(_to_polars(benchmark), date_col, "benchmark")
+            benchmark_pl, _ = _canonicalise_date_column(_to_polars(benchmark), "benchmark", date_col)
+            benchmark_returns = _prices_to_returns(benchmark_pl, resolved_col)
 
+        # A frame-valued rf is canonicalised here too, since the frames handed on
+        # below are resolved already and date_col no longer describes them.
+        rf_forwarded: NativeFrameOrScalar = (
+            rf if isinstance(rf, int | float) else _canonicalise_date_column(_to_polars(rf), "rf", date_col)[0]
+        )
+
+        # Naming the resolved column keeps auto-detection from picking a different
+        # one downstream — it would not find a non-temporal (e.g. integer) index.
         return cls.from_returns(
             returns=returns_pl,
-            rf=rf,
+            rf=rf_forwarded,
             benchmark=benchmark_returns,
-            date_col=date_col,
+            date_col=resolved_col,
             null_strategy=null_strategy,
         )
 

--- a/src/jquantstats/exceptions.py
+++ b/src/jquantstats/exceptions.py
@@ -28,10 +28,12 @@ class MissingDateColumnError(JQuantStatsError, ValueError):
     Args:
         frame_name: Descriptive name of the frame missing the column (e.g. ``"prices"``).
         column: Name of the date column that was looked up (e.g. the
-            ``date_col`` argument). When omitted, the default ``'date'``
-            column is assumed.
+            ``date_col`` argument). When omitted, the column was being
+            auto-detected rather than looked up by name.
         available: Column names actually present in the frame, included in
-            the error message to help diagnose the mismatch.
+            the error message to help diagnose the mismatch. Supplying them
+            without a *column* selects the auto-detection wording — no
+            temporal column was found to use as the date axis.
 
     Examples:
         >>> raise MissingDateColumnError("prices")  # doctest: +ELLIPSIS
@@ -43,12 +45,17 @@ class MissingDateColumnError(JQuantStatsError, ValueError):
     def __init__(self, frame_name: str, column: str | None = None, available: list[str] | None = None) -> None:
         """Initialize with the frame name and, optionally, the missing column and available columns."""
         available = [] if available is None else list(available)
-        if column is None:
+        cols = ", ".join(f"'{c}'" for c in available) if available else ""
+        if column is None and not cols:
             msg = f"DataFrame '{frame_name}' is missing the required 'date' column."
         else:
-            cols = ", ".join(f"'{c}'" for c in available) if available else ""
+            lookup = (
+                f"has no column '{column}' to use as the date column"
+                if column is not None
+                else "has no temporal column to use as the date column"
+            )
             msg = (
-                f"DataFrame '{frame_name}' has no column '{column}' to use as the date column"
+                f"DataFrame '{frame_name}' {lookup}"
                 + (f"; available columns: {cols}" if cols else "")
                 + ". Pass date_col=<name of an existing column>."
             )

--- a/tests/test_jquantstats/conftest.py
+++ b/tests/test_jquantstats/conftest.py
@@ -148,7 +148,7 @@ def edge(data):
         Data: A Data object with returns and benchmark data that are all zeros.
 
     """
-    index = data.index["Date"]
+    index = data.index["date"]
     returns = pl.DataFrame({"index": index, "returns": [0.0] * len(index)})
     benchmark = pl.DataFrame({"index": index, "benchmark": [0.0] * len(index)})
 

--- a/tests/test_jquantstats/test__reports/test_reports.py
+++ b/tests/test_jquantstats/test__reports/test_reports.py
@@ -616,7 +616,7 @@ def test_metrics_full_mode_correlation_raises(data):
             """Return all DataFrame without benchmark column to break pl.corr."""
             real_all: pl.DataFrame = self._real.all  # type: ignore[union-attr]
             # Drop the benchmark column so selecting it later raises
-            return real_all.select(["Date", "AAPL", "META"])
+            return real_all.select(["date", "AAPL", "META"])
 
         @property
         def benchmark(self) -> pl.DataFrame:

--- a/tests/test_jquantstats/test_data.py
+++ b/tests/test_jquantstats/test_data.py
@@ -89,11 +89,12 @@ def test_date_col(data):
         data (_Data): The data fixture containing a Data object.
 
     Verifies:
-        The date_col property returns the expected date column name.
+        The date_col property reports the canonical ``'date'``, even though the
+        source frame labelled the column ``'Date'`` (#929).
 
     """
     x = data.date_col
-    assert x == ["Date"]
+    assert x == ["date"]
 
 
 def test_periods(data):
@@ -324,15 +325,15 @@ def test_copy_no_benchmark(data_no_benchmark):
 
 def test_truncate_by_start_and_end(data):
     """Tests truncate(start, end) filters rows inclusively by date."""
-    first_date = data.index["Date"][0]
-    last_date = data.index["Date"][-1]
-    mid_start = data.index["Date"][10]
-    mid_end = data.index["Date"][20]
+    first_date = data.index["date"][0]
+    last_date = data.index["date"][-1]
+    mid_start = data.index["date"][10]
+    mid_end = data.index["date"][20]
 
     result = data.truncate(start=mid_start, end=mid_end)
 
-    assert result.index["Date"][0] == mid_start
-    assert result.index["Date"][-1] == mid_end
+    assert result.index["date"][0] == mid_start
+    assert result.index["date"][-1] == mid_end
     assert result.returns.shape[0] == 11
     assert result.index.shape[0] == result.returns.shape[0]
     if result.benchmark is not None:
@@ -345,17 +346,17 @@ def test_truncate_by_start_and_end(data):
 
 def test_truncate_start_only(data):
     """Tests truncate(start=...) returns rows from start to the end of the data."""
-    mid_start = data.index["Date"][10]
+    mid_start = data.index["date"][10]
     result = data.truncate(start=mid_start)
-    assert result.index["Date"][0] == mid_start
+    assert result.index["date"][0] == mid_start
     assert result.returns.shape[0] == data.returns.shape[0] - 10
 
 
 def test_truncate_end_only(data):
     """Tests truncate(end=...) returns rows from the beginning up to end inclusive."""
-    mid_end = data.index["Date"][9]
+    mid_end = data.index["date"][9]
     result = data.truncate(end=mid_end)
-    assert result.index["Date"][-1] == mid_end
+    assert result.index["date"][-1] == mid_end
     assert result.returns.shape[0] == 10
 
 
@@ -369,8 +370,8 @@ def test_truncate_no_bounds_returns_all(data):
 
 def test_truncate_no_benchmark(data_no_benchmark):
     """Tests truncate() works when there is no benchmark."""
-    mid_start = data_no_benchmark.index["Date"][5]
-    mid_end = data_no_benchmark.index["Date"][15]
+    mid_start = data_no_benchmark.index["date"][5]
+    mid_end = data_no_benchmark.index["date"][15]
     result = data_no_benchmark.truncate(start=mid_start, end=mid_end)
     assert result.benchmark is None
     assert result.returns.shape[0] == 11

--- a/tests/test_jquantstats/test_data_from_returns.py
+++ b/tests/test_jquantstats/test_data_from_returns.py
@@ -42,7 +42,7 @@ def test_with_constant_rf(returns):
     result = Data.from_returns(returns=returns, rf=rf, date_col="Date")
 
     assert_series_equal(result.returns["Meta"], returns["Meta"] - rf)
-    assert_series_equal(result.index.to_series(), returns["Date"])
+    assert_series_equal(result.index.to_series(), returns["Date"].rename("date"))
     # Verify there's no benchmark
     assert result.benchmark is None
 

--- a/tests/test_jquantstats/test_date_column.py
+++ b/tests/test_jquantstats/test_date_column.py
@@ -1,0 +1,115 @@
+"""#929: Data and Portfolio agree on the name of the date column.
+
+``Data.from_returns`` used to default to ``date_col="Date"`` while every
+``Portfolio`` internal canonicalised on lowercase ``'date'``, so two objects of
+the same class carried a different index column name depending on how they were
+built. The date column is now auto-detected and a temporal axis always ends up
+as ``'date'``.
+"""
+
+import polars as pl
+import pytest
+
+from jquantstats import Data, Portfolio
+from jquantstats.exceptions import MissingDateColumnError
+
+N = 6
+
+
+@pytest.fixture
+def dates() -> pl.Series:
+    """Six consecutive days."""
+    return pl.date_range(pl.date(2020, 1, 1), pl.date(2020, 1, 6), interval="1d", eager=True)
+
+
+@pytest.fixture
+def returns(dates: pl.Series) -> pl.DataFrame:
+    """A returns frame whose date column is labelled ``'Date'``."""
+    return pl.DataFrame({"Date": dates, "Fund": [0.01, -0.02, 0.03, 0.0, 0.01, -0.01]})
+
+
+@pytest.fixture
+def prices(dates: pl.Series) -> pl.DataFrame:
+    """A price frame whose date column is labelled ``'Date'``."""
+    return pl.DataFrame({"Date": dates, "A": [100.0, 101.0, 99.0, 99.5, 102.0, 101.0]})
+
+
+def test_from_returns_auto_detects_and_canonicalises(returns: pl.DataFrame) -> None:
+    """A 'Date' column is found without being named and reported as 'date'."""
+    data = Data.from_returns(returns)
+    assert data.index.columns == ["date"]
+    assert data.date_col == ["date"]
+    assert data.index["date"].to_list() == returns["Date"].to_list()
+
+
+def test_from_returns_explicit_date_col_is_canonicalised(returns: pl.DataFrame) -> None:
+    """Naming the column explicitly picks the same column and the same label."""
+    assert Data.from_returns(returns, date_col="Date").index.columns == ["date"]
+
+
+def test_from_prices_auto_detects_and_canonicalises(prices: pl.DataFrame) -> None:
+    """from_prices resolves its date column the same way from_returns does."""
+    assert Data.from_prices(prices).index.columns == ["date"]
+
+
+def test_lowercase_input_is_accepted(returns: pl.DataFrame) -> None:
+    """A frame already using 'date' is passed through untouched."""
+    lowercase = returns.rename({"Date": "date"})
+    assert Data.from_returns(lowercase).index.columns == ["date"]
+
+
+def test_data_and_portfolio_data_agree(returns: pl.DataFrame, prices: pl.DataFrame) -> None:
+    """The issue's reproduction: one reader works against both objects."""
+    data = Data.from_returns(returns)
+    portfolio = Portfolio.from_cash_position(
+        prices=prices,
+        cash_position=prices.with_columns(pl.lit(1e5).alias("A")),
+        aum=1e6,
+    )
+
+    def first_date(obj: Data) -> object:
+        return obj.index["date"].min()
+
+    assert data.date_col == portfolio.data.date_col == ["date"]
+    assert first_date(data) == first_date(portfolio.data)
+
+
+def test_frames_may_label_their_date_columns_differently(returns: pl.DataFrame, dates: pl.Series) -> None:
+    """Auto-detection runs per frame, so returns/benchmark/rf need not agree."""
+    benchmark = pl.DataFrame({"timestamp": dates, "Market": [0.005] * N})
+    rf = pl.DataFrame({"when": dates, "rf": [0.0001] * N})
+
+    data = Data.from_returns(returns, benchmark=benchmark, rf=rf)
+
+    assert data.index.columns == ["date"]
+    assert data.benchmark is not None
+    assert data.benchmark.columns == ["Market"]
+
+
+def test_from_prices_rf_frame_is_canonicalised(prices: pl.DataFrame, dates: pl.Series) -> None:
+    """A frame-valued rf reaching from_prices resolves like the price frame."""
+    rf = pl.DataFrame({"Date": dates[1:], "rf": [0.0001] * (N - 1)})
+    assert Data.from_prices(prices, rf=rf).index.columns == ["date"]
+
+
+def test_direct_construction_normalises_the_index(returns: pl.DataFrame) -> None:
+    """Building a Data by hand carries the same guarantee as the constructors."""
+    data = Data(returns=returns.drop("Date"), index=returns.select("Date"))
+    assert data.index.columns == ["date"]
+
+
+def test_no_temporal_column_raises_and_names_the_frame(returns: pl.DataFrame) -> None:
+    """Auto-detection failure says what it looked for and how to override it."""
+    integer_indexed = returns.with_columns(pl.int_range(0, N).alias("Date"))
+    with pytest.raises(MissingDateColumnError, match="'returns' has no temporal column") as exc_info:
+        Data.from_returns(integer_indexed)
+    assert exc_info.value.frame_name == "returns"
+    assert exc_info.value.column is None
+    assert "Date" in exc_info.value.available
+
+
+def test_non_temporal_date_col_keeps_its_name(returns: pl.DataFrame) -> None:
+    """An integer axis nominated by name is not relabelled 'date' — it is not one."""
+    integer_indexed = returns.with_columns(pl.int_range(0, N).alias("i"))
+    data = Data.from_returns(integer_indexed.drop("Date"), date_col="i")
+    assert data.date_col == ["i"]

--- a/tests/test_jquantstats/test_migration/conftest.py
+++ b/tests/test_jquantstats/test_migration/conftest.py
@@ -23,16 +23,16 @@ def stats(data):
 
 @pytest.fixture
 def pandas_frame(data):
-    """Fixture that returns the data as a pandas DataFrame with Date as index.
+    """Fixture that returns the data as a pandas DataFrame with the date as index.
 
     Args:
         data: The data fixture containing a Data object.
 
     Returns:
-        pd.DataFrame: A pandas DataFrame with Date as index and all data columns.
+        pd.DataFrame: A pandas DataFrame with the date as index and all data columns.
 
     """
-    return data.all.to_pandas().set_index("Date")
+    return data.all.to_pandas().set_index("date")
 
 
 @pytest.fixture

--- a/tests/test_jquantstats/test_migration/test_basic.py
+++ b/tests/test_jquantstats/test_migration/test_basic.py
@@ -61,7 +61,7 @@ from ..tolerances import TOL_FLOAT64
 )
 def test_migration(stats, method, kwargs, tol):
     """Verify each stat method produces the same result as quantstats."""
-    aapl = stats.all.to_pandas().set_index("Date")["AAPL"]
+    aapl = stats.all.to_pandas().set_index("date")["AAPL"]
     x = getattr(stats, method)(**kwargs)["AAPL"]
     y = getattr(qs.stats, method)(aapl, **kwargs)
     assert x == pytest.approx(y, abs=tol)
@@ -69,7 +69,7 @@ def test_migration(stats, method, kwargs, tol):
 
 def test_conditional_value_at_risk(stats):
     """Test conditional_value_at_risk matches QuantStats output."""
-    returns = stats.all.to_pandas().set_index("Date")["AAPL"]
+    returns = stats.all.to_pandas().set_index("date")["AAPL"]
     x = qs.stats.conditional_value_at_risk(returns, confidence=0.99)
     y = stats.conditional_value_at_risk(confidence=0.99)["AAPL"]
     assert x == pytest.approx(y, abs=TOL_FLOAT64)

--- a/tests/test_jquantstats/test_migration/test_new_stats.py
+++ b/tests/test_jquantstats/test_migration/test_new_stats.py
@@ -125,7 +125,7 @@ def test_rolling_greeks_beta(stats, aapl, benchmark_pd):
     jqs_df = stats.rolling_greeks(rolling_period=126, periods_per_year=252)
     qs_df = qs.stats.rolling_greeks(aapl, benchmark_pd, periods=126)
 
-    jqs_pd = jqs_df.to_pandas().set_index("Date")["AAPL_beta"].dropna()
+    jqs_pd = jqs_df.to_pandas().set_index("date")["AAPL_beta"].dropna()
     qs_beta = qs_df["beta"].dropna()
     common = jqs_pd.index.intersection(qs_beta.index)
 

--- a/tests/test_jquantstats/test_migration/test_rolling.py
+++ b/tests/test_jquantstats/test_migration/test_rolling.py
@@ -21,11 +21,11 @@ from ..tolerances import TOL_FLOAT64
 )
 def test_rolling(stats, method, kwargs, atol):
     """Verify each rolling method produces the same time-series as quantstats."""
-    aapl = stats.all.to_pandas().set_index("Date")["AAPL"]
+    aapl = stats.all.to_pandas().set_index("date")["AAPL"]
     jqs_df = getattr(stats, method)(**kwargs)
     qs_series = getattr(qs.stats, method)(aapl, **kwargs)
 
-    jqs_pd = jqs_df.to_pandas().set_index("Date")["AAPL"].dropna()
+    jqs_pd = jqs_df.to_pandas().set_index("date")["AAPL"].dropna()
     qs_clean = qs_series.dropna()
     common = jqs_pd.index.intersection(qs_clean.index)
 
@@ -38,12 +38,12 @@ def test_pct_rank(stats):
     aapl_returns = stats.returns["AAPL"]
     aapl_prices = _DrawdownMixin.prices(aapl_returns)
     aapl_prices_pd = aapl_prices.to_pandas()
-    aapl_prices_pd.index = stats.index["Date"].to_pandas()
+    aapl_prices_pd.index = stats.index["date"].to_pandas()
 
     jqs_df = stats.pct_rank(window=60)
     qs_series = qs.stats.pct_rank(aapl_prices_pd, window=60)
 
-    jqs_pd = jqs_df.to_pandas().set_index("Date")["AAPL"].dropna()
+    jqs_pd = jqs_df.to_pandas().set_index("date")["AAPL"].dropna()
     qs_clean = qs_series.dropna()
     common = jqs_pd.index.intersection(qs_clean.index)
 

--- a/tests/test_jquantstats/test_truncate.py
+++ b/tests/test_jquantstats/test_truncate.py
@@ -61,8 +61,15 @@ def dated_data() -> Data:
 
 @pytest.fixture
 def int_data() -> Data:
-    """An 80-row Data with an integer index."""
-    return Data.from_returns(pl.DataFrame({"Date": list(range(N)), "R": pl.Series([0.001] * N, dtype=pl.Float64)}))
+    """An 80-row Data with an integer index.
+
+    The index column has to be nominated explicitly: auto-detection looks for a
+    temporal column and there is none here.
+    """
+    return Data.from_returns(
+        pl.DataFrame({"Date": list(range(N)), "R": pl.Series([0.001] * N, dtype=pl.Float64)}),
+        date_col="Date",
+    )
 
 
 # ─── #926: string bounds are parsed ───────────────────────────────────────────


### PR DESCRIPTION
Closes #929.

`Data.from_returns` / `from_prices` defaulted to `date_col="Date"` while every
`Portfolio` internal canonicalises on lowercase `date`. Two objects of the same
class therefore carried a different index column name depending on how they were
built, so `data.index.columns[0]` was not a reliable thing to write against and
the two documented entry points taught opposite conventions.

This is option 1 from the issue (the settled end state), implemented via
option 3 (auto-detection) in one step.

## What changed

- `date_col` now defaults to `None` and auto-detects the **first temporal
  column** of each frame. Returns, benchmark and a frame-valued `rf` resolve
  independently, so they no longer have to share a label.
- A temporal date axis is renamed to `date` — in the constructors *and* in
  `Data.__post_init__`, so a hand-built or reshaped `Data` carries the same
  invariant.
- An explicit `date_col` still wins and may name a non-temporal column. Such a
  column **keeps its own name**: relabelling an integer row index `date` would
  be a lie. That path is now required for date-free frames, since
  auto-detection has nothing to find there.
- `_require_date_col` is replaced by `_canonicalise_date_column`;
  `MissingDateColumnError` gained the auto-detection wording ("has no temporal
  column to use as the date column; available columns: …") while keeping its
  existing message for the `Portfolio.monthly` call site.

```python
Data.from_returns(df_with_Date_col).index.columns    # ['date']
Data.from_returns(df, date_col="Date").index.columns # ['date']
pf.data.index.columns                                # ['date']
```

## Breaking change

Anyone reading `data.index["Date"]` must switch to `data.index["date"]`.
`Data.date_col` remains the supported way to read the name. Docs
(`getting_started.md` gains a *The date column* section, `faq.md` a Q,
`MIGRATION.md`, and `STABILITY.md` which now records the guarantee) are updated
in step, as is the quantstats-migration skill.

## Verification

- `tests/test_jquantstats/test_date_column.py` — 10 new cases, including the
  issue's exact reproduction and a `Data` vs `Portfolio.data` cross-check.
- `make test` → 1389 passed, 100% coverage, import contracts kept.
- `make fmt`, `make typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)