### PR TITLE
Execute the fenced docstring examples, and split resolve_bounds

### DIFF
--- a/src/jquantstats/__init__.py
+++ b/src/jquantstats/__init__.py
@@ -8,18 +8,21 @@ Use `Portfolio` when you have price series and
 position sizes.  Portfolio compiles the NAV curve from raw inputs and exposes
 the full analytics suite via ``.stats``, ``.plots``, and ``.report``.
 
-```python
-from jquantstats import Portfolio
-import polars as pl
-
-pf = Portfolio.from_cash_position(
-    prices=prices_df,
-    cash_position=positions_df,
-    aum=1_000_000,
-)
-pf.stats.sharpe()
-pf.plots.snapshot()
-```
+    >>> import polars as pl
+    >>> from jquantstats import Portfolio
+    >>> prices = pl.DataFrame(
+    ...     {"date": ["2023-01-01", "2023-01-02", "2023-01-03"], "A": [100.0, 101.0, 99.0]}
+    ... ).with_columns(pl.col("date").str.to_date())
+    >>> positions = pl.DataFrame(
+    ...     {"date": ["2023-01-01", "2023-01-02", "2023-01-03"], "A": [1000.0, 1000.0, 1000.0]}
+    ... ).with_columns(pl.col("date").str.to_date())
+    >>> pf = Portfolio.from_cash_position(prices=prices, cash_position=positions, aum=1_000_000)
+    >>> pf.assets
+    ['A']
+    >>> sorted(pf.stats.sharpe())
+    ['returns']
+    >>> type(pf.plots.snapshot()).__name__
+    'Figure'
 
 **Entry point 2 — returns series (for arbitrary return streams):**
 
@@ -27,17 +30,24 @@ Use `Data` when you already have a returns series
 (e.g. downloaded from a data vendor) and want benchmark comparison or
 factor analytics.
 
-```python
-from jquantstats import Data
-import polars as pl
-
-data = Data.from_returns(returns=returns_df, benchmark=bench_df)
-data.stats.sharpe()
-data.plots.snapshot(title="Performance")
-```
+    >>> from jquantstats import Data
+    >>> returns = pl.DataFrame(
+    ...     {"date": ["2023-01-01", "2023-01-02", "2023-01-03"], "Asset1": [0.01, -0.02, 0.03]}
+    ... ).with_columns(pl.col("date").str.to_date())
+    >>> benchmark = pl.DataFrame(
+    ...     {"date": ["2023-01-01", "2023-01-02", "2023-01-03"], "Market": [0.005, -0.01, 0.02]}
+    ... ).with_columns(pl.col("date").str.to_date())
+    >>> data = Data.from_returns(returns=returns, benchmark=benchmark)
+    >>> data.benchmark.columns
+    ['Market']
+    >>> type(data.plots.snapshot(title="Performance")).__name__
+    'Figure'
 
 The two APIs are layered: ``portfolio.data`` returns a `Data`
 object so you can always drop into the returns-series API from a Portfolio.
+
+    >>> type(pf.data).__name__
+    'Data'
 
 For more information, visit the `jQuantStats Documentation <https://jebel-quant.github.io/jquantstats/book>`_.
 """

--- a/src/jquantstats/_cache.py
+++ b/src/jquantstats/_cache.py
@@ -26,11 +26,24 @@ def cached_in_slot(slot: str) -> Callable[[Callable[[Any], T]], Callable[[Any], 
 
     Apply below ``@property`` so the property getter is the wrapped function:
 
-    ```python
-    @property
-    @cached_in_slot("_profits_cache")
-    def profits(self) -> pl.DataFrame: ...
-    ```
+    >>> class Prices:
+    ...     __slots__ = ("_calls", "_profits_cache")
+    ...     def __init__(self):
+    ...         self._calls = 0
+    ...         self._profits_cache = None  # the slot must start as None
+    ...     @property
+    ...     @cached_in_slot("_profits_cache")
+    ...     def profits(self):
+    ...         self._calls += 1
+    ...         return [1, 2, 3]
+
+    The second access is served from the slot rather than recomputed:
+
+    >>> prices = Prices()
+    >>> prices.profits, prices.profits
+    ([1, 2, 3], [1, 2, 3])
+    >>> prices._calls
+    1
 
     Args:
         slot: Name of the declared slot field used as the cache. The field

--- a/src/jquantstats/_truncate.py
+++ b/src/jquantstats/_truncate.py
@@ -79,6 +79,57 @@ def _classify(param: str, value: Any) -> tuple[Mode, Any]:
     raise InvalidTruncateBoundError(param, value)
 
 
+def _resolve_row_bounds(start: Any, end: Any) -> tuple[Mode, Any, Any]:
+    """Resolve bounds against an integer index, where only row numbers are legal.
+
+    Split out of `resolve_bounds` so the non-temporal rule reads as one thing:
+    a row number is the only meaning a bound can carry here, so anything else is
+    reported against that expectation rather than being classified further.
+
+    ``bool`` is rejected for the reason `_classify` rejects it — ``start=True``
+    is far more likely to be a mistake than a request for row 1 — but the error
+    differs: on an integer index the complaint is the index type, not the bound
+    type, so `IntegerIndexBoundError` names what was expected.
+
+    Args:
+        start: Inclusive lower bound, or ``None``.
+        end: Inclusive upper bound, or ``None``.
+
+    Returns:
+        ``(mode, start, end)`` with the bounds unchanged — a row index needs no
+        coercion. ``mode`` is ``"none"`` when both bounds are ``None``, else
+        ``"rows"``.
+
+    Raises:
+        IntegerIndexBoundError: If either bound is not an ``int``.
+    """
+    for param, value in (("start", start), ("end", end)):
+        if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
+            raise IntegerIndexBoundError(param, type(value).__name__)
+    return ("none" if start is None and end is None else "rows"), start, end
+
+
+def _reject_mixed_modes(start_mode: Mode, end_mode: Mode) -> None:
+    """Reject a row index paired with a date, in either order.
+
+    The two checks are mirror images, and the argument order to
+    `MixedTruncateBoundsError` is not symmetric: the first name is the bound
+    that disagrees with the axis already established by the other, so the
+    message reads as a complaint about the newcomer rather than about the pair.
+
+    Args:
+        start_mode: The mode `_classify` assigned to *start*.
+        end_mode: The mode `_classify` assigned to *end*.
+
+    Raises:
+        MixedTruncateBoundsError: If one bound is a row index and the other a date.
+    """
+    if start_mode == "rows" and end_mode == "dates":
+        raise MixedTruncateBoundsError("start", "end")
+    if start_mode == "dates" and end_mode == "rows":
+        raise MixedTruncateBoundsError("end", "start")
+
+
 def resolve_bounds(start: Any, end: Any, *, temporal: bool) -> tuple[Mode, Any, Any]:
     """Decide which axis *start* and *end* address, and coerce them for it.
 
@@ -103,20 +154,13 @@ def resolve_bounds(start: Any, end: Any, *, temporal: bool) -> tuple[Mode, Any, 
         MixedTruncateBoundsError: If one bound is a row index and the other a date.
     """
     if not temporal:
-        # Integer index: a row number is the only thing a bound can mean, so any
-        # other type is reported against that expectation.
-        for param, value in (("start", start), ("end", end)):
-            if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
-                raise IntegerIndexBoundError(param, type(value).__name__)
-        return ("none" if start is None and end is None else "rows"), start, end
+        return _resolve_row_bounds(start, end)
 
     start_mode, start_value = _classify("start", start)
     end_mode, end_value = _classify("end", end)
+    _reject_mixed_modes(start_mode, end_mode)
 
-    if start_mode == "rows" and end_mode == "dates":
-        raise MixedTruncateBoundsError("start", "end")
-    if start_mode == "dates" and end_mode == "rows":
-        raise MixedTruncateBoundsError("end", "start")
-
+    # With the modes agreed, whichever bound is set names the axis; when only one
+    # is given the other stays "none" and contributes nothing.
     mode: Mode = start_mode if start_mode != "none" else end_mode
     return mode, start_value, end_value

--- a/src/jquantstats/_utils/_construction.py
+++ b/src/jquantstats/_utils/_construction.py
@@ -119,15 +119,20 @@ def interpolate(df: pl.DataFrame) -> pl.DataFrame:
         filled; schema and dtypes of the original columns are preserved.
 
     Examples:
-        ```python
-        import polars as pl
-        from jquantstats import interpolate
+        >>> import polars as pl
+        >>> from jquantstats import interpolate
+        >>> df = pl.DataFrame({"a": [None, 1.0, None, 3.0, None], "b": ["x", "y", "z", "w", "v"]})
+        >>> result = interpolate(df)
 
-        df = pl.DataFrame({"a": [None, 1.0, None, 3.0, None], "b": ["x", "y", "z", "w", "v"]})
-        result = interpolate(df)
-        # a: [None, 1.0, 1.0, 3.0, None]  (leading/trailing nulls untouched)
-        # b: ["x", "y", "z", "w", "v"]    (non-numeric unchanged)
-        ```
+        The interior null is filled; the leading and trailing ones are left alone:
+
+        >>> result["a"].to_list()
+        [None, 1.0, 1.0, 3.0, None]
+
+        Non-numeric columns pass through untouched:
+
+        >>> result["b"].to_list()
+        ['x', 'y', 'z', 'w', 'v']
 
     """
     # Choose a temp column name guaranteed not to collide with any user column.

--- a/src/jquantstats/data.py
+++ b/src/jquantstats/data.py
@@ -155,45 +155,40 @@ class Data(_ReshapeMixin):
                 their common dates drops rows from either frame.
 
         Examples:
-            Basic usage:
+            Basic usage. Note the ``Date`` column is canonicalised to ``date``:
 
-            ```python
-            from jquantstats import Data
-            import polars as pl
-
-            returns = pl.DataFrame({
-                "Date": ["2023-01-01", "2023-01-02", "2023-01-03"],
-                "Asset1": [0.01, -0.02, 0.03]
-            }).with_columns(pl.col("Date").str.to_date())
-
-            data = Data.from_returns(returns=returns)
-            ```
+            >>> import polars as pl
+            >>> from jquantstats import Data
+            >>> returns = pl.DataFrame(
+            ...     {"Date": ["2023-01-01", "2023-01-02", "2023-01-03"], "Asset1": [0.01, -0.02, 0.03]}
+            ... ).with_columns(pl.col("Date").str.to_date())
+            >>> data = Data.from_returns(returns=returns)
+            >>> data.assets
+            ['Asset1']
+            >>> data.all.columns
+            ['date', 'Asset1']
 
             With benchmark and risk-free rate:
 
-            ```python
-            benchmark = pl.DataFrame({
-                "Date": ["2023-01-01", "2023-01-02", "2023-01-03"],
-                "Market": [0.005, -0.01, 0.02]
-            }).with_columns(pl.col("Date").str.to_date())
+            >>> benchmark = pl.DataFrame(
+            ...     {"Date": ["2023-01-01", "2023-01-02", "2023-01-03"], "Market": [0.005, -0.01, 0.02]}
+            ... ).with_columns(pl.col("Date").str.to_date())
+            >>> data = Data.from_returns(returns=returns, benchmark=benchmark, rf=0.0002)
+            >>> data.benchmark.columns
+            ['Market']
 
-            data = Data.from_returns(returns=returns, benchmark=benchmark, rf=0.0002)
-            ```
+            Handling nulls automatically. ``"drop"`` mirrors pandas/'uantStats
+            behaviour and loses the offending row; ``"forward_fill"`` keeps it:
 
-            Handling nulls automatically:
-
-            ```python
-            returns_with_nulls = pl.DataFrame({
-                "Date": ["2023-01-01", "2023-01-02", "2023-01-03"],
-                "Asset1": [0.01, None, 0.03]
-            }).with_columns(pl.col("Date").str.to_date())
-
-            # Drop rows with nulls (mirrors pandas/QuantStats behaviour)
-            data = Data.from_returns(returns=returns_with_nulls, null_strategy="drop")
-
-            # Or forward-fill nulls
-            data = Data.from_returns(returns=returns_with_nulls, null_strategy="forward_fill")
-            ```
+            >>> returns_with_nulls = pl.DataFrame(
+            ...     {"Date": ["2023-01-01", "2023-01-02", "2023-01-03"], "Asset1": [0.01, None, 0.03]}
+            ... ).with_columns(pl.col("Date").str.to_date())
+            >>> Data.from_returns(returns=returns_with_nulls, null_strategy="drop").returns["Asset1"].to_list()
+            [0.01, 0.03]
+            >>> Data.from_returns(
+            ...     returns=returns_with_nulls, null_strategy="forward_fill"
+            ... ).returns["Asset1"].to_list()
+            [0.01, 0.01, 0.03]
 
         """
         # Resolve the date column once, up front: a temporal axis is renamed to the
@@ -285,17 +280,18 @@ class Data(_ReshapeMixin):
                 returns are derived so the offending frame is named explicitly.
 
         Examples:
-            ```python
-            from jquantstats import Data
-            import polars as pl
+            Prices become returns, so the first row is consumed:
 
-            prices = pl.DataFrame({
-                "Date": ["2023-01-01", "2023-01-02", "2023-01-03"],
-                "Asset1": [100.0, 101.0, 99.0]
-            }).with_columns(pl.col("Date").str.to_date())
-
-            data = Data.from_prices(prices=prices)
-            ```
+            >>> import polars as pl
+            >>> from jquantstats import Data
+            >>> prices = pl.DataFrame(
+            ...     {"Date": ["2023-01-01", "2023-01-02", "2023-01-03"], "Asset1": [100.0, 101.0, 99.0]}
+            ... ).with_columns(pl.col("Date").str.to_date())
+            >>> data = Data.from_prices(prices=prices)
+            >>> data.returns.height
+            2
+            >>> [round(r, 6) for r in data.returns["Asset1"].to_list()]
+            [0.01, -0.019802]
 
         """
         prices_pl, resolved_col = _canonicalise_date_column(_to_polars(prices), "prices", date_col)


### PR DESCRIPTION
Fixes the two findings from the `/rhiza:quality` run: #937 and #938.

## #937 — the fenced docstring examples now execute

`pytest-rhiza`'s `test_docstrings` check runs stdlib `doctest`, which collects **only**
`>>>` examples. Eight examples were written as ```python fences, so nothing ran them —
and the split was the worst possible way round: every *verified* example lived in a
private `_portfolio_*` / `_stats` module, while the unverified ones were in the library's
front door.

| File | Was | Now |
|---|---|---|
| `__init__.py` | 2 fences, **not runnable** — referenced undefined `prices_df`, `positions_df`, `returns_df`, `bench_df` | self-contained; asserts `pf.assets`, the `sharpe()` keys, `data.benchmark.columns`, and both `.plots.snapshot()` types |
| `data.py` | 4 fences on `from_returns` / `from_prices` | asserts the canonicalised columns, the benchmark column, and both `null_strategy` outcomes (`[0.01, 0.03]` vs `[0.01, 0.01, 0.03]`) |
| `_utils/_construction.py` | 1 fence describing output in `#` comments | asserts the interior fill and the untouched non-numeric column |
| `_cache.py` | 1 fence showing decorator *syntax* with a `...` body | a real class demonstrating the slot contract — cached on first access, `_calls == 1` after two reads |

Three of the eight could not have run as written, which is the point: they documented an
API without ever being checked against it.

**Examples executed by the gate: 188 → 231, across 11 → 15 modules.** No ```python fence
remains anywhere in `src/`.

Verified the gate genuinely exercises them rather than skipping: breaking one new example
on purpose (`prices._calls` → `99`) makes `test_docstrings` fail with `Expected: 99`, and
it returns to green when restored. The examples pass under the gate's own flags
(`ELLIPSIS | NORMALIZE_WHITESPACE`) — not just under a hand-rolled runner.

## #938 — `resolve_bounds` complexity

It was the only block in the codebase ranking C or worse: **CC 13**, against a repo
average of **A (2.80)** over 518 blocks. The complexity came from three separable jobs
interleaved in one body, not from any single decision being intricate.

Extracted two helpers, leaving `resolve_bounds` a short coordinator:

- **`_resolve_row_bounds`** — the non-temporal path, where a row index is the only legal
  bound, so anything else raises `IntegerIndexBoundError`.
- **`_reject_mixed_modes`** — the two mirror-image `MixedTruncateBoundsError` raises. Its
  argument order is deliberately asymmetric (`("start", "end")` vs `("end", "start")`) so
  the message names the bound that disagrees with the axis already established; that is
  now written down rather than implied.

```
resolve_bounds       C (13) -> A (3)
_resolve_row_bounds  B (7)   (new)
_reject_mixed_modes  A (5)   (new)
```

**No C-or-worse block remains in `src` or `api`.** Behaviour and the public signature are
unchanged — the branches moved rather than changed, so the existing `_truncate` tests
cover them untouched.

## Gates

All run locally on this branch, at v1.4.2 through the `rhiza-task` shim:

| Gate | Result |
|---|---|
| `test` | 1390 passed, 5 skipped (kaleido/Chrome), **100% line + branch** — 3373 stmts, 688 branches, 0 missed |
| `rhiza-test` | 34 passed, incl. `test_doctests` over all 231 examples |
| `typecheck` | `ty` clean; `mypy --strict` clean, 64 modules |
| `docs-coverage` | 100.0% vs a 100.0% minimum |
| `deps` | clean |
| `fmt` | all 21 hooks pass, including the import-linter contracts; nothing reformatted |

`_truncate.py` coverage went 40 → 44 statements, still 100% with all 20 branches covered.

Closes #937
Closes #938
