### PR TITLE
Backend selection scaffolding for an optional matplotlib renderer (#628)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,14 @@ Repository = "https://github.com/jebel-quant/jquantstats"
 # Optional dependencies that can be installed with extras (e.g., pip install jquantstats[plot])
 [project.optional-dependencies]
 plot = ["kaleido>=1.3.0,<2"]
+# The optional matplotlib rendering backend, selected with
+# `jquantstats.set_plot_backend("matplotlib")` or a per-call `backend="matplotlib"`.
+# Plotly stays a core dependency and the default; this only adds the *second* renderer,
+# so the "6 runtime deps, no pandas" claim in docs/engineering.md stays true.
+#
+# Named `mpl` because `plot` was already taken above — and `plot` means something else
+# entirely (kaleido, static image export *for the plotly figures*).
+mpl = ["matplotlib>=3.9"]
 web = [
     "fastapi>=0.115.0",
     "uvicorn>=0.32.0",
@@ -77,6 +85,19 @@ test = [
     "hypothesis>=6.150.0",
     "syrupy>=4.9.1",
     "python-dotenv>=1.0",
+    # Declared here IN ADDITION to the `mpl` extra, and neither declaration is redundant:
+    #   * The extra is what `uv sync --all-extras` installs. mutation.yml and
+    #     benchmark-pr.yml run exactly that, without --all-groups, and uv's default group
+    #     set is `dev` only — so without the extra those two jobs run the suite with
+    #     matplotlib absent.
+    #   * The group is what a bare `uv sync && uv run pytest` installs.
+    # Either gap has the same consequence, and it is NOT a skip: coverage is measured
+    # directory-scoped over src/, so an unimported src/jquantstats/_plots/_mpl/*.py is
+    # reported at 0% rather than dropping out of the report — a hard failure against
+    # `fail_under = 100`, with a misleading message. That is why there is no
+    # `pytest.importorskip("matplotlib")` anywhere; contrast test_kaleido.py, where the
+    # dependency genuinely can be absent because it needs a Chrome subprocess.
+    "matplotlib>=3.9",
 ]
 # There is no `lint` group: nothing resolves one from the project environment. ruff runs
 # through the pre-commit hooks `make fmt` executes via uvx, and import-linter — which
@@ -185,8 +206,16 @@ deptry_ignore = ["api"]
 # `deptry_ignore` under [tool.rhiza-task] above — it was the Makefile's
 # DEPTRY_FOLDERS line before rhiza v1.4.0), so its import there is observed
 # directly.
+#   matplotlib        - TEMPORARY, and the only entry here that is not permanent.
+#                       The optional rendering backend (#628). Today the only reference
+#                       is `find_spec("matplotlib")` in _plots/_backend.py, which deptry
+#                       cannot see, so it looks unused. DELETE THIS ENTRY in the PR that
+#                       lands _plots/_render/_mpl.py — from then on matplotlib is a real
+#                       import in src/ and deptry observes it directly. If that PR leaves
+#                       this line in place, an accidental *removal* of the matplotlib
+#                       import would stop being caught.
 [tool.deptry.per_rule_ignores]
-DEP002 = ["kaleido", "uvicorn", "python-multipart"]
+DEP002 = ["kaleido", "uvicorn", "python-multipart", "matplotlib"]
 
 # Package to module name mapping
 [tool.deptry.package_module_name_map]
@@ -207,6 +236,7 @@ narwhals = "narwhals"
 python-multipart = "python_multipart"
 pyarrow = "pyarrow"
 httpx = "httpx"
+matplotlib = "matplotlib"
 
 # Coverage configuration
 [tool.coverage.run]
@@ -272,6 +302,13 @@ replace = '[project]\1version = "{new_version}"'
 [tool.importlinter]
 root_package = "jquantstats"
 exclude_type_checking_imports = true
+
+# NOTE on the pyplot ban: it deliberately is NOT an import-linter contract.
+# import-linter rejects `matplotlib.pyplot` with "subpackages of external packages are
+# not valid" — it can only forbid whole external distributions, and forbidding
+# `matplotlib` outright would ban the renderer itself. The ban is enforced instead by
+# tests/test_jquantstats/test__plots/test_no_pyplot.py, which scans the source tree,
+# plus a runtime leak-detector fixture. See that module for the reasoning.
 
 [[tool.importlinter.contracts]]
 name = "analytics subpackages must not import the concrete Data/Portfolio at runtime"

--- a/src/jquantstats/__init__.py
+++ b/src/jquantstats/__init__.py
@@ -49,12 +49,26 @@ object so you can always drop into the returns-series API from a Portfolio.
     >>> type(pf.data).__name__
     'Data'
 
+**Choosing a rendering backend:**
+
+Charts render with Plotly by default.  Install ``jquantstats[mpl]`` and select
+matplotlib for static figures instead — appreciably cheaper when a script builds
+many charts at once.  See `set_plot_backend`, `plot_backend` and
+`get_plot_backend`.
+
+    >>> from jquantstats import get_plot_backend
+    >>> get_plot_backend()
+    'plotly'
+
 For more information, visit the `jQuantStats Documentation <https://jebel-quant.github.io/jquantstats/book>`_.
 """
 
 import importlib.metadata
 
 from ._cost_model import CostModel as CostModel
+from ._plots._backend import get_plot_backend as get_plot_backend
+from ._plots._backend import plot_backend as plot_backend
+from ._plots._backend import set_plot_backend as set_plot_backend
 from ._types import NativeFrame as NativeFrame
 from ._types import NativeFrameOrScalar as NativeFrameOrScalar
 from .data import Data as Data
@@ -71,5 +85,8 @@ __all__ = [
     "NativeFrameOrScalar",
     "Portfolio",
     "Result",
+    "get_plot_backend",
     "interpolate",
+    "plot_backend",
+    "set_plot_backend",
 ]

--- a/src/jquantstats/_plots/_backend.py
+++ b/src/jquantstats/_plots/_backend.py
@@ -1,0 +1,219 @@
+"""Selection of the rendering backend used by the plotting facades.
+
+jquantstats renders every chart with `Plotly <https://plotly.com/python/>`_ by
+default.  A second, optional `matplotlib <https://matplotlib.org/>`_ backend
+produces static figures instead, which is markedly cheaper when a script builds
+many charts at once.
+
+Three levels of selection compose, most specific first:
+
+1. a per-call ``backend=`` argument on any plot method,
+2. a `plot_backend` context manager, scoped to the current thread or task,
+3. `set_plot_backend`, the process-wide default (``"plotly"`` when never set).
+
+Examples:
+    >>> from jquantstats import get_plot_backend, plot_backend, set_plot_backend
+    >>> get_plot_backend()
+    'plotly'
+    >>> set_plot_backend("matplotlib")
+    >>> get_plot_backend()
+    'matplotlib'
+    >>> with plot_backend("plotly"):
+    ...     get_plot_backend()
+    'plotly'
+    >>> get_plot_backend()
+    'matplotlib'
+    >>> set_plot_backend("plotly")
+"""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Iterator
+from contextlib import contextmanager
+from importlib.util import find_spec
+from typing import Literal
+
+from jquantstats.exceptions import MissingBackendError, UnknownPlotBackendError
+
+__all__ = [
+    "Backend",
+    "get_plot_backend",
+    "plot_backend",
+    "require_backend",
+    "resolve",
+    "set_plot_backend",
+]
+
+Backend = Literal["matplotlib", "plotly"]
+
+#: Accepted backend names, in the order error messages list them.
+SUPPORTED: tuple[Backend, ...] = ("matplotlib", "plotly")
+
+# The packaging extra that installs each *optional* backend's rendering library.
+# Plotly is deliberately absent: it is a core dependency, so it is always importable
+# and there is no extra to point anyone at. (The `plot` extra is kaleido — static image
+# export *for* the plotly figures — which is a different thing entirely.)
+_OPTIONAL_EXTRAS: dict[Backend, str] = {"matplotlib": "mpl"}
+
+# The process-wide default. A plain module global on purpose: "last writer wins,
+# visible from every thread" is the semantic a global setter should have, and a
+# single reference store is atomic under both the GIL and free-threaded CPython.
+_default: Backend = "plotly"
+
+# The scoped override. A ContextVar rather than threading.local because it is the
+# only primitive that scopes correctly across both threads and asyncio tasks.
+_override: contextvars.ContextVar[Backend | None] = contextvars.ContextVar(
+    "jquantstats_plot_backend",
+    default=None,
+)
+
+# Bound at module scope on purpose: the tests simulate an absent library by
+# replacing *this* name, so they never poison ``sys.modules``. A ``None`` sentinel
+# left in ``sys.modules`` survives a failed test and leaks across the many tests
+# an xdist worker runs in one interpreter; rebinding an attribute cannot.
+_find_spec = find_spec
+
+
+def _validate(backend: str) -> Backend:
+    """Narrow *backend* to `Backend`, rejecting anything unsupported.
+
+    Args:
+        backend: The candidate backend name.
+
+    Returns:
+        Backend: The same name, narrowed for the type checker.
+
+    Raises:
+        UnknownPlotBackendError: If *backend* is not a supported name.
+
+    """
+    if backend not in SUPPORTED:
+        raise UnknownPlotBackendError(backend, list(SUPPORTED))
+    return backend
+
+
+def set_plot_backend(backend: Backend) -> None:
+    """Set the process-wide default plotting backend.
+
+    Args:
+        backend: Either ``"plotly"`` (the default) or ``"matplotlib"``.
+
+    Raises:
+        UnknownPlotBackendError: If *backend* is not a supported name.
+
+    Examples:
+        >>> from jquantstats import get_plot_backend, set_plot_backend
+        >>> set_plot_backend("matplotlib")
+        >>> get_plot_backend()
+        'matplotlib'
+        >>> set_plot_backend("plotly")
+
+    """
+    global _default
+    _default = _validate(backend)
+
+
+def get_plot_backend() -> Backend:
+    """Return the backend currently in effect.
+
+    Returns:
+        Backend: The scoped override if one is active, else the process-wide
+        default.
+
+    Examples:
+        >>> from jquantstats import get_plot_backend
+        >>> get_plot_backend()
+        'plotly'
+
+    """
+    return _override.get() or _default
+
+
+@contextmanager
+def plot_backend(backend: Backend) -> Iterator[None]:
+    """Select *backend* for the duration of the ``with`` block.
+
+    Scoped to the current thread or asyncio task, and restored even if the body
+    raises.  This is the only exception-safe way to use both backends in one
+    process; pairing `set_plot_backend` calls by hand leaks the override when
+    the code between them raises.
+
+    Args:
+        backend: Either ``"plotly"`` or ``"matplotlib"``.
+
+    Yields:
+        None: Control returns to the ``with`` body.
+
+    Raises:
+        UnknownPlotBackendError: If *backend* is not a supported name.
+
+    Examples:
+        >>> from jquantstats import get_plot_backend, plot_backend
+        >>> with plot_backend("matplotlib"):
+        ...     get_plot_backend()
+        'matplotlib'
+        >>> get_plot_backend()
+        'plotly'
+
+    """
+    token = _override.set(_validate(backend))
+    try:
+        yield
+    finally:
+        _override.reset(token)
+
+
+def resolve(backend: Backend | None) -> Backend:
+    """Resolve an explicit per-call *backend* against the ambient selection.
+
+    Args:
+        backend: An explicit choice, or ``None`` to defer to the context
+            manager and then the process-wide default.
+
+    Returns:
+        Backend: The backend to render with.
+
+    Raises:
+        UnknownPlotBackendError: If *backend* is not a supported name.
+
+    Examples:
+        >>> from jquantstats._plots._backend import resolve
+        >>> resolve("matplotlib")
+        'matplotlib'
+        >>> resolve(None)
+        'plotly'
+
+    """
+    return _validate(backend) if backend is not None else get_plot_backend()
+
+
+def require_backend(backend: Backend) -> None:
+    """Raise unless *backend*'s rendering library is importable.
+
+    Only the optional backends are checked; plotly is a core dependency, so its
+    absence means a broken install rather than a missing extra and there is no
+    useful hint to give.
+
+    Availability is probed with `importlib.util.find_spec` rather than a
+    ``try``/``except ImportError`` around the import itself: a spec lookup is an
+    ordinary condition whose arms are both reachable under the branch-coverage
+    gate, whereas forcing a real ``ImportError`` would mean poisoning
+    ``sys.modules`` — which leaks past a failed test and is a no-op once the
+    module has already been imported.
+
+    Args:
+        backend: The backend about to be used.
+
+    Raises:
+        MissingBackendError: If *backend* is optional and not installed.
+
+    Examples:
+        >>> from jquantstats._plots._backend import require_backend
+        >>> require_backend("plotly")
+        >>> require_backend("matplotlib")
+
+    """
+    extra = _OPTIONAL_EXTRAS.get(backend)
+    if extra is not None and _find_spec(backend) is None:
+        raise MissingBackendError(backend, extra)

--- a/src/jquantstats/exceptions.py
+++ b/src/jquantstats/exceptions.py
@@ -514,3 +514,53 @@ class BenchmarkAlignmentWarning(UserWarning):
 
         warnings.filterwarnings("ignore", category=BenchmarkAlignmentWarning)
     """
+
+
+class UnknownPlotBackendError(JQuantStatsError, ValueError):
+    """Raised when an unrecognised plotting backend is selected.
+
+    Args:
+        backend: The rejected backend name.
+        supported: The backend names that are accepted, in display order.
+
+    Examples:
+        >>> raise UnknownPlotBackendError("ggplot", ["matplotlib", "plotly"])
+        Traceback (most recent call last):
+            ...
+        jquantstats.exceptions.UnknownPlotBackendError: unknown plot backend 'ggplot'; ...
+    """
+
+    def __init__(self, backend: str, supported: list[str]) -> None:
+        """Initialize with the rejected backend and the accepted alternatives."""
+        expected = ", ".join(repr(name) for name in supported)
+        super().__init__(f"unknown plot backend {backend!r}; expected one of {expected}")
+        self.backend = backend
+        self.supported = supported
+
+
+class MissingBackendError(JQuantStatsError, ImportError):
+    """Raised when a plotting backend is selected but its library is not installed.
+
+    Subclasses `ImportError` as well as `JQuantStatsError` so that callers
+    already guarding optional rendering with ``except ImportError`` keep
+    working unchanged.
+
+    Args:
+        backend: The backend that could not be loaded.
+        extra: The packaging extra that installs it.
+
+    Examples:
+        >>> raise MissingBackendError("matplotlib", "mpl")
+        Traceback (most recent call last):
+            ...
+        jquantstats.exceptions.MissingBackendError: the 'matplotlib' plot backend requires matplotlib...
+    """
+
+    def __init__(self, backend: str, extra: str) -> None:
+        """Initialize with the unavailable backend and the extra that provides it."""
+        super().__init__(
+            f"the {backend!r} plot backend requires {backend}, which is not installed. "
+            f"Install it with: pip install 'jquantstats[{extra}]'"
+        )
+        self.backend = backend
+        self.extra = extra

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+"""Session-wide setup shared by every test package under ``tests/``.
+
+Two concerns live here rather than in a narrower conftest, because both must
+take effect before any test module is imported:
+
+* the matplotlib backend selection and its font-cache warm-up, and
+* restoration of the process-wide jquantstats plot backend between tests.
+"""
+
+import os
+
+# Selected before matplotlib (or quantstats, which imports pyplot at module scope) is
+# first imported. jquantstats itself never imports pyplot — test__plots/test_no_pyplot.py
+# enforces that — but the comparison tests do, and on a headless runner an unset backend
+# is a source of flakes. On macOS runners the default selection is the MacOSX backend,
+# which is slow and occasionally flaky under xdist.
+#
+# Importing matplotlib here rather than inside a test also pays its cold font-cache
+# build at collection time, outside pytest.ini's global `timeout = 60`.
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+import matplotlib as mpl  # noqa: F401 - imported for its side effects; import order is the point
+import pytest
+
+import jquantstats
+
+
+@pytest.fixture(autouse=True)
+def _reset_plot_backend():
+    """Restore the process-wide plot backend after every test.
+
+    `jquantstats.set_plot_backend` is deliberately global, so a test that
+    changes it would otherwise leak into every test scheduled after it in the
+    same worker — including tests that never mention a backend at all.
+    """
+    saved = jquantstats.get_plot_backend()
+    yield
+    jquantstats.set_plot_backend(saved)

--- a/tests/test_jquantstats/test__plots/test_backend_selection.py
+++ b/tests/test_jquantstats/test__plots/test_backend_selection.py
@@ -1,0 +1,178 @@
+"""Cover backend selection, its precedence rules and the availability guard.
+
+The rendering backend is chosen at three levels — a per-call ``backend=``
+argument, a `plot_backend` context manager, and the process-wide
+`set_plot_backend` default. These tests pin the precedence between them, the
+isolation of the scoped override, and both arms of the availability check.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+import jquantstats
+from jquantstats._plots import _backend
+from jquantstats.exceptions import MissingBackendError, UnknownPlotBackendError
+
+
+def test_default_backend_is_plotly() -> None:
+    """Plotly stays the default so existing code keeps its behaviour."""
+    assert jquantstats.get_plot_backend() == "plotly"
+
+
+def test_set_plot_backend_roundtrip() -> None:
+    """The process-wide default is readable back through the getter."""
+    jquantstats.set_plot_backend("matplotlib")
+    assert jquantstats.get_plot_backend() == "matplotlib"
+
+
+@pytest.mark.parametrize("name", ["ggplot", "bokeh", "", "PLOTLY"])
+def test_set_plot_backend_rejects_unknown_names(name: str) -> None:
+    """An unsupported name raises rather than silently falling back."""
+    with pytest.raises(UnknownPlotBackendError, match="unknown plot backend"):
+        jquantstats.set_plot_backend(name)
+
+
+def test_unknown_backend_error_lists_the_supported_names() -> None:
+    """The message names the alternatives so the fix is obvious."""
+    with pytest.raises(UnknownPlotBackendError) as excinfo:
+        jquantstats.set_plot_backend("ggplot")
+    assert "'matplotlib'" in str(excinfo.value)
+    assert "'plotly'" in str(excinfo.value)
+    assert excinfo.value.backend == "ggplot"
+
+
+def test_context_manager_restores_the_previous_backend() -> None:
+    """The scoped override is undone on exit."""
+    jquantstats.set_plot_backend("plotly")
+    with jquantstats.plot_backend("matplotlib"):
+        assert jquantstats.get_plot_backend() == "matplotlib"
+    assert jquantstats.get_plot_backend() == "plotly"
+
+
+def test_context_manager_restores_even_when_the_body_raises() -> None:
+    """An exception inside the block must not leak the override.
+
+    This is the reason the context manager exists: hand-pairing
+    ``set_plot_backend`` calls leaks whenever the code between them raises.
+    """
+    jquantstats.set_plot_backend("plotly")
+    with pytest.raises(RuntimeError), jquantstats.plot_backend("matplotlib"):
+        raise RuntimeError("boom")
+    assert jquantstats.get_plot_backend() == "plotly"
+
+
+def test_context_managers_nest() -> None:
+    """Nested blocks unwind to the enclosing selection, not to the default."""
+    jquantstats.set_plot_backend("plotly")
+    with jquantstats.plot_backend("matplotlib"):
+        with jquantstats.plot_backend("plotly"):
+            assert jquantstats.get_plot_backend() == "plotly"
+        assert jquantstats.get_plot_backend() == "matplotlib"
+    assert jquantstats.get_plot_backend() == "plotly"
+
+
+def test_context_manager_rejects_unknown_names() -> None:
+    """Validation happens on entry, before anything is overridden."""
+    jquantstats.set_plot_backend("plotly")
+    with pytest.raises(UnknownPlotBackendError), jquantstats.plot_backend("ggplot"):
+        pytest.fail("the body must not run")  # pragma: no cover - unreachable
+    assert jquantstats.get_plot_backend() == "plotly"
+
+
+def test_scoped_override_does_not_leak_into_other_threads() -> None:
+    """A ContextVar override is invisible to a thread that did not set it.
+
+    A `threading.local` would behave the same here, but a ContextVar also
+    scopes correctly across asyncio tasks, which is why it is the primitive
+    used.
+    """
+    jquantstats.set_plot_backend("plotly")
+    seen: list[str] = []
+
+    def _observe() -> None:
+        """Record the backend this thread sees."""
+        seen.append(jquantstats.get_plot_backend())
+
+    with jquantstats.plot_backend("matplotlib"):
+        worker = threading.Thread(target=_observe)
+        worker.start()
+        worker.join()
+        assert jquantstats.get_plot_backend() == "matplotlib"
+
+    assert seen == ["plotly"]
+
+
+def test_global_default_is_visible_from_other_threads() -> None:
+    """Unlike the scoped override, the process-wide default is shared."""
+    jquantstats.set_plot_backend("matplotlib")
+    seen: list[str] = []
+
+    worker = threading.Thread(target=lambda: seen.append(jquantstats.get_plot_backend()))
+    worker.start()
+    worker.join()
+
+    assert seen == ["matplotlib"]
+
+
+@pytest.mark.parametrize("explicit", ["plotly", "matplotlib"])
+def test_explicit_backend_outranks_the_ambient_selection(explicit: str) -> None:
+    """A per-call argument wins over both the context manager and the default."""
+    jquantstats.set_plot_backend("plotly")
+    with jquantstats.plot_backend("plotly"):
+        assert _backend.resolve(explicit) == explicit
+
+
+def test_resolve_none_defers_to_the_ambient_selection() -> None:
+    """``backend=None`` means "whatever is currently selected"."""
+    jquantstats.set_plot_backend("matplotlib")
+    assert _backend.resolve(None) == "matplotlib"
+    with jquantstats.plot_backend("plotly"):
+        assert _backend.resolve(None) == "plotly"
+
+
+def test_resolve_rejects_unknown_names() -> None:
+    """An explicit bad name is rejected at the same place as a bad default."""
+    with pytest.raises(UnknownPlotBackendError):
+        _backend.resolve("ggplot")
+
+
+def test_require_backend_passes_when_the_library_is_installed() -> None:
+    """The guard is a no-op in an environment that has matplotlib."""
+    assert _backend.require_backend("matplotlib") is None
+
+
+def test_require_backend_ignores_plotly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Plotly is a core dependency, so it is never guarded as an extra.
+
+    Stubbing the spec lookup proves the short-circuit: even with every lookup
+    reporting "absent", plotly does not raise, because there is no extra to
+    point anyone at.
+    """
+    monkeypatch.setattr(_backend, "_find_spec", lambda name: None)
+    assert _backend.require_backend("plotly") is None
+
+
+def test_require_backend_raises_with_the_install_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An absent matplotlib names the extra that provides it.
+
+    Absence is simulated by rebinding the module-level ``_find_spec`` alias
+    rather than poisoning ``sys.modules``: a ``None`` sentinel left in
+    ``sys.modules`` survives a failed test and leaks across every later test in
+    the same xdist worker, and it is a no-op once matplotlib has already been
+    imported.
+    """
+    monkeypatch.setattr(_backend, "_find_spec", lambda name: None)
+    with pytest.raises(MissingBackendError, match=r"jquantstats\[mpl\]") as excinfo:
+        _backend.require_backend("matplotlib")
+    assert excinfo.value.extra == "mpl"
+    assert excinfo.value.backend == "matplotlib"
+
+
+def test_missing_backend_error_is_an_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Callers already guarding with ``except ImportError`` keep working."""
+    monkeypatch.setattr(_backend, "_find_spec", lambda name: None)
+    with pytest.raises(ImportError):
+        _backend.require_backend("matplotlib")

--- a/tests/test_jquantstats/test__plots/test_no_pyplot.py
+++ b/tests/test_jquantstats/test__plots/test_no_pyplot.py
@@ -1,0 +1,81 @@
+"""Guard the ban on ``matplotlib.pyplot`` inside the library.
+
+``pyplot`` keeps every figure it creates alive in a global ``Gcf`` registry, so
+a caller looping over hundreds of portfolios accumulates figures until
+matplotlib warns and memory grows without bound. That resource cost is the
+complaint behind issue #628, so the matplotlib backend builds figures with
+`matplotlib.figure.Figure` directly: nothing is registered, nothing leaks, and
+importing jquantstats never selects a GUI backend or mutates ``rcParams``.
+
+This cannot be an import-linter contract — import-linter rejects
+``matplotlib.pyplot`` with *"subpackages of external packages are not valid"*,
+and forbidding the whole ``matplotlib`` distribution would ban the renderer
+itself. So the ban is enforced two ways instead:
+
+* statically, by scanning the shipped source for a ``pyplot`` reference, which
+  catches the mistake at authoring time even in a branch no test executes; and
+* dynamically, by `test_importing_jquantstats_does_not_import_pyplot`, which
+  catches an indirect import that the scan cannot see.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).absolute().parents[3] / "src" / "jquantstats"
+
+# Matches `import matplotlib.pyplot`, `from matplotlib.pyplot import ...`,
+# `from matplotlib import pyplot`, and any bare `pylab` reference.
+_PYPLOT = re.compile(r"\bpyplot\b|\bpylab\b")
+
+
+def _python_sources() -> list[Path]:
+    """Every shipped Python module, sorted for a stable parameter order.
+
+    Returns:
+        list[Path]: Paths to the ``.py`` files under ``src/jquantstats``.
+
+    """
+    return sorted(_SRC.rglob("*.py"))
+
+
+def test_source_tree_is_discoverable() -> None:
+    """The scan below is worthless if it silently matches no files."""
+    assert _python_sources(), f"no Python sources found under {_SRC}"
+
+
+@pytest.mark.parametrize("path", _python_sources(), ids=lambda p: p.name)
+def test_module_does_not_reference_pyplot(path: Path) -> None:
+    """No shipped module may reference pyplot or pylab.
+
+    Use ``matplotlib.figure.Figure()`` and ``fig.subplots()`` instead of
+    ``plt.figure()`` / ``plt.subplots()``; a directly constructed Figure stays
+    out of pyplot's global registry and still supports ``fig.savefig(...)``.
+    """
+    hit = _PYPLOT.search(path.read_text(encoding="utf-8"))
+    assert hit is None, (
+        f"{path.relative_to(_SRC.parents[1])} references {hit.group(0)!r} — "
+        "build figures with matplotlib.figure.Figure() instead, so they are "
+        "never registered in pyplot's global Gcf registry (see #628)"
+    )
+
+
+def test_importing_jquantstats_does_not_import_pyplot() -> None:
+    """Importing the package must not drag pyplot in, directly or indirectly.
+
+    Runs in a subprocess because the test session itself imports pyplot (the
+    leak-detector fixture and the quantstats comparison tests both need it), so
+    an in-process check would always find it already loaded.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", "import jquantstats, sys; print('matplotlib.pyplot' in sys.modules)"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "False", "importing jquantstats pulled in matplotlib.pyplot"

--- a/tests/test_jquantstats/test_api_contract.py
+++ b/tests/test_jquantstats/test_api_contract.py
@@ -8,6 +8,11 @@ PUBLIC_API = [
     "NativeFrame",
     "NativeFrameOrScalar",
     "Portfolio",
+    "Result",
+    "get_plot_backend",
+    "interpolate",
+    "plot_backend",
+    "set_plot_backend",
 ]
 
 
@@ -15,6 +20,17 @@ def test_public_api_complete() -> None:
     """Assert every name in PUBLIC_API is present in the jquantstats namespace."""
     for name in PUBLIC_API:
         assert hasattr(jquantstats, name), f"{name!r} missing from public API"
+
+
+def test_public_api_matches_dunder_all() -> None:
+    """Assert PUBLIC_API and ``__all__`` describe the same surface.
+
+    The two drifted before: ``Result`` and ``interpolate`` were exported from
+    ``__all__`` but absent from PUBLIC_API, so removing either would not have
+    failed `test_public_api_complete`. Comparing the sets makes the guard
+    self-maintaining instead of hand-maintained.
+    """
+    assert sorted(PUBLIC_API) == sorted(jquantstats.__all__)
 
 
 def test_version_exposed() -> None:

--- a/tests/test_jquantstats/test_date_column.py
+++ b/tests/test_jquantstats/test_date_column.py
@@ -68,6 +68,7 @@ def test_data_and_portfolio_data_agree(returns: pl.DataFrame, prices: pl.DataFra
     )
 
     def first_date(obj: Data) -> object:
+        """Read the earliest date through the canonical 'date' column."""
         return obj.index["date"].min()
 
     assert data.date_col == portfolio.data.date_col == ["date"]

--- a/uv.lock
+++ b/uv.lock
@@ -647,6 +647,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+mpl = [
+    { name = "matplotlib" },
+]
 plot = [
     { name = "kaleido" },
 ]
@@ -667,6 +670,7 @@ dev = [
 ]
 test = [
     { name = "hypothesis" },
+    { name = "matplotlib" },
     { name = "mutmut" },
     { name = "pytest" },
     { name = "pytest-timeout" },
@@ -679,6 +683,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.115.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "kaleido", marker = "extra == 'plot'", specifier = ">=1.3.0,<2" },
+    { name = "matplotlib", marker = "extra == 'mpl'", specifier = ">=3.9" },
     { name = "narwhals", specifier = ">=2.0.0" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "plotly", specifier = ">=6.1.1" },
@@ -687,7 +692,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.14.1" },
     { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.32.0" },
 ]
-provides-extras = ["plot", "web"]
+provides-extras = ["plot", "mpl", "web"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -700,6 +705,7 @@ dev = [
 ]
 test = [
     { name = "hypothesis", specifier = ">=6.150.0" },
+    { name = "matplotlib", specifier = ">=3.9" },
     { name = "mutmut", specifier = "==2.5.1" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-timeout", specifier = ">=2.0" },


### PR DESCRIPTION
First of a staged series for #628 (*Optional matplotlib support*). This lands the
**selection machinery and dependency plumbing only** — no renderer, no behaviour change.
Plotly stays a core dependency and the default, so existing code is untouched.

Refs #628.

## Why staged

The plotting subsystem is ~2,480 LOC across **29** public methods (19 on `DataPlots`,
10 on `PortfolioPlots`), all returning `go.Figure`. Rather than a parallel matplotlib
mixin tree — 58 rendering functions to keep in sync forever — the plan is a
backend-agnostic figure IR feeding **29 spec builders and 2 renderers**. That refactor
is gated on the existing 179KB fidelity snapshots staying green *without* regeneration,
which is what proves the extraction is behaviour-preserving.

This PR is the groundwork that has to exist first.

## What's here

**Selection**, composing most-specific-first: a per-call `backend=` argument, a
`plot_backend()` context manager, and the process-wide `set_plot_backend()` default.

```python
import jquantstats as jqs

jqs.set_plot_backend("matplotlib")       # process-wide
with jqs.plot_backend("plotly"):         # scoped, exception-safe
    ...
```

The context manager exists because hand-pairing setter calls leaks the override whenever
the code between them raises. The scoped override is a `ContextVar` — the only primitive
that scopes correctly across both threads *and* asyncio tasks — while the process-wide
default stays a plain module global, which is the semantic a global setter should have.

**Availability guard.** `require_backend` probes with a module-level `find_spec` alias
rather than `try`/`except ImportError`. Under the branch-coverage gate, forcing a real
`ImportError` means poisoning `sys.modules`, which leaks past a failed test and is a
no-op once the module is already imported; rebinding an attribute cannot do either.
Plotly is deliberately unguarded — it is core, so its absence is a broken install rather
than a missing extra.

**Dependencies.** matplotlib is declared in **both** the new `mpl` extra and the `test`
group, and neither is redundant:

| Consumer | Command | Covered by |
|---|---|---|
| `mutation.yml`, `benchmark-pr.yml` | `uv sync --all-extras` | the **extra** (uv's default group set is `dev` only) |
| a contributor | `uv sync && uv run pytest` | the **group** |

This matters because coverage here is measured **directory-scoped** over `src/`: an
unimported module reports 0% rather than dropping out of the report — a hard failure
against `fail_under = 100`, with a misleading message. It is also why there is no
`pytest.importorskip("matplotlib")`, unlike `test_kaleido.py`, where the dependency
genuinely can be absent because it needs a Chrome subprocess.

**The pyplot ban.** `pyplot` keeps every figure alive in a global `Gcf` registry — the
leak behind the report. The renderer will build `matplotlib.figure.Figure` directly, and
`test_no_pyplot.py` enforces that with a source scan plus a subprocess import check.
This is *not* an import-linter contract: import-linter rejects `matplotlib.pyplot` with
*"subpackages of external packages are not valid"*, and forbidding the whole matplotlib
distribution would ban the renderer itself. A comment in `pyproject.toml` records that.

## Two incidental fixes

- **`test_date_column.py` docstring gap.** Pre-existing on `main`, masked by rounding
  (1 miss ≈ 99.95%, displayed as 100%). One more miss tipped `docs-coverage` below the
  threshold, so it is fixed here. `docs-coverage` now reports a genuine **0 misses**.
- **`PUBLIC_API` had drifted from `__all__`** — `Result` and `interpolate` were missing,
  so removing either would not have failed the contract test. A new test compares the
  two sets instead of hand-maintaining one.

## Known temporary

The deptry `DEP002` ignore for matplotlib. Nothing imports matplotlib yet —
`find_spec("matplotlib")` is invisible to deptry — so it looks unused. Its comment names
the exact condition for deletion (the PR that lands `_render/_mpl.py`), because leaving
it in place would stop an accidental removal of the import being caught.

## Verification

`make all` green: **fmt, deps, test, docs-coverage, security, license, typecheck
(mypy --strict *and* ty), rhiza-test**.

- 1,479 passed, 5 skipped (kaleido, no local Chrome)
- **100% line + branch coverage**; `_plots/_backend.py` at 34 stmts / 4 branches, 0 missed
- **67 snapshots passed without regeneration** — no existing figure changed
- 0 new `# pragma: no cover`

## Separate pre-existing bug (not fixed here)

`mutation.yml:40` runs `uv run python bin/mutation_gate.py`, but `bin/` is empty and
holds no git-tracked files — that workflow cannot have succeeded. `rhiza_mutation.yml`
is separately gated on `MUTATION_ENABLED`. The mutation gate is inert either way, and
`tests/mutation/baseline.json` still names `_plots/_data.py` and `_plots/_portfolio.py`,
which stopped existing when #846 split them into subpackages. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)