### PR TITLE
Introduce the figure spec and route the cumulative charts through it (#628)

### DIFF
--- a/src/jquantstats/_plots/_data/_cumulative.py
+++ b/src/jquantstats/_plots/_data/_cumulative.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING
 
 import plotly.graph_objects as go
-import polars as pl
 
-from ._styling import _apply_base_layout, _apply_figsize, _ticker_colors
+from .._render import render_plotly
+from .._specs import compare_spec, cumulative_returns_spec, earnings_spec, log_returns_spec
 
 if TYPE_CHECKING:
     from jquantstats._protocol import DataLike
@@ -35,31 +34,7 @@ class _CumulativePlotsMixin:
             go.Figure: Interactive Plotly line chart.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        colors = _ticker_colors(tickers)
-
-        prices = df.with_columns([(1.0 + pl.col(t)).cum_prod().alias(t) for t in tickers])
-
-        fig = go.Figure()
-        for ticker in tickers:
-            fig.add_trace(
-                go.Scatter(
-                    x=prices[date_col],
-                    y=prices[ticker],
-                    mode="lines",
-                    name=ticker,
-                    line={"color": colors[ticker], "width": 2},
-                    hovertemplate=f"<b>%{{x|%b %Y}}</b><br>{ticker}: %{{y:.2f}}x",
-                )
-            )
-
-        _apply_base_layout(fig, title)
-        fig.update_yaxes(title_text="Cumulative Return", tickformat=".2f")
-        if log_scale:
-            fig.update_yaxes(type="log")
-        return fig
+        return render_plotly(cumulative_returns_spec(self._data, title=title, log_scale=log_scale))
 
     def compare(self, title: str = "Comparison vs Benchmark", figsize: tuple[int, int] | None = None) -> go.Figure:
         """Compare cumulative returns of each asset against the benchmark.
@@ -75,47 +50,7 @@ class _CumulativePlotsMixin:
             AttributeError: If no benchmark data is available.
 
         """
-        benchmark_df = getattr(self._data, "benchmark", None)
-        if benchmark_df is None:
-            raise AttributeError("compare() requires benchmark data to be set")  # noqa: TRY003
-
-        df = self._data.all
-        date_col = df.columns[0]
-        assets = list(self._data.returns.columns)
-        benchmarks = list(benchmark_df.columns)
-
-        series = assets + benchmarks
-        colors = _ticker_colors(series)
-        prices = df.with_columns([(1.0 + pl.col(col)).cum_prod().alias(col) for col in series])
-
-        fig = go.Figure()
-        for asset in assets:
-            fig.add_trace(
-                go.Scatter(
-                    x=prices[date_col],
-                    y=prices[asset],
-                    mode="lines",
-                    name=asset,
-                    line={"color": colors[asset], "width": 2},
-                    hovertemplate=f"<b>%{{x|%b %Y}}</b><br>{asset}: %{{y:.2f}}x",
-                )
-            )
-        for benchmark in benchmarks:
-            fig.add_trace(
-                go.Scatter(
-                    x=prices[date_col],
-                    y=prices[benchmark],
-                    mode="lines",
-                    name=benchmark,
-                    line={"color": colors[benchmark], "width": 2.5, "dash": "dash"},
-                    hovertemplate=f"<b>%{{x|%b %Y}}</b><br>{benchmark}: %{{y:.2f}}x",
-                )
-            )
-
-        _apply_base_layout(fig, title)
-        _apply_figsize(fig, figsize)
-        fig.update_yaxes(title_text="Cumulative Return", tickformat=".2f")
-        return fig
+        return render_plotly(compare_spec(self._data, title=title, figsize=figsize))
 
     def log_returns(self, title: str = "Log Returns", figsize: tuple[int, int] | None = None) -> go.Figure:
         """Cumulative log returns over time.
@@ -132,30 +67,7 @@ class _CumulativePlotsMixin:
             go.Figure: Interactive Plotly line chart.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        colors = _ticker_colors(tickers)
-
-        log_prices = df.with_columns([(1.0 + pl.col(t)).cum_prod().log(math.e).alias(t) for t in tickers])
-
-        fig = go.Figure()
-        for ticker in tickers:
-            fig.add_trace(
-                go.Scatter(
-                    x=log_prices[date_col],
-                    y=log_prices[ticker],
-                    mode="lines",
-                    name=ticker,
-                    line={"color": colors[ticker], "width": 2},
-                    hovertemplate=f"<b>%{{x|%b %Y}}</b><br>{ticker}: %{{y:.4f}}",
-                )
-            )
-
-        _apply_base_layout(fig, title)
-        _apply_figsize(fig, figsize)
-        fig.update_yaxes(title_text="Log Return")
-        return fig
+        return render_plotly(log_returns_spec(self._data, title=title, figsize=figsize))
 
     def earnings(
         self,
@@ -179,33 +91,4 @@ class _CumulativePlotsMixin:
             go.Figure: Interactive Plotly line chart.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        colors = _ticker_colors(tickers)
-
-        if compounded:
-            equity = df.with_columns([(start_balance * (1.0 + pl.col(t)).cum_prod()).alias(t) for t in tickers])
-        else:
-            equity = df.with_columns([(start_balance * (1.0 + pl.col(t).cum_sum())).alias(t) for t in tickers])
-
-        fig = go.Figure()
-        for ticker in tickers:
-            fig.add_trace(
-                go.Scatter(
-                    x=equity[date_col],
-                    y=equity[ticker],
-                    mode="lines",
-                    name=ticker,
-                    line={"color": colors[ticker], "width": 2},
-                    hovertemplate=f"<b>%{{x|%b %Y}}</b><br>{ticker}: $%{{y:,.0f}}",
-                )
-            )
-
-        _apply_base_layout(fig, title)
-        fig.update_yaxes(
-            title_text=f"Portfolio Value (starting ${start_balance:,.0f})",
-            tickprefix="$",
-            tickformat=",.0f",
-        )
-        return fig
+        return render_plotly(earnings_spec(self._data, start_balance=start_balance, title=title, compounded=compounded))

--- a/src/jquantstats/_plots/_data/_styling.py
+++ b/src/jquantstats/_plots/_data/_styling.py
@@ -1,41 +1,30 @@
-"""Shared styling and figure-layout helpers for the data plots."""
+"""Shared styling and figure-layout helpers for the data plots.
+
+The colour helpers here are re-exported from `jquantstats._plots._style`, which
+is where they now live: choosing a colour is backend-neutral, whereas applying a
+Plotly layout is not. The aliases keep the plot families that have not yet moved
+to the spec/renderer split working against a single definition.
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
-import plotly.express as px
 import plotly.graph_objects as go
 
+from .._style import hex_to_rgba as _hex_to_rgba
+from .._style import ticker_colors as _ticker_colors
 
-def _hex_to_rgba(hex_color: str, alpha: float = 0.5) -> str:
-    """Convert a hex colour string to an RGBA CSS string.
-
-    Args:
-        hex_color: A hex colour string (with or without a leading ``#``).
-        alpha: Opacity in the range [0, 1]. Defaults to 0.5.
-
-    Returns:
-        An RGBA CSS string suitable for use in Plotly colour arguments.
-
-    """
-    hex_color = hex_color.lstrip("#")
-    r, g, b = tuple(int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
-    return f"rgba({r}, {g}, {b}, {alpha})"
-
-
-def _ticker_colors(tickers: list[str]) -> dict[str, str]:
-    """Map ticker names to Plotly qualitative palette colours.
-
-    Args:
-        tickers: Ordered list of ticker / column names.
-
-    Returns:
-        dict mapping each ticker to a hex colour string.
-
-    """
-    palette = px.colors.qualitative.Plotly
-    return {ticker: palette[i % len(palette)] for i, ticker in enumerate(tickers)}
+__all__ = [
+    "_apply_base_layout",
+    "_apply_figsize",
+    "_bar_colors",
+    "_compute_drawdown_periods",
+    "_date_range_selector",
+    "_hex_to_rgba",
+    "_ticker_colors",
+    "_yearly_bar_colors",
+]
 
 
 def _date_range_selector() -> dict[str, Any]:

--- a/src/jquantstats/_plots/_render/__init__.py
+++ b/src/jquantstats/_plots/_render/__init__.py
@@ -1,0 +1,10 @@
+"""Renderers turning a `~jquantstats._plots._spec.FigureSpec` into a figure.
+
+One module per backend. Backend *selection* lands with the matplotlib renderer;
+until there is a second backend to choose between, callers use `render_plotly`
+directly.
+"""
+
+from ._plotly import render_plotly as render_plotly
+
+__all__ = ["render_plotly"]

--- a/src/jquantstats/_plots/_render/_plotly.py
+++ b/src/jquantstats/_plots/_render/_plotly.py
@@ -1,0 +1,126 @@
+"""Render a `FigureSpec` with Plotly.
+
+This module owns every Plotly-specific decision: how a semantic
+`~jquantstats._plots._spec.TickFormat` becomes a d3 format string, how a
+`~jquantstats._plots._spec.HoverSpec` becomes a hovertemplate, and how the
+shared layout is applied.
+
+It deliberately reuses `_apply_base_layout` and `_apply_figsize` rather than
+restating what they do. Those helpers already produce the layout every chart in
+the package has, so routing through them is what lets a chart move onto the
+spec/renderer split without altering a single byte of its rendered output — the
+property the full-fidelity snapshot tests exist to pin.
+"""
+
+from __future__ import annotations
+
+import plotly.graph_objects as go
+
+from .._data._styling import _apply_base_layout, _apply_figsize
+from .._spec import Axis, FigureSpec, HoverSpec, LineSeries, TickFormat
+
+__all__ = ["render_plotly"]
+
+# Semantic tick format -> d3 format string, the vocabulary Plotly speaks.
+_D3_FORMATS: dict[TickFormat, str] = {
+    "float2": ".2f",
+    "float4": ".4f",
+    "currency0": ",.0f",
+}
+
+# Semantic dash style -> Plotly's `line.dash` vocabulary.
+_DASHES = {"solid": "solid", "dash": "dash"}
+
+
+def _hovertemplate(hover: HoverSpec) -> str:
+    """Build a Plotly hovertemplate from a structural hover description.
+
+    Args:
+        hover: What the tooltip should say.
+
+    Returns:
+        str: A hovertemplate string.
+
+    """
+    header = "<b>%{x|%b %Y}</b><br>" if hover.date_header else ""
+    value = f"%{{y:{_D3_FORMATS[hover.value_format]}}}"
+    return f"{header}{hover.label}: {hover.prefix}{value}{hover.suffix}"
+
+
+def _scatter(line: LineSeries) -> go.Scatter:
+    """Convert one line series into a Plotly scatter trace.
+
+    Args:
+        line: The series to draw.
+
+    Returns:
+        go.Scatter: The trace, styled per the series.
+
+    """
+    style: dict[str, object] = {"color": line.color, "width": line.width}
+    if line.dash != "solid":
+        style["dash"] = _DASHES[line.dash]
+
+    trace = go.Scatter(x=line.x, y=line.y, mode="lines", name=line.name, line=style)
+    if line.hover is not None:
+        trace.update(hovertemplate=_hovertemplate(line.hover))
+    return trace
+
+
+def _axis_kwargs(axis: Axis) -> dict[str, object]:
+    """Collect the axis properties a spec actually asked for.
+
+    Only requested properties are returned. Emitting a default for an untouched
+    property would change the serialised figure, which the fidelity snapshots
+    would (correctly) flag.
+
+    Args:
+        axis: The axis configuration.
+
+    Returns:
+        dict[str, object]: Keyword arguments for ``update_xaxes`` /
+        ``update_yaxes``.
+
+    """
+    kwargs: dict[str, object] = {}
+    if axis.title is not None:
+        kwargs["title_text"] = axis.title
+    if axis.tick_prefix:
+        kwargs["tickprefix"] = axis.tick_prefix
+    if axis.tick_format is not None:
+        kwargs["tickformat"] = _D3_FORMATS[axis.tick_format]
+    if axis.log:
+        kwargs["type"] = "log"
+    return kwargs
+
+
+def render_plotly(spec: FigureSpec) -> go.Figure:
+    """Render *spec* as an interactive Plotly figure.
+
+    Args:
+        spec: The chart to draw. Must describe exactly one panel; multi-panel
+            charts arrive with the dashboards.
+
+    Returns:
+        go.Figure: The rendered figure.
+
+    Raises:
+        ValueError: If *spec* does not contain exactly one panel.
+
+    """
+    (panel,) = spec.panels
+
+    fig = go.Figure()
+    for line in panel.lines:
+        fig.add_trace(_scatter(line))
+
+    _apply_base_layout(fig, spec.title, height=spec.height, with_range_selector=spec.date_range_selector)
+    _apply_figsize(fig, spec.figsize)
+
+    x_kwargs = _axis_kwargs(panel.xaxis)
+    if x_kwargs:
+        fig.update_xaxes(**x_kwargs)
+    y_kwargs = _axis_kwargs(panel.yaxis)
+    if y_kwargs:
+        fig.update_yaxes(**y_kwargs)
+    return fig

--- a/src/jquantstats/_plots/_spec.py
+++ b/src/jquantstats/_plots/_spec.py
@@ -1,0 +1,169 @@
+"""A backend-agnostic description of a chart.
+
+Every plot method in jquantstats is two separable jobs: prepare the numbers with
+polars, then hand them to a drawing library. The types here are the seam between
+those halves. A *spec builder* under `jquantstats._plots._specs` turns a dataset
+into a `FigureSpec`; a *renderer* under `jquantstats._plots._render` turns that
+`FigureSpec` into a Plotly or matplotlib figure.
+
+The point of the seam is arithmetic. Without it a second backend means a second
+copy of every rolling beta, drawdown scan and Monte Carlo path, and the two
+copies drift. With it there is one builder per chart and one renderer per
+backend.
+
+Nothing here may import a drawing library, and no field may hold a
+backend-specific value — no Plotly format strings, no matplotlib linestyle
+tuples. Where a visual property has to be named, it is named semantically
+(`"float2"`, `"dash"`) and each renderer maps it to its own vocabulary.
+
+**Series stay as `polars.Series`.** Plotly serialises a Series to a compact
+binary buffer and a Python list to a plain JSON array, so converting here would
+silently change every rendered figure. Renderers that need other containers
+convert at the point of use.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+import polars as pl
+
+__all__ = [
+    "Axis",
+    "Dash",
+    "FigureSpec",
+    "HoverSpec",
+    "LineSeries",
+    "Panel",
+    "TickFormat",
+]
+
+#: How to render a number, named by intent rather than by any backend's syntax.
+#:
+#: ``float2``/``float4`` are fixed-point to that many decimals; ``currency0`` is
+#: a thousands-separated integer. Each renderer owns the mapping — Plotly wants
+#: ``".2f"``, matplotlib wants a ``Formatter`` — so neither vocabulary leaks in
+#: here.
+TickFormat = Literal["float2", "float4", "currency0"]
+
+#: Line styles, kept to the set the charts actually use.
+Dash = Literal["solid", "dash"]
+
+
+@dataclass(frozen=True, slots=True)
+class HoverSpec:
+    """The tooltip shown when a pointer rests on a series.
+
+    Interactive-only, and therefore Plotly-only: matplotlib has no equivalent
+    and its renderer ignores this entirely. It is described structurally rather
+    than as a template string so that spec builders never write Plotly syntax.
+
+    Attributes:
+        label: Text naming the series, shown before the value.
+        value_format: How to render the value.
+        prefix: Written immediately before the value, e.g. a currency sign.
+        suffix: Written immediately after the value, e.g. ``"x"`` to mark a
+            growth multiple.
+        date_header: Show the x-value as a bold ``Mon YYYY`` heading above.
+
+    """
+
+    label: str
+    value_format: TickFormat
+    prefix: str = ""
+    suffix: str = ""
+    date_header: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class LineSeries:
+    """One line drawn across a panel.
+
+    Attributes:
+        name: Legend entry for the series.
+        x: Horizontal positions, typically the date column.
+        y: Vertical positions.
+        color: Line colour as ``#RRGGBB``; both backends accept that spelling.
+        width: Stroke width.
+        dash: Stroke pattern.
+        hover: Tooltip description, or None to leave the backend's default.
+
+    """
+
+    name: str
+    x: pl.Series
+    y: pl.Series
+    color: str
+    # Left as an int so a whole-number width serialises as `2` rather than
+    # `2.0`. Plotly preserves the distinction in its JSON, and the fidelity
+    # snapshots compare that JSON exactly.
+    width: float = 2
+    dash: Dash = "solid"
+    hover: HoverSpec | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Axis:
+    """Configuration for one axis of a panel.
+
+    Every field defaults to "leave it alone", so a renderer sets only what a
+    builder asked for. That matters for fidelity: emitting a property the
+    original chart never set would change the rendered output.
+
+    Attributes:
+        title: Axis label, or None for no label.
+        tick_format: How to render tick values, or None for the default.
+        tick_prefix: Written before each tick value, e.g. a currency sign.
+        log: Use a logarithmic scale.
+
+    """
+
+    title: str | None = None
+    tick_format: TickFormat | None = None
+    tick_prefix: str = ""
+    log: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class Panel:
+    """One set of axes and the marks drawn on it.
+
+    A chart is a tuple of panels. Most are a single panel; the dashboards stack
+    several sharing an x-axis.
+
+    Attributes:
+        lines: Line series to draw.
+        xaxis: Horizontal axis configuration.
+        yaxis: Vertical axis configuration.
+        title: Heading for this panel, used when a chart has several.
+
+    """
+
+    lines: tuple[LineSeries, ...] = ()
+    xaxis: Axis = field(default_factory=Axis)
+    yaxis: Axis = field(default_factory=Axis)
+    title: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FigureSpec:
+    """A complete chart, ready for any renderer.
+
+    Attributes:
+        title: Chart title.
+        panels: The panels to draw, top to bottom.
+        height: Figure height in pixels.
+        figsize: Optional ``(width, height)`` in pixels, overriding *height*.
+            Pixels for both backends; the matplotlib renderer converts to
+            inches so one public signature means the same thing either way.
+        date_range_selector: Offer the Plotly range-selector buttons. Ignored
+            by matplotlib, which has no interactive widgets.
+
+    """
+
+    title: str
+    panels: tuple[Panel, ...]
+    height: int = 600
+    figsize: tuple[int, int] | None = None
+    date_range_selector: bool = True

--- a/src/jquantstats/_plots/_specs/__init__.py
+++ b/src/jquantstats/_plots/_specs/__init__.py
@@ -1,0 +1,17 @@
+"""Spec builders: polars in, `~jquantstats._plots._spec.FigureSpec` out.
+
+One module per chart family. Nothing here imports a drawing library, so the
+arithmetic behind a chart is written once no matter how many backends render it.
+"""
+
+from ._cumulative import compare_spec as compare_spec
+from ._cumulative import cumulative_returns_spec as cumulative_returns_spec
+from ._cumulative import earnings_spec as earnings_spec
+from ._cumulative import log_returns_spec as log_returns_spec
+
+__all__ = [
+    "compare_spec",
+    "cumulative_returns_spec",
+    "earnings_spec",
+    "log_returns_spec",
+]

--- a/src/jquantstats/_plots/_specs/_cumulative.py
+++ b/src/jquantstats/_plots/_specs/_cumulative.py
@@ -1,0 +1,201 @@
+"""Spec builders for the cumulative-return and equity-curve charts.
+
+Each builder takes a dataset and returns a `FigureSpec`. The arithmetic lives
+here once; `jquantstats._plots._render` decides how it is drawn.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+from .._spec import Axis, Dash, FigureSpec, HoverSpec, LineSeries, Panel, TickFormat
+from .._style import ticker_colors
+
+if TYPE_CHECKING:
+    from jquantstats._protocol import DataLike
+
+__all__ = [
+    "compare_spec",
+    "cumulative_returns_spec",
+    "earnings_spec",
+    "log_returns_spec",
+]
+
+
+def _split_columns(frame: pl.DataFrame) -> tuple[str, list[str]]:
+    """Separate the date column from the value columns.
+
+    Args:
+        frame: A frame whose first column is the date axis.
+
+    Returns:
+        tuple[str, list[str]]: The date column name and every other column.
+
+    """
+    date_col = frame.columns[0]
+    return date_col, [c for c in frame.columns if c != date_col]
+
+
+def _lines(
+    frame: pl.DataFrame,
+    date_col: str,
+    tickers: list[str],
+    colors: dict[str, str],
+    value_format: TickFormat,
+    *,
+    prefix: str = "",
+    suffix: str = "",
+    width: float = 2,
+    dash: Dash = "solid",
+) -> list[LineSeries]:
+    """Build one line series per ticker, all sharing a style.
+
+    Args:
+        frame: The prepared frame holding the plotted values.
+        date_col: Name of the date column.
+        tickers: Columns to draw, in order.
+        colors: Ticker to hex colour mapping.
+        value_format: How tooltip values are rendered.
+        prefix: Written before each tooltip value.
+        suffix: Written after each tooltip value.
+        width: Stroke width.
+        dash: Stroke pattern.
+
+    Returns:
+        list[LineSeries]: One series per ticker, in the given order.
+
+    """
+    return [
+        LineSeries(
+            name=ticker,
+            x=frame[date_col],
+            y=frame[ticker],
+            color=colors[ticker],
+            width=width,
+            dash=dash,
+            hover=HoverSpec(label=ticker, value_format=value_format, prefix=prefix, suffix=suffix),
+        )
+        for ticker in tickers
+    ]
+
+
+def cumulative_returns_spec(data: DataLike, title: str, log_scale: bool) -> FigureSpec:
+    """Describe the cumulative compounded-returns chart.
+
+    Args:
+        data: The dataset to plot.
+        title: Chart title.
+        log_scale: Use a logarithmic y-axis.
+
+    Returns:
+        FigureSpec: One line per column of ``data.all``.
+
+    """
+    df = data.all
+    date_col, tickers = _split_columns(df)
+    prices = df.with_columns([(1.0 + pl.col(t)).cum_prod().alias(t) for t in tickers])
+
+    panel = Panel(
+        # The "x" suffix reads the value as a growth multiple: "1.42x".
+        lines=tuple(_lines(prices, date_col, tickers, ticker_colors(tickers), "float2", suffix="x")),
+        yaxis=Axis(title="Cumulative Return", tick_format="float2", log=log_scale),
+    )
+    return FigureSpec(title=title, panels=(panel,))
+
+
+def compare_spec(data: DataLike, title: str, figsize: tuple[int, int] | None) -> FigureSpec:
+    """Describe the asset-versus-benchmark comparison chart.
+
+    Benchmarks are drawn after the assets, slightly heavier and dashed, so they
+    read as the reference rather than as another asset.
+
+    Args:
+        data: The dataset to plot. Must carry benchmark columns.
+        title: Chart title.
+        figsize: Optional ``(width, height)`` in pixels.
+
+    Returns:
+        FigureSpec: Asset lines followed by benchmark lines.
+
+    Raises:
+        AttributeError: If no benchmark data is available.
+
+    """
+    benchmark_df = getattr(data, "benchmark", None)
+    if benchmark_df is None:
+        raise AttributeError("compare() requires benchmark data to be set")  # noqa: TRY003
+
+    df = data.all
+    date_col, _ = _split_columns(df)
+    assets = list(data.returns.columns)
+    benchmarks = list(benchmark_df.columns)
+
+    colors = ticker_colors(assets + benchmarks)
+    prices = df.with_columns([(1.0 + pl.col(col)).cum_prod().alias(col) for col in assets + benchmarks])
+
+    panel = Panel(
+        lines=(
+            *_lines(prices, date_col, assets, colors, "float2", suffix="x"),
+            *_lines(prices, date_col, benchmarks, colors, "float2", suffix="x", width=2.5, dash="dash"),
+        ),
+        yaxis=Axis(title="Cumulative Return", tick_format="float2"),
+    )
+    return FigureSpec(title=title, panels=(panel,), figsize=figsize)
+
+
+def log_returns_spec(data: DataLike, title: str, figsize: tuple[int, int] | None) -> FigureSpec:
+    """Describe the cumulative log-returns chart.
+
+    Args:
+        data: The dataset to plot.
+        title: Chart title.
+        figsize: Optional ``(width, height)`` in pixels.
+
+    Returns:
+        FigureSpec: One line per column, on a linear axis of log values.
+
+    """
+    df = data.all
+    date_col, tickers = _split_columns(df)
+    log_prices = df.with_columns([(1.0 + pl.col(t)).cum_prod().log(math.e).alias(t) for t in tickers])
+
+    panel = Panel(
+        lines=tuple(_lines(log_prices, date_col, tickers, ticker_colors(tickers), "float4")),
+        yaxis=Axis(title="Log Return"),
+    )
+    return FigureSpec(title=title, panels=(panel,), figsize=figsize)
+
+
+def earnings_spec(data: DataLike, start_balance: float, title: str, compounded: bool) -> FigureSpec:
+    """Describe the dollar equity curve.
+
+    Args:
+        data: The dataset to plot.
+        start_balance: Starting portfolio value in currency units.
+        title: Chart title.
+        compounded: Compound the returns; when False they are summed.
+
+    Returns:
+        FigureSpec: One line per column, scaled to *start_balance*.
+
+    """
+    df = data.all
+    date_col, tickers = _split_columns(df)
+
+    if compounded:
+        equity = df.with_columns([(start_balance * (1.0 + pl.col(t)).cum_prod()).alias(t) for t in tickers])
+    else:
+        equity = df.with_columns([(start_balance * (1.0 + pl.col(t).cum_sum())).alias(t) for t in tickers])
+
+    panel = Panel(
+        lines=tuple(_lines(equity, date_col, tickers, ticker_colors(tickers), "currency0", prefix="$")),
+        yaxis=Axis(
+            title=f"Portfolio Value (starting ${start_balance:,.0f})",
+            tick_format="currency0",
+            tick_prefix="$",
+        ),
+    )
+    return FigureSpec(title=title, panels=(panel,))

--- a/src/jquantstats/_plots/_style.py
+++ b/src/jquantstats/_plots/_style.py
@@ -1,0 +1,57 @@
+"""Colour helpers shared by every chart, independent of any drawing library.
+
+These decide *which* colours a chart uses. How those colours are applied to a
+figure is a renderer's job, so nothing here imports a drawing library.
+
+The palette is Plotly's qualitative sequence, kept because changing it would
+alter every existing chart. `plotly.express` is imported only to read that list
+of hex strings; no figure is built and no renderer is selected.
+"""
+
+from __future__ import annotations
+
+import plotly.express as px
+
+__all__ = ["hex_to_rgba", "ticker_colors"]
+
+
+def hex_to_rgba(hex_color: str, alpha: float = 0.5) -> str:
+    """Convert a hex colour to an RGBA CSS string.
+
+    Args:
+        hex_color: A hex colour, with or without a leading ``#``.
+        alpha: Opacity in the range [0, 1]. Defaults to 0.5.
+
+    Returns:
+        str: An ``rgba(r, g, b, a)`` string. Both backends accept this
+        spelling, so it needs no per-renderer translation.
+
+    Examples:
+        >>> hex_to_rgba("#636efa", 0.4)
+        'rgba(99, 110, 250, 0.4)'
+
+    """
+    hex_color = hex_color.lstrip("#")
+    r, g, b = (int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
+    return f"rgba({r}, {g}, {b}, {alpha})"
+
+
+def ticker_colors(tickers: list[str]) -> dict[str, str]:
+    """Assign a stable colour to each ticker.
+
+    Colours are taken from the palette in order and wrap around once it is
+    exhausted, so the same ticker list always yields the same mapping.
+
+    Args:
+        tickers: Ordered ticker / column names.
+
+    Returns:
+        dict[str, str]: One hex colour per ticker.
+
+    Examples:
+        >>> ticker_colors(["AAPL", "META"])["AAPL"]
+        '#636EFA'
+
+    """
+    palette = px.colors.qualitative.Plotly
+    return {ticker: palette[i % len(palette)] for i, ticker in enumerate(tickers)}

--- a/tests/test_jquantstats/test__plots/test_spec_render.py
+++ b/tests/test_jquantstats/test__plots/test_spec_render.py
@@ -1,0 +1,260 @@
+"""Unit tests for the figure spec and the Plotly renderer.
+
+The chart-level behaviour of the cumulative family is already pinned by
+``test_plots.py`` and the two snapshot suites. These tests cover the seam
+itself: that a spec builder describes what it should, and that the renderer
+translates each semantic property into the right Plotly vocabulary — including
+the properties it must *not* emit when a builder left them unset.
+"""
+
+from __future__ import annotations
+
+import json
+
+import plotly.graph_objects as go
+import polars as pl
+import pytest
+
+from jquantstats._plots._render import render_plotly
+from jquantstats._plots._render._plotly import _axis_kwargs, _hovertemplate
+from jquantstats._plots._spec import Axis, FigureSpec, HoverSpec, LineSeries, Panel
+from jquantstats._plots._specs import (
+    compare_spec,
+    cumulative_returns_spec,
+    earnings_spec,
+    log_returns_spec,
+)
+from jquantstats._plots._style import hex_to_rgba, ticker_colors
+
+
+def _line(**overrides) -> LineSeries:
+    """Build a minimal line series, overriding selected fields."""
+    defaults = {
+        "name": "AAPL",
+        "x": pl.Series("date", [1, 2, 3]),
+        "y": pl.Series("AAPL", [1.0, 1.1, 1.2]),
+        "color": "#636efa",
+    }
+    return LineSeries(**{**defaults, **overrides})
+
+
+def _spec(panel: Panel, **overrides) -> FigureSpec:
+    """Build a single-panel figure spec, overriding selected fields."""
+    return FigureSpec(**{"title": "T", "panels": (panel,), **overrides})
+
+
+# ── the spec is backend-neutral ───────────────────────────────────────────────
+
+
+def test_spec_holds_polars_series_not_lists(data) -> None:
+    """Series must stay as polars Series through the spec.
+
+    Plotly serialises a Series to a compact binary buffer and a Python list to
+    a plain JSON array, so a conversion anywhere in the spec layer would
+    silently change every rendered figure.
+    """
+    spec = cumulative_returns_spec(data, title="T", log_scale=False)
+    line = spec.panels[0].lines[0]
+    assert isinstance(line.x, pl.Series)
+    assert isinstance(line.y, pl.Series)
+
+
+def test_spec_dataclasses_are_frozen() -> None:
+    """A spec is a description, not a mutable builder."""
+    with pytest.raises(AttributeError):
+        _line().name = "other"
+
+
+# ── style helpers ────────────────────────────────────────────────────────────
+
+
+def test_ticker_colors_are_stable_and_wrap() -> None:
+    """Colours are positional and wrap once the palette is exhausted."""
+    many = [f"T{i}" for i in range(12)]
+    colors = ticker_colors(many)
+    assert colors["T0"] == ticker_colors(["T0"])["T0"]
+    assert colors["T10"] == colors["T0"], "palette of 10 should wrap"
+
+
+def test_hex_to_rgba_accepts_both_spellings() -> None:
+    """A leading '#' is optional."""
+    assert hex_to_rgba("#636efa", 0.4) == hex_to_rgba("636efa", 0.4)
+
+
+# ── hovertemplate translation ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("hover", "expected"),
+    [
+        (
+            HoverSpec(label="AAPL", value_format="float2", suffix="x"),
+            "<b>%{x|%b %Y}</b><br>AAPL: %{y:.2f}x",
+        ),
+        (
+            HoverSpec(label="AAPL", value_format="float4"),
+            "<b>%{x|%b %Y}</b><br>AAPL: %{y:.4f}",
+        ),
+        (
+            HoverSpec(label="AAPL", value_format="currency0", prefix="$"),
+            "<b>%{x|%b %Y}</b><br>AAPL: $%{y:,.0f}",
+        ),
+        (
+            HoverSpec(label="AAPL", value_format="float2", date_header=False),
+            "AAPL: %{y:.2f}",
+        ),
+    ],
+)
+def test_hovertemplate_translation(hover: HoverSpec, expected: str) -> None:
+    """Each semantic hover field maps onto the expected Plotly template."""
+    assert _hovertemplate(hover) == expected
+
+
+# ── axis translation ─────────────────────────────────────────────────────────
+
+
+def test_unset_axis_emits_nothing() -> None:
+    """An untouched axis contributes no properties.
+
+    Emitting a default for a property the chart never set would change the
+    serialised figure.
+    """
+    assert _axis_kwargs(Axis()) == {}
+
+
+def test_axis_translates_every_property() -> None:
+    """Each semantic axis field maps onto the expected Plotly property."""
+    kwargs = _axis_kwargs(Axis(title="V", tick_format="currency0", tick_prefix="$", log=True))
+    assert kwargs == {"title_text": "V", "tickprefix": "$", "tickformat": ",.0f", "type": "log"}
+
+
+# ── renderer ─────────────────────────────────────────────────────────────────
+
+
+def test_render_rejects_multi_panel_specs() -> None:
+    """Multi-panel rendering arrives with the dashboards, not before."""
+    panel = Panel(lines=(_line(),))
+    with pytest.raises(ValueError, match="too many values"):
+        render_plotly(FigureSpec(title="T", panels=(panel, panel)))
+
+
+def test_solid_lines_omit_the_dash_property() -> None:
+    """`solid` is Plotly's default, so it is left unstated."""
+    fig = render_plotly(_spec(Panel(lines=(_line(dash="solid"),))))
+    assert "dash" not in json.loads(fig.to_json())["data"][0]["line"]
+
+
+def test_dashed_lines_state_the_dash_property() -> None:
+    """A non-default stroke pattern is emitted."""
+    fig = render_plotly(_spec(Panel(lines=(_line(dash="dash"),))))
+    assert json.loads(fig.to_json())["data"][0]["line"]["dash"] == "dash"
+
+
+def test_line_without_hover_emits_no_hovertemplate() -> None:
+    """A series may opt out of a tooltip entirely."""
+    fig = render_plotly(_spec(Panel(lines=(_line(hover=None),))))
+    assert "hovertemplate" not in json.loads(fig.to_json())["data"][0]
+
+
+def test_figsize_sets_width_and_height() -> None:
+    """`figsize` is in pixels and overrides the default height."""
+    fig = render_plotly(_spec(Panel(lines=(_line(),)), figsize=(920, 420)))
+    assert (fig.layout.width, fig.layout.height) == (920, 420)
+
+
+def test_height_applies_when_no_figsize_given() -> None:
+    """Without `figsize` the spec height stands and no width is set."""
+    fig = render_plotly(_spec(Panel(lines=(_line(),)), height=480))
+    assert fig.layout.height == 480
+    assert fig.layout.width is None
+
+
+def test_range_selector_can_be_suppressed() -> None:
+    """Charts without a date axis opt out of the range selector."""
+    fig = render_plotly(_spec(Panel(lines=(_line(),)), date_range_selector=False))
+    assert "rangeselector" not in json.loads(fig.to_json())["layout"]["xaxis"]
+
+
+def test_range_selector_is_attached_by_default() -> None:
+    """Date-axis charts get the 6m/1y/3y/YTD/All buttons."""
+    fig = render_plotly(_spec(Panel(lines=(_line(),))))
+    assert json.loads(fig.to_json())["layout"]["xaxis"]["rangeselector"]["buttons"]
+
+
+def test_render_returns_a_plotly_figure() -> None:
+    """The Plotly renderer produces a Plotly figure."""
+    assert isinstance(render_plotly(_spec(Panel(lines=(_line(),)))), go.Figure)
+
+
+def test_both_axes_are_honoured() -> None:
+    """A configured x-axis reaches the figure, not just the y-axis.
+
+    No chart in the cumulative family configures its x-axis, so without this
+    the x-axis path would be an untested no-op — and a builder that later set
+    an x-axis title would find it silently dropped.
+    """
+    panel = Panel(lines=(_line(),), xaxis=Axis(title="When"), yaxis=Axis(title="How much"))
+    fig = render_plotly(_spec(panel))
+    assert fig.layout.xaxis.title.text == "When"
+    assert fig.layout.yaxis.title.text == "How much"
+
+
+def test_unconfigured_axes_stay_untouched() -> None:
+    """Neither axis gains a title when the spec sets none."""
+    fig = render_plotly(_spec(Panel(lines=(_line(),))))
+    assert fig.layout.xaxis.title.text is None
+    assert fig.layout.yaxis.title.text is None
+
+
+# ── builders describe what the charts need ───────────────────────────────────
+
+
+def test_cumulative_spec_marks_growth_multiples(data) -> None:
+    """The 'x' suffix reads the value as a growth multiple."""
+    spec = cumulative_returns_spec(data, title="T", log_scale=False)
+    assert all(line.hover.suffix == "x" for line in spec.panels[0].lines)
+
+
+def test_cumulative_spec_honours_log_scale(data) -> None:
+    """`log_scale` reaches the y-axis rather than the data."""
+    assert cumulative_returns_spec(data, title="T", log_scale=True).panels[0].yaxis.log is True
+    assert cumulative_returns_spec(data, title="T", log_scale=False).panels[0].yaxis.log is False
+
+
+def test_compare_spec_draws_benchmarks_last_and_dashed(data) -> None:
+    """Benchmarks read as the reference, not as another asset."""
+    spec = compare_spec(data, title="T", figsize=None)
+    assets = list(data.returns.columns)
+    lines = spec.panels[0].lines
+
+    assert [line.name for line in lines[: len(assets)]] == assets
+    for line in lines[len(assets) :]:
+        assert line.dash == "dash"
+        assert line.width == 2.5
+
+
+def test_compare_spec_requires_a_benchmark(data_no_benchmark) -> None:
+    """Validation lives in the builder, so every backend raises alike."""
+    with pytest.raises(AttributeError, match=r"^compare\(\) requires benchmark data to be set$"):
+        compare_spec(data_no_benchmark, title="T", figsize=None)
+
+
+def test_log_returns_spec_leaves_the_tick_format_alone(data) -> None:
+    """Log values carry no tick format, matching the original chart."""
+    yaxis = log_returns_spec(data, title="T", figsize=None).panels[0].yaxis
+    assert yaxis.title == "Log Return"
+    assert yaxis.tick_format is None
+
+
+def test_earnings_spec_labels_the_starting_balance(data) -> None:
+    """The axis states the starting balance, formatted with separators."""
+    yaxis = earnings_spec(data, start_balance=250_000, title="T", compounded=True).panels[0].yaxis
+    assert yaxis.title == "Portfolio Value (starting $250,000)"
+    assert yaxis.tick_prefix == "$"
+
+
+def test_earnings_spec_compounding_changes_the_values(data) -> None:
+    """`compounded` selects cumprod over cumsum, giving different curves."""
+    compounded = earnings_spec(data, start_balance=1e5, title="T", compounded=True)
+    summed = earnings_spec(data, start_balance=1e5, title="T", compounded=False)
+    assert compounded.panels[0].lines[0].y.to_list() != summed.panels[0].lines[0].y.to_list()


### PR DESCRIPTION
Second of the #628 series. Adds the backend-agnostic figure IR, a Plotly renderer over
it, and moves the four cumulative-family charts onto that seam.

**No behaviour change — every rendered figure is byte-identical to before.**

> **Stacked on #940.** Base is `feat/628-matplotlib-backend`, so this diff shows only
> the spec work. Merge #940 first and this will retarget to `main`.

## Why an IR, not a parallel mixin tree

There are 29 public plot methods. A second mixin tree means 29 more rendering functions
permanently paired with the existing 29 — **58 to keep in sync** — and every polars
expression behind them duplicated. A spec layer gives **29 builders and 2 renderers**, so
a chart's arithmetic is written once no matter how many backends draw it.

This continues a direction the repo already started: `_compute_drawdown_periods`,
`_monthly_heatmap_matrix`, `_period_agg_exprs` and `_rolling_beta_expr` are all pure
data-prep helpers today.

```
_spec.py      FigureSpec → Panel[] → LineSeries / Axis / HoverSpec   (no drawing library)
_specs/       polars in, FigureSpec out                              (no drawing library)
_render/      FigureSpec in, figure out                              (one module per backend)
_data/        thin facades: docstring + one call
```

`_data/_cumulative.py` goes from **70 statements to 16**.

## The gate did its job

The acceptance criterion was the full-fidelity snapshots passing **without**
`--snapshot-update`. They do — and they caught two things that inspection did not:

- **`returns` and `compare` hovertemplates end in a literal `x`.** The value is a growth
  multiple: `1.42x`. I had dropped it. `HoverSpec` grew a `suffix` field.
- **Line width was written `2`, not `2.0`.** Plotly preserves int-vs-float in its JSON,
  so a float default silently changed the serialised output. `LineSeries.width` now
  defaults to an int, with a comment explaining why anyone touching it should not
  "tidy" it.

Neither would have been caught by a structural snapshot. This is the evidence that the
IR is faithful, which is what the rest of the series depends on.

## Three details the IR is shaped around

1. **Series stay as `polars.Series`.** Plotly serialises a Series to a compact binary
   buffer and a Python list to a plain JSON array — converting anywhere in the spec layer
   would silently change every figure. Verified directly before writing the IR.
2. **Axis fields default to "leave it alone".** `log_returns` sets no tick format;
   emitting a default for an untouched property would change the output.
3. **Formats are named semantically** (`"float2"`, `"currency0"`), never as d3 strings.
   The Plotly renderer owns that mapping; matplotlib will own its own.

The renderer routes through the existing `_apply_base_layout` / `_apply_figsize` rather
than restating them. Those already produce the layout every chart has, so reusing them is
what makes byte-identical output *achievable* rather than merely hoped for.

## Deliberately not here

- **Backend dispatch.** With one renderer there is nothing to choose between, and a
  placeholder matplotlib branch would be untestable against the branch-coverage gate. It
  arrives with the renderer that makes it real.
- **Multi-panel rendering.** `render_plotly` takes exactly one panel, via tuple
  unpacking. Writing the subplot path now would be uncovered code.

One thing I did *not* defer: the renderer honours `Panel.xaxis` even though no cumulative
chart sets one. Since the IR can express it, ignoring it would be a silent trap rather
than merely dead code — so it is implemented and directly tested.

## Verification

`make all` green: **fmt, deps, test, docs-coverage, security, license, typecheck
(mypy --strict *and* ty), rhiza-test**.

- 1,513 passed, 5 skipped (kaleido, no local Chrome)
- **100% line + branch coverage**, 0 new `# pragma: no cover`, 0 new `noqa`
- **67 snapshots passed without regeneration**

Also fixes a doctest in the moved colour helper — the Plotly palette returns uppercase
hex — which the rhiza doctest gate caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)