### PR TITLE
Add the matplotlib backend for the cumulative charts (#628)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,16 +206,8 @@ deptry_ignore = ["api"]
 # `deptry_ignore` under [tool.rhiza-task] above — it was the Makefile's
 # DEPTRY_FOLDERS line before rhiza v1.4.0), so its import there is observed
 # directly.
-#   matplotlib        - TEMPORARY, and the only entry here that is not permanent.
-#                       The optional rendering backend (#628). Today the only reference
-#                       is `find_spec("matplotlib")` in _plots/_backend.py, which deptry
-#                       cannot see, so it looks unused. DELETE THIS ENTRY in the PR that
-#                       lands _plots/_render/_mpl.py — from then on matplotlib is a real
-#                       import in src/ and deptry observes it directly. If that PR leaves
-#                       this line in place, an accidental *removal* of the matplotlib
-#                       import would stop being caught.
 [tool.deptry.per_rule_ignores]
-DEP002 = ["kaleido", "uvicorn", "python-multipart", "matplotlib"]
+DEP002 = ["kaleido", "uvicorn", "python-multipart"]
 
 # Package to module name mapping
 [tool.deptry.package_module_name_map]

--- a/src/jquantstats/_plots/_data/_cumulative.py
+++ b/src/jquantstats/_plots/_data/_cumulative.py
@@ -2,25 +2,55 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
-import plotly.graph_objects as go
-
-from .._render import render_plotly
+from .._render import render
 from .._specs import compare_spec, cumulative_returns_spec, earnings_spec, log_returns_spec
 
 if TYPE_CHECKING:
+    from matplotlib.figure import Figure as MplFigure
+    from plotly.graph_objects import Figure as PlotlyFigure
+
     from jquantstats._protocol import DataLike
+
+    from .._backend import Backend
+    from .._render import Figure
 
 
 class _CumulativePlotsMixin:
-    """Cumulative-return and equity-curve plots for :class:`DataPlots`."""
+    """Cumulative-return and equity-curve plots for :class:`DataPlots`.
+
+    Every method here accepts a ``backend`` keyword selecting the renderer, and
+    is overloaded on it: omitting it (or naming ``"plotly"``) is typed as
+    returning a `plotly.graph_objects.Figure`, so callers written before the
+    matplotlib backend existed keep exactly the type they had.
+
+    One caveat that no type system can express: after
+    `jquantstats.set_plot_backend` changes the process-wide default, a call
+    that passes no ``backend`` returns the new default's figure type while
+    still being *typed* as Plotly's. Pass ``backend=`` explicitly if you change
+    the global default and care about static types.
+    """
 
     __slots__ = ()
 
     _data: DataLike
 
-    def returns(self, title: str = "Cumulative Returns", log_scale: bool = False) -> go.Figure:
+    @overload
+    def returns(
+        self, title: str = ..., log_scale: bool = ..., *, backend: Literal["plotly"] | None = ...
+    ) -> PlotlyFigure: ...
+
+    @overload
+    def returns(self, title: str = ..., log_scale: bool = ..., *, backend: Literal["matplotlib"]) -> MplFigure: ...
+
+    def returns(
+        self,
+        title: str = "Cumulative Returns",
+        log_scale: bool = False,
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Cumulative compounded returns over time.
 
         Plots ``(1 + r).cumprod()`` for every column in the dataset (including
@@ -29,30 +59,72 @@ class _CumulativePlotsMixin:
         Args:
             title: Chart title. Defaults to ``"Cumulative Returns"``.
             log_scale: Use a logarithmic y-axis. Defaults to False.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly line chart.
+            Figure: A line chart.
 
         """
-        return render_plotly(cumulative_returns_spec(self._data, title=title, log_scale=log_scale))
+        return render(cumulative_returns_spec(self._data, title=title, log_scale=log_scale), backend)
 
-    def compare(self, title: str = "Comparison vs Benchmark", figsize: tuple[int, int] | None = None) -> go.Figure:
+    @overload
+    def compare(
+        self,
+        title: str = ...,
+        figsize: tuple[int, int] | None = ...,
+        *,
+        backend: Literal["plotly"] | None = ...,
+    ) -> PlotlyFigure: ...
+
+    @overload
+    def compare(
+        self, title: str = ..., figsize: tuple[int, int] | None = ..., *, backend: Literal["matplotlib"]
+    ) -> MplFigure: ...
+
+    def compare(
+        self,
+        title: str = "Comparison vs Benchmark",
+        figsize: tuple[int, int] | None = None,
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Compare cumulative returns of each asset against the benchmark.
 
         Args:
             title: Chart title. Defaults to ``"Comparison vs Benchmark"``.
             figsize: Optional ``(width, height)`` in pixels.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly line chart.
+            Figure: A line chart.
 
         Raises:
             AttributeError: If no benchmark data is available.
 
         """
-        return render_plotly(compare_spec(self._data, title=title, figsize=figsize))
+        return render(compare_spec(self._data, title=title, figsize=figsize), backend)
 
-    def log_returns(self, title: str = "Log Returns", figsize: tuple[int, int] | None = None) -> go.Figure:
+    @overload
+    def log_returns(
+        self,
+        title: str = ...,
+        figsize: tuple[int, int] | None = ...,
+        *,
+        backend: Literal["plotly"] | None = ...,
+    ) -> PlotlyFigure: ...
+
+    @overload
+    def log_returns(
+        self, title: str = ..., figsize: tuple[int, int] | None = ..., *, backend: Literal["matplotlib"]
+    ) -> MplFigure: ...
+
+    def log_returns(
+        self,
+        title: str = "Log Returns",
+        figsize: tuple[int, int] | None = None,
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Cumulative log returns over time.
 
         Plots ``log((1 + r).cumprod())`` — the natural log of the compounded
@@ -62,19 +134,42 @@ class _CumulativePlotsMixin:
         Args:
             title: Chart title. Defaults to ``"Log Returns"``.
             figsize: Optional ``(width, height)`` in pixels.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly line chart.
+            Figure: A line chart.
 
         """
-        return render_plotly(log_returns_spec(self._data, title=title, figsize=figsize))
+        return render(log_returns_spec(self._data, title=title, figsize=figsize), backend)
+
+    @overload
+    def earnings(
+        self,
+        start_balance: float = ...,
+        title: str = ...,
+        compounded: bool = ...,
+        *,
+        backend: Literal["plotly"] | None = ...,
+    ) -> PlotlyFigure: ...
+
+    @overload
+    def earnings(
+        self,
+        start_balance: float = ...,
+        title: str = ...,
+        compounded: bool = ...,
+        *,
+        backend: Literal["matplotlib"],
+    ) -> MplFigure: ...
 
     def earnings(
         self,
         start_balance: float = 1e5,
         title: str = "Portfolio Earnings",
         compounded: bool = True,
-    ) -> go.Figure:
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Dollar equity curve showing portfolio value over time.
 
         Scales cumulative returns by *start_balance* so the y-axis reflects
@@ -86,9 +181,11 @@ class _CumulativePlotsMixin:
             title: Chart title. Defaults to ``"Portfolio Earnings"``.
             compounded: Use compounded returns (``cumprod``). When False uses
                 cumulative sum. Defaults to True.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly line chart.
+            Figure: A line chart.
 
         """
-        return render_plotly(earnings_spec(self._data, start_balance=start_balance, title=title, compounded=compounded))
+        spec = earnings_spec(self._data, start_balance=start_balance, title=title, compounded=compounded)
+        return render(spec, backend)

--- a/src/jquantstats/_plots/_render/__init__.py
+++ b/src/jquantstats/_plots/_render/__init__.py
@@ -1,10 +1,66 @@
 """Renderers turning a `~jquantstats._plots._spec.FigureSpec` into a figure.
 
-One module per backend. Backend *selection* lands with the matplotlib renderer;
-until there is a second backend to choose between, callers use `render_plotly`
-directly.
+One module per backend, and `render` is the only place that chooses between
+them. Because every chart is described as a spec, that one function serves every
+plot method — there is no per-method dispatch to write or to keep in step.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeAlias
+
+from .._backend import Backend, require_backend, resolve
 from ._plotly import render_plotly as render_plotly
 
-__all__ = ["render_plotly"]
+if TYPE_CHECKING:
+    from matplotlib.figure import Figure as MplFigure
+    from plotly.graph_objects import Figure as PlotlyFigure
+
+    from .._spec import FigureSpec
+
+    #: What a renderer returns once the backend is only known at runtime.
+    #:
+    #: Type-checking-only, like the two imports above it: matplotlib is an
+    #: optional dependency, and every module here carries
+    #: ``from __future__ import annotations``, so an annotation naming these is
+    #: never evaluated.
+    #:
+    #: Public plot methods do not expose this union directly. They overload on
+    #: the literal ``backend`` argument instead, so ``data.plots.returns()``
+    #: still infers exactly ``go.Figure`` and no existing caller has to narrow
+    #: a union that was not there before.
+    Figure: TypeAlias = PlotlyFigure | MplFigure
+
+__all__ = ["render", "render_plotly"]
+
+
+def render(spec: FigureSpec, backend: Backend | None = None) -> Figure:
+    """Render *spec* with the selected backend.
+
+    Args:
+        spec: The chart to draw.
+        backend: An explicit choice, or None to use the ambient selection —
+            a `~jquantstats.plot_backend` block, else the process-wide default.
+
+    Returns:
+        Figure: A `plotly.graph_objects.Figure` or a
+        `matplotlib.figure.Figure`, according to the backend in effect.
+
+    Raises:
+        UnknownPlotBackendError: If *backend* names an unsupported backend.
+        MissingBackendError: If the selected backend's library is not installed.
+
+    """
+    selected = resolve(backend)
+    if selected == "plotly":
+        return render_plotly(spec)
+
+    # Imported here, not at module scope, so that `import jquantstats` never
+    # imports matplotlib and the extra stays genuinely optional. The
+    # availability check runs first so an absent library produces a message
+    # naming the extra rather than a bare ModuleNotFoundError from deep inside
+    # the import machinery.
+    require_backend(selected)
+    from ._mpl import render_mpl
+
+    return render_mpl(spec)

--- a/src/jquantstats/_plots/_render/_mpl.py
+++ b/src/jquantstats/_plots/_render/_mpl.py
@@ -1,0 +1,150 @@
+"""Render a `FigureSpec` with matplotlib.
+
+Figures are built by constructing `matplotlib.figure.Figure` directly rather
+than through ``pyplot``. pyplot keeps every figure it creates alive in a global
+registry, so a script looping over hundreds of portfolios accumulates figures
+until matplotlib warns and memory grows without bound — the resource cost behind
+issue #628. A directly constructed Figure is owned by its caller, garbage
+collected normally, and still supports ``fig.savefig(...)``. Importing this
+module also never selects a GUI backend or mutates ``rcParams``.
+
+This backend reproduces the same data and the same static design as the Plotly
+one. It does not emulate interactivity: hover tooltips and the date
+range-selector buttons have no matplotlib equivalent and are silently absent.
+Everything determining *what* is plotted — series, colours, axis scales and tick
+formats — is reproduced.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from matplotlib.ticker import StrMethodFormatter
+
+from .._spec import Axis, FigureSpec, LineSeries, TickFormat
+
+if TYPE_CHECKING:
+    from matplotlib.ticker import Formatter
+
+__all__ = ["render_mpl"]
+
+# Pixels per inch used to reinterpret the pixel sizes the specs carry, so
+# `figsize=(920, 420)` frames the same chart on either backend.
+_DPI = 100
+
+# Width for a spec that names none. Plotly lets a figure size itself to its
+# container; matplotlib needs a number up front, so charts that never set a
+# width get this one.
+_DEFAULT_WIDTH_PX = 1000
+
+# Semantic tick format -> a str.format field spec.
+_FORMATS = {
+    "float2": "{x:.2f}",
+    "float4": "{x:.4f}",
+    "currency0": "{x:,.0f}",
+}
+
+# Semantic dash style -> matplotlib's linestyle vocabulary.
+_LINESTYLES = {"solid": "-", "dash": "--"}
+
+# The Plotly charts draw on white with a light grey grid; mirror that here so a
+# figure is recognisably the same chart whichever backend drew it.
+_GRID_COLOR = "lightgrey"
+_GRID_WIDTH = 0.5
+
+
+def _tick_formatter(tick_format: TickFormat, prefix: str) -> Formatter:
+    """Build a tick formatter for one axis.
+
+    Args:
+        tick_format: How to render the number.
+        prefix: Written before each tick value, e.g. a currency sign.
+
+    Returns:
+        Formatter: A formatter applying the requested format and prefix.
+
+    """
+    return StrMethodFormatter(f"{prefix}{_FORMATS[tick_format]}")
+
+
+def _draw_line(ax: Axes, line: LineSeries) -> None:
+    """Draw one series onto *ax*.
+
+    The series' `~jquantstats._spec.HoverSpec` is ignored: tooltips are
+    interactive, and this backend is static.
+
+    Args:
+        ax: The axes to draw on.
+        line: The series to draw.
+
+    """
+    # `to_numpy`, not `to_list`: a polars null becomes NaN in a float array but
+    # `None` in a list, and matplotlib draws a gap for the former while the
+    # latter forces a slow object-dtype array it cannot interpolate across.
+    ax.plot(
+        line.x.to_numpy(),
+        line.y.to_numpy(),
+        color=line.color,
+        linewidth=line.width,
+        linestyle=_LINESTYLES[line.dash],
+        label=line.name,
+    )
+
+
+def _apply_axis(ax: Axes, axis: Axis, *, vertical: bool) -> None:
+    """Apply one axis configuration to *ax*.
+
+    Only properties the spec actually set are touched, mirroring the Plotly
+    renderer so the two backends agree on what "unset" means.
+
+    Args:
+        ax: The axes to configure.
+        axis: The requested configuration.
+        vertical: Configure the y-axis rather than the x-axis.
+
+    """
+    target = ax.yaxis if vertical else ax.xaxis
+    if axis.title is not None:
+        target.set_label_text(axis.title)
+    if axis.tick_format is not None:
+        target.set_major_formatter(_tick_formatter(axis.tick_format, axis.tick_prefix))
+    if axis.log:
+        set_scale = ax.set_yscale if vertical else ax.set_xscale
+        set_scale("log")
+
+
+def render_mpl(spec: FigureSpec) -> Figure:
+    """Render *spec* as a static matplotlib figure.
+
+    Args:
+        spec: The chart to draw. Must describe exactly one panel; multi-panel
+            charts arrive with the dashboards.
+
+    Returns:
+        Figure: The rendered figure. It is not registered with pyplot, so the
+        caller owns it and nothing accumulates between calls.
+
+    Raises:
+        ValueError: If *spec* does not contain exactly one panel.
+
+    """
+    (panel,) = spec.panels
+
+    width, height = spec.figsize if spec.figsize is not None else (_DEFAULT_WIDTH_PX, spec.height)
+    fig = Figure(figsize=(width / _DPI, height / _DPI), dpi=_DPI)
+    ax = fig.subplots()
+
+    for line in panel.lines:
+        _draw_line(ax, line)
+
+    ax.set_facecolor("white")
+    ax.grid(visible=True, color=_GRID_COLOR, linewidth=_GRID_WIDTH)
+    _apply_axis(ax, panel.xaxis, vertical=False)
+    _apply_axis(ax, panel.yaxis, vertical=True)
+
+    if panel.lines:
+        ax.legend(loc="upper left", frameon=False, ncols=len(panel.lines))
+    fig.suptitle(spec.title)
+    return fig

--- a/src/jquantstats/_reports/_data.py
+++ b/src/jquantstats/_reports/_data.py
@@ -10,6 +10,7 @@ import polars as pl
 if TYPE_CHECKING:
     from jquantstats._protocol import DataLike
 
+from .._plots._backend import plot_backend
 from ._html import (
     _build_full_html,
     _drawdowns_section_html,
@@ -199,7 +200,12 @@ def _report_charts_html(plots: Any, temporal_index: bool) -> str:
                 f"Index is not temporal; skipping calendar-based charts: {skipped}.",
                 stacklevel=2,
             )
-        chart_parts = _collect_chart_divs(plots, _chart_methods, _calendar_charts, temporal_index)
+        # The report embeds Plotly JSON and links plotly.js, so its charts must be
+        # Plotly figures no matter what `set_plot_backend` has been told. Without
+        # this, a matplotlib default would leave every chart silently blank:
+        # `_try_plotly_div` swallows the resulting failure and returns "".
+        with plot_backend("plotly"):
+            chart_parts = _collect_chart_divs(plots, _chart_methods, _calendar_charts, temporal_index)
 
     return "\n".join(chart_parts) if chart_parts else "<p>No charts available.</p>"
 

--- a/src/jquantstats/_reports/_portfolio.py
+++ b/src/jquantstats/_reports/_portfolio.py
@@ -18,6 +18,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 if TYPE_CHECKING:
     from ._protocol import PortfolioLike
 
+from .._plots._backend import plot_backend
 from ._formatting import _fmt, _is_finite, _plotly_div, _table_html
 
 # templates/ lives one level above this subpackage (at src/jquantstats/templates/)
@@ -262,14 +263,19 @@ class Report:
             except Exception as exc:
                 return f'<p class="chart-unavailable">Chart unavailable: {exc}</p>'
 
-        snapshot_div = _try_div(pf.plots.snapshot)
-        rolling_sharpe_div = _try_div(pf.plots.rolling_sharpe_plot)
-        rolling_vol_div = _try_div(pf.plots.rolling_volatility_plot)
-        annual_sharpe_div = _try_div(pf.plots.annual_sharpe_plot)
-        monthly_heatmap_div = _try_div(pf.plots.monthly_returns_heatmap)
-        corr_div = _try_div(pf.plots.correlation_heatmap)
-        lead_lag_div = _try_div(pf.plots.lead_lag_ir_plot)
-        trading_cost_div = _try_div(pf.plots.trading_cost_impact_plot)
+        # The report embeds Plotly JSON and links plotly.js, so its charts must be
+        # Plotly figures no matter what `set_plot_backend` has been told. Without
+        # this, a matplotlib default would leave every chart as a "Chart
+        # unavailable" notice: `_try_div` swallows the resulting failure.
+        with plot_backend("plotly"):
+            snapshot_div = _try_div(pf.plots.snapshot)
+            rolling_sharpe_div = _try_div(pf.plots.rolling_sharpe_plot)
+            rolling_vol_div = _try_div(pf.plots.rolling_volatility_plot)
+            annual_sharpe_div = _try_div(pf.plots.annual_sharpe_plot)
+            monthly_heatmap_div = _try_div(pf.plots.monthly_returns_heatmap)
+            corr_div = _try_div(pf.plots.correlation_heatmap)
+            lead_lag_div = _try_div(pf.plots.lead_lag_ir_plot)
+            trading_cost_div = _try_div(pf.plots.trading_cost_impact_plot)
 
         # ── Stats table ───────────────────────────────────────────────────────
         stats_table = _stats_table_html(pf.stats.summary())

--- a/src/jquantstats/result.py
+++ b/src/jquantstats/result.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import polars as pl
 
+from ._plots._backend import plot_backend
 from .exceptions import MuSchemaError
 from .portfolio import Portfolio
 
@@ -61,11 +62,15 @@ class Result:
 
         self.portfolio.cashposition.write_csv(file=data / "position.csv")
 
-        fig = self.portfolio.plots.snapshot()
-        fig.write_html(file=plots / "snapshot.html", auto_open=False, include_plotlyjs="cdn")
-        fig = self.portfolio.plots.lead_lag_ir_plot()
-        fig.write_html(file=plots / "lag_ir.html", auto_open=False, include_plotlyjs="cdn")
-        fig = self.portfolio.plots.lagged_performance_plot()
-        fig.write_html(file=plots / "lagged_perf.html", auto_open=False, include_plotlyjs="cdn")
-        fig = self.portfolio.plots.smoothed_holdings_performance_plot()
-        fig.write_html(file=plots / "smooth_perf.html", auto_open=False, include_plotlyjs="cdn")
+        # `write_html` is a Plotly-only method, so these charts must be Plotly
+        # figures whatever `set_plot_backend` has been told; a matplotlib figure
+        # would raise AttributeError here.
+        with plot_backend("plotly"):
+            fig = self.portfolio.plots.snapshot()
+            fig.write_html(file=plots / "snapshot.html", auto_open=False, include_plotlyjs="cdn")
+            fig = self.portfolio.plots.lead_lag_ir_plot()
+            fig.write_html(file=plots / "lag_ir.html", auto_open=False, include_plotlyjs="cdn")
+            fig = self.portfolio.plots.lagged_performance_plot()
+            fig.write_html(file=plots / "lagged_perf.html", auto_open=False, include_plotlyjs="cdn")
+            fig = self.portfolio.plots.smoothed_holdings_performance_plot()
+            fig.write_html(file=plots / "smooth_perf.html", auto_open=False, include_plotlyjs="cdn")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,3 +36,25 @@ def _reset_plot_backend():
     saved = jquantstats.get_plot_backend()
     yield
     jquantstats.set_plot_backend(saved)
+
+
+@pytest.fixture(autouse=True)
+def _no_pyplot_leak():
+    """Fail if library code registered a figure in pyplot's global manager.
+
+    The matplotlib backend builds figures with `matplotlib.figure.Figure` so
+    that nothing accumulates in pyplot's ``Gcf`` registry — the leak behind
+    issue #628. A plain ``plt.close("all")`` teardown would quietly clean up a
+    regression instead of reporting it, so the delta is asserted first and only
+    then cleared.
+    """
+    import matplotlib.pyplot as plt
+
+    before = set(plt.get_fignums())
+    yield
+    leaked = set(plt.get_fignums()) - before
+    plt.close("all")
+    assert not leaked, (
+        f"pyplot-managed figures {sorted(leaked)} leaked — build figures with "
+        "matplotlib.figure.Figure(), not plt.figure()/plt.subplots()"
+    )

--- a/tests/test_jquantstats/test__plots/test_mpl_backend.py
+++ b/tests/test_jquantstats/test__plots/test_mpl_backend.py
@@ -1,0 +1,260 @@
+"""The matplotlib rendering backend, and its parity with Plotly.
+
+Three concerns, in order:
+
+* **dispatch** — that a backend is selected from the right place;
+* **parity** — that both backends plot the same numbers, which is the property
+  the spec/renderer split exists to guarantee;
+* **translation** — that each semantic spec property reaches the right
+  matplotlib artist, including the ones no cumulative chart happens to use.
+"""
+
+from __future__ import annotations
+
+import matplotlib.figure as mfigure
+import plotly.graph_objects as go
+import polars as pl
+import pytest
+from matplotlib.ticker import StrMethodFormatter
+
+import jquantstats
+from jquantstats._plots import _backend
+from jquantstats._plots._render import render, render_plotly
+from jquantstats._plots._render._mpl import _DEFAULT_WIDTH_PX, _DPI, render_mpl
+from jquantstats._plots._spec import Axis, FigureSpec, LineSeries, Panel
+from jquantstats.exceptions import MissingBackendError
+
+# Every cumulative chart, with arguments exercising the interesting branches.
+CUMULATIVE_CHARTS = [
+    ("returns", {}),
+    ("returns", {"log_scale": True}),
+    ("compare", {}),
+    ("compare", {"figsize": (920, 420)}),
+    ("log_returns", {}),
+    ("log_returns", {"figsize": (800, 400)}),
+    ("earnings", {}),
+    ("earnings", {"compounded": False}),
+    ("earnings", {"start_balance": 250_000}),
+]
+_IDS = [f"{name}-{sorted(kwargs)}" for name, kwargs in CUMULATIVE_CHARTS]
+
+
+def _line(**overrides) -> LineSeries:
+    """Build a minimal line series, overriding selected fields."""
+    defaults = {
+        "name": "AAPL",
+        "x": pl.Series("date", [1, 2, 3]),
+        "y": pl.Series("AAPL", [1.0, 1.1, 1.2]),
+        "color": "#636EFA",
+    }
+    return LineSeries(**{**defaults, **overrides})
+
+
+def _spec(panel: Panel, **overrides) -> FigureSpec:
+    """Build a single-panel figure spec, overriding selected fields."""
+    return FigureSpec(**{"title": "T", "panels": (panel,), **overrides})
+
+
+# ── dispatch ─────────────────────────────────────────────────────────────────
+
+
+def test_default_backend_still_returns_plotly(data) -> None:
+    """Existing callers are untouched: no argument still means Plotly."""
+    assert isinstance(data.plots.returns(), go.Figure)
+
+
+def test_explicit_backend_selects_matplotlib(data) -> None:
+    """A per-call argument selects the renderer."""
+    assert isinstance(data.plots.returns(backend="matplotlib"), mfigure.Figure)
+
+
+def test_global_default_reaches_the_plot_methods(data) -> None:
+    """`set_plot_backend` changes what a bare call returns."""
+    jquantstats.set_plot_backend("matplotlib")
+    assert isinstance(data.plots.returns(), mfigure.Figure)
+
+
+def test_context_manager_reaches_the_plot_methods(data) -> None:
+    """A scoped override applies inside the block and not outside it."""
+    with jquantstats.plot_backend("matplotlib"):
+        assert isinstance(data.plots.returns(), mfigure.Figure)
+    assert isinstance(data.plots.returns(), go.Figure)
+
+
+def test_explicit_argument_outranks_the_global_default(data) -> None:
+    """The most specific selection wins."""
+    jquantstats.set_plot_backend("matplotlib")
+    assert isinstance(data.plots.returns(backend="plotly"), go.Figure)
+
+
+def test_missing_matplotlib_names_the_extra(data, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Selecting an uninstalled backend explains how to install it."""
+    monkeypatch.setattr(_backend, "_find_spec", lambda name: None)
+    with pytest.raises(MissingBackendError, match=r"jquantstats\[mpl\]"):
+        data.plots.returns(backend="matplotlib")
+
+
+def test_render_dispatches_to_both_backends() -> None:
+    """`render` is the single seam both backends are reached through."""
+    spec = _spec(Panel(lines=(_line(),)))
+    assert isinstance(render(spec, "plotly"), go.Figure)
+    assert isinstance(render(spec, "matplotlib"), mfigure.Figure)
+
+
+# ── parity ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(("method", "kwargs"), CUMULATIVE_CHARTS, ids=_IDS)
+def test_backends_plot_the_same_numbers(data, method: str, kwargs: dict) -> None:
+    """Both backends draw identical series for every cumulative chart.
+
+    This is the anti-drift ratchet. It only holds because both figures are
+    rendered from one spec, so there is a single copy of the arithmetic; if the
+    two renderers are ever fed from separate code paths, this fails.
+    """
+    plotly_fig = getattr(data.plots, method)(**kwargs, backend="plotly")
+    mpl_fig = getattr(data.plots, method)(**kwargs, backend="matplotlib")
+
+    mpl_lines = mpl_fig.axes[0].get_lines()
+    assert len(mpl_lines) == len(plotly_fig.data)
+
+    for trace, line in zip(plotly_fig.data, mpl_lines, strict=True):
+        assert trace.name == line.get_label()
+        assert list(trace.y) == pytest.approx(list(line.get_ydata()), nan_ok=True)
+
+
+@pytest.mark.parametrize(("method", "kwargs"), CUMULATIVE_CHARTS, ids=_IDS)
+def test_backends_agree_on_colours(data, method: str, kwargs: dict) -> None:
+    """Colour is chosen in the spec, so both backends use the same one."""
+    plotly_fig = getattr(data.plots, method)(**kwargs, backend="plotly")
+    mpl_fig = getattr(data.plots, method)(**kwargs, backend="matplotlib")
+
+    plotly_colors = [trace.line.color.lower() for trace in plotly_fig.data]
+    mpl_colors = [line.get_color().lower() for line in mpl_fig.axes[0].get_lines()]
+    assert plotly_colors == mpl_colors
+
+
+def test_validation_is_backend_independent(data_no_benchmark) -> None:
+    """Validation sits in the builder, so every backend raises alike."""
+    for backend in ("plotly", "matplotlib"):
+        with pytest.raises(AttributeError, match=r"^compare\(\) requires benchmark data to be set$"):
+            data_no_benchmark.plots.compare(backend=backend)
+
+
+# ── translation ──────────────────────────────────────────────────────────────
+
+
+def test_figures_are_not_registered_with_pyplot(data) -> None:
+    """Rendering must not add to pyplot's global registry.
+
+    A figure that pyplot owns is never garbage collected, which is the leak
+    behind issue #628. The autouse leak fixture guards the whole suite; this
+    states the requirement where it is easy to find.
+    """
+    import matplotlib.pyplot as plt
+
+    before = set(plt.get_fignums())
+    for _ in range(25):
+        data.plots.returns(backend="matplotlib")
+    assert set(plt.get_fignums()) == before
+
+
+def test_figsize_is_pixels_on_both_backends(data) -> None:
+    """`figsize=(920, 420)` means the same thing either way.
+
+    Plotly measures in pixels and matplotlib in inches, so the renderer
+    converts. Without that, one public signature would frame two different
+    charts.
+    """
+    plotly_fig = data.plots.compare(figsize=(920, 420), backend="plotly")
+    mpl_fig = data.plots.compare(figsize=(920, 420), backend="matplotlib")
+
+    assert (plotly_fig.layout.width, plotly_fig.layout.height) == (920, 420)
+    assert mpl_fig.get_size_inches().tolist() == [9.2, 4.2]
+    assert mpl_fig.dpi == _DPI
+
+
+def test_default_width_applies_when_no_figsize_given(data) -> None:
+    """A chart that names no width still needs a concrete one."""
+    fig = data.plots.returns(backend="matplotlib")
+    assert fig.get_size_inches().tolist() == [_DEFAULT_WIDTH_PX / _DPI, 600 / _DPI]
+
+
+def test_title_becomes_the_figure_suptitle(data) -> None:
+    """The chart title survives the translation."""
+    assert data.plots.returns(title="Growth", backend="matplotlib").get_suptitle() == "Growth"
+
+
+def test_dashed_benchmarks_are_dashed(data) -> None:
+    """Benchmarks read as the reference on this backend too."""
+    fig = data.plots.compare(backend="matplotlib")
+    styles = [line.get_linestyle() for line in fig.axes[0].get_lines()]
+    assert "--" in styles, f"expected a dashed benchmark, got {styles}"
+
+
+def test_log_scale_reaches_the_axis(data) -> None:
+    """`log_scale` sets the axis scale rather than transforming the data."""
+    assert data.plots.returns(log_scale=True, backend="matplotlib").axes[0].get_yscale() == "log"
+    assert data.plots.returns(log_scale=False, backend="matplotlib").axes[0].get_yscale() == "linear"
+
+
+def test_currency_ticks_carry_the_prefix(data) -> None:
+    """The earnings axis renders as money."""
+    fig = data.plots.earnings(backend="matplotlib")
+    assert fig.axes[0].yaxis.get_major_formatter()(12345.0) == "$12,345"
+
+
+def test_axis_without_tick_format_keeps_the_default_formatter(data) -> None:
+    """Log returns set no tick format, so matplotlib's default stands."""
+    fig = data.plots.log_returns(backend="matplotlib")
+    assert not isinstance(fig.axes[0].yaxis.get_major_formatter(), StrMethodFormatter)
+
+
+def test_both_axes_are_honoured() -> None:
+    """A configured x-axis reaches the figure, not just the y-axis.
+
+    No cumulative chart configures its x-axis, so without this the x-axis path
+    would be an untested no-op on this backend.
+    """
+    panel = Panel(
+        lines=(_line(),),
+        xaxis=Axis(title="When", tick_format="float2", log=True),
+        yaxis=Axis(title="How much"),
+    )
+    ax = render_mpl(_spec(panel)).axes[0]
+    assert ax.get_xlabel() == "When"
+    assert ax.get_ylabel() == "How much"
+    assert ax.get_xscale() == "log"
+
+
+def test_lineless_spec_draws_no_legend() -> None:
+    """An empty chart must not ask matplotlib for a legend with no entries."""
+    fig = render_mpl(_spec(Panel()))
+    assert fig.axes[0].get_legend() is None
+
+
+def test_render_rejects_multi_panel_specs() -> None:
+    """Multi-panel rendering arrives with the dashboards, not before."""
+    panel = Panel(lines=(_line(),))
+    with pytest.raises(ValueError, match="too many values"):
+        render_mpl(FigureSpec(title="T", panels=(panel, panel)))
+
+
+def test_hover_is_dropped_rather_than_emulated(data) -> None:
+    """Tooltips are interactive; the static backend simply omits them.
+
+    Recorded as a deliberate degradation rather than left as an unstated gap.
+    """
+    plotly_fig = data.plots.returns(backend="plotly")
+    assert plotly_fig.data[0].hovertemplate
+
+    mpl_fig = data.plots.returns(backend="matplotlib")
+    assert not mpl_fig.axes[0].texts
+
+
+def test_renderers_are_independent_of_one_another() -> None:
+    """Rendering one backend must not disturb the other's output."""
+    spec = _spec(Panel(lines=(_line(),)))
+    before = render_plotly(spec).to_json()
+    render_mpl(spec)
+    assert render_plotly(spec).to_json() == before

--- a/tests/test_jquantstats/test__plots/test_no_pyplot.py
+++ b/tests/test_jquantstats/test__plots/test_no_pyplot.py
@@ -12,15 +12,20 @@ This cannot be an import-linter contract — import-linter rejects
 and forbidding the whole ``matplotlib`` distribution would ban the renderer
 itself. So the ban is enforced two ways instead:
 
-* statically, by scanning the shipped source for a ``pyplot`` reference, which
-  catches the mistake at authoring time even in a branch no test executes; and
+* statically, by inspecting each module's import statements, which catches the
+  mistake at authoring time even in a branch no test executes; and
 * dynamically, by `test_importing_jquantstats_does_not_import_pyplot`, which
-  catches an indirect import that the scan cannot see.
+  catches an indirect import that no static check can see.
+
+The static half reads the parsed syntax tree rather than the file's text. A
+text search also matches prose — this module and the matplotlib renderer both
+have to *name* pyplot to explain why they avoid it — and a guard that punishes
+its own documentation would just be commented out.
 """
 
 from __future__ import annotations
 
-import re
+import ast
 import subprocess
 import sys
 from pathlib import Path
@@ -28,10 +33,7 @@ from pathlib import Path
 import pytest
 
 _SRC = Path(__file__).absolute().parents[3] / "src" / "jquantstats"
-
-# Matches `import matplotlib.pyplot`, `from matplotlib.pyplot import ...`,
-# `from matplotlib import pyplot`, and any bare `pylab` reference.
-_PYPLOT = re.compile(r"\bpyplot\b|\bpylab\b")
+_BANNED = {"matplotlib.pyplot", "pylab"}
 
 
 def _python_sources() -> list[Path]:
@@ -44,24 +46,61 @@ def _python_sources() -> list[Path]:
     return sorted(_SRC.rglob("*.py"))
 
 
+def _banned_imports(source: str) -> list[str]:
+    """Find banned module imports in *source*.
+
+    Covers ``import matplotlib.pyplot``, ``from matplotlib.pyplot import ...``
+    and ``from matplotlib import pyplot``, in any nesting — a function-local
+    import is exactly as leaky as a top-level one.
+
+    Args:
+        source: Python source text.
+
+    Returns:
+        list[str]: The banned module names imported, in source order.
+
+    """
+    found: list[str] = []
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            found.extend(alias.name for alias in node.names if alias.name in _BANNED)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module in _BANNED:
+                found.append(module)
+            elif module == "matplotlib":
+                found.extend(f"matplotlib.{a.name}" for a in node.names if a.name == "pyplot")
+    return found
+
+
 def test_source_tree_is_discoverable() -> None:
     """The scan below is worthless if it silently matches no files."""
     assert _python_sources(), f"no Python sources found under {_SRC}"
 
 
+def test_detects_a_banned_import() -> None:
+    """The detector itself works, on each spelling it must catch."""
+    assert _banned_imports("import matplotlib.pyplot as plt") == ["matplotlib.pyplot"]
+    assert _banned_imports("from matplotlib import pyplot") == ["matplotlib.pyplot"]
+    assert _banned_imports("from matplotlib.pyplot import plot") == ["matplotlib.pyplot"]
+    assert _banned_imports("def f():\n    import pylab") == ["pylab"]
+    assert _banned_imports("from matplotlib.figure import Figure") == []
+    assert _banned_imports('"""A docstring mentioning pyplot and plt."""') == []
+
+
 @pytest.mark.parametrize("path", _python_sources(), ids=lambda p: p.name)
-def test_module_does_not_reference_pyplot(path: Path) -> None:
-    """No shipped module may reference pyplot or pylab.
+def test_module_does_not_import_pyplot(path: Path) -> None:
+    """No shipped module may import pyplot or pylab.
 
     Use ``matplotlib.figure.Figure()`` and ``fig.subplots()`` instead of
     ``plt.figure()`` / ``plt.subplots()``; a directly constructed Figure stays
     out of pyplot's global registry and still supports ``fig.savefig(...)``.
     """
-    hit = _PYPLOT.search(path.read_text(encoding="utf-8"))
-    assert hit is None, (
-        f"{path.relative_to(_SRC.parents[1])} references {hit.group(0)!r} — "
-        "build figures with matplotlib.figure.Figure() instead, so they are "
-        "never registered in pyplot's global Gcf registry (see #628)"
+    found = _banned_imports(path.read_text(encoding="utf-8"))
+    assert not found, (
+        f"{path.relative_to(_SRC.parents[1])} imports {found} — build figures with "
+        "matplotlib.figure.Figure() instead, so they are never registered in "
+        "pyplot's global Gcf registry (see #628)"
     )
 
 
@@ -79,3 +118,28 @@ def test_importing_jquantstats_does_not_import_pyplot() -> None:
         check=True,
     )
     assert result.stdout.strip() == "False", "importing jquantstats pulled in matplotlib.pyplot"
+
+
+def test_rendering_does_not_import_pyplot() -> None:
+    """Nor may actually drawing a matplotlib figure pull pyplot in.
+
+    The import-time check above would still pass if the renderer imported
+    pyplot lazily inside its drawing code, which is precisely where a
+    ``plt.subplots()`` would end up.
+    """
+    script = (
+        "import sys, datetime as dt, polars as pl\n"
+        "from jquantstats import Data\n"
+        "d0 = dt.date(2023, 1, 1)\n"
+        "r = pl.DataFrame({'date': [d0 + dt.timedelta(days=i) for i in range(9)],\n"
+        "                  'A': [0.01, -0.02, 0.03] * 3})\n"
+        "Data.from_returns(returns=r).plots.returns(backend='matplotlib')\n"
+        "print('matplotlib.pyplot' in sys.modules)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "False", "rendering a matplotlib figure pulled in pyplot"

--- a/tests/test_jquantstats/test__reports/test_reports_stay_plotly.py
+++ b/tests/test_jquantstats/test__reports/test_reports_stay_plotly.py
@@ -1,0 +1,80 @@
+"""The HTML reports stay Plotly whatever the global backend is set to.
+
+Reports embed Plotly JSON and link plotly.js, so they cannot use a matplotlib
+figure. Nothing about that fails loudly if it regresses: the report builders
+wrap each chart in a try/except that turns a failure into an empty string or a
+"Chart unavailable" notice, so a report would simply come out with no charts.
+These tests are the alarm for that.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import polars as pl
+import pytest
+
+import jquantstats
+from jquantstats import Portfolio
+
+
+@pytest.fixture
+def simple_portfolio() -> Portfolio:
+    """20-day single-asset Portfolio, enough to render every report chart."""
+    n = 20
+    start = date(2020, 1, 1)
+    dates = pl.date_range(start=start, end=start + timedelta(days=n - 1), interval="1d", eager=True).cast(pl.Date)
+    return Portfolio.from_cash_position(
+        prices=pl.DataFrame({"date": dates, "A": pl.Series([100.0 * (1.005**i) for i in range(n)])}),
+        cash_position=pl.DataFrame({"date": dates, "A": pl.Series([1000.0] * n, dtype=pl.Float64)}),
+        aum=1e5,
+    )
+
+
+def test_data_report_renders_every_chart_under_a_matplotlib_default(data) -> None:
+    """`Data.reports.full()` renders all eight charts even so.
+
+    The count is the whole test. A matplotlib figure reaching this path does
+    not raise — `_try_plotly_div` swallows the failure and returns "" — so the
+    chart just disappears while the other seven still prove "Plotly is in the
+    output". Asserting the total is what makes the failure visible: without the
+    backend pinned, this is 7.
+    """
+    jquantstats.set_plot_backend("matplotlib")
+    html = data.reports.full()
+
+    assert "cdn.plot.ly" in html
+    assert html.count("Plotly.newPlot") == 8
+
+
+def test_portfolio_report_embeds_plotly_under_a_matplotlib_default(simple_portfolio) -> None:
+    """`Portfolio.report.to_html()` renders Plotly charts even so."""
+    jquantstats.set_plot_backend("matplotlib")
+    html = simple_portfolio.report.to_html()
+
+    assert "cdn.plot.ly" in html
+    # The literal notice, not the class name — the stylesheet defines
+    # `.chart-unavailable` whether or not any chart actually failed.
+    assert '<p class="chart-unavailable">' not in html
+    # All eight portfolio charts, so a partial failure is caught too.
+    assert html.count("Plotly.newPlot") == 8
+
+
+def test_result_writes_plotly_html_under_a_matplotlib_default(simple_portfolio, tmp_path) -> None:
+    """`Result.create_reports()` still writes Plotly documents.
+
+    `write_html` exists only on a Plotly figure, so a matplotlib figure reaching
+    this path raises AttributeError rather than degrading quietly.
+    """
+    jquantstats.set_plot_backend("matplotlib")
+    jquantstats.Result(portfolio=simple_portfolio).create_reports(tmp_path)
+
+    snapshot = (tmp_path / "plots" / "snapshot.html").read_text(encoding="utf-8")
+    assert "cdn.plot.ly" in snapshot
+
+
+def test_reports_restore_the_caller_s_backend(data) -> None:
+    """Pinning Plotly inside a report must not leak out of it."""
+    jquantstats.set_plot_backend("matplotlib")
+    data.reports.full()
+    assert jquantstats.get_plot_backend() == "matplotlib"


### PR DESCRIPTION
Third of the #628 series, and the one that makes the feature real. The four cumulative
charts now render with matplotlib as well as Plotly:

```python
import jquantstats as jqs

data.plots.returns(backend="matplotlib")   # per call
with jqs.plot_backend("matplotlib"): ...   # scoped
jqs.set_plot_backend("matplotlib")         # process-wide
```

Plotly stays the default — nothing changes for existing callers.

> **Stacked on #943**, which is stacked on #940. Base is `feat/628-cumulative-spec`, so
> this diff shows only the matplotlib work.

## The spec split paying off

Because both figures come from one spec, the matplotlib renderer is **~40 statements**
rather than a second copy of every chart — and a parity test can assert the two backends
plot the same numbers, which it does across all nine argument combinations:

```python
for trace, line in zip(plotly_fig.data, mpl_lines, strict=True):
    assert trace.name == line.get_label()
    assert list(trace.y) == pytest.approx(list(line.get_ydata()), nan_ok=True)
```

That is the anti-drift ratchet. It can only pass while there is a single copy of the
arithmetic; feed the two renderers from separate code paths and it fails.

## No pyplot, enforced three ways

pyplot keeps every figure alive in a global `Gcf` registry — the leak behind the original
report. Figures are built with `matplotlib.figure.Figure` directly, so the caller owns
them. That is enforced, not merely intended:

- an **AST-based import check** over every shipped module;
- a **subprocess test** that renders a chart and asserts pyplot was never imported (an
  import-time check alone would miss a lazy `plt.subplots()` inside drawing code);
- an **autouse fixture** failing any test that leaves a new pyplot-managed figure behind.

## A silent-failure hole in the reports, now closed

`_try_plotly_div` and `_try_div` turn a rendering failure into `""` or a "Chart
unavailable" notice. So a matplotlib figure reaching a report **would not raise** — the
chart would simply vanish. The three report paths now pin Plotly with
`plot_backend("plotly")`.

Using the context manager rather than passing `backend="plotly"` at each call site means
it works uniformly for the 25 methods that have not migrated yet, and needs no further
change as they do.

**The first version of the regression test did not actually catch this.** Asserting
"Plotly is in the output" still passed without the pin, because the seven unmigrated
charts rendered Plotly and masked the one that disappeared. I verified the counterfactual
and rewrote the assertion as a chart count, which does fail (8 → 7).

## Typing

`@overload` on the literal `backend`, rather than widening the return type. Widening
would break `_reports/_protocol.py` under `--strict` and force every `py.typed` consumer
to narrow a union that was not there before.

| call | inferred |
|---|---|
| `data.plots.returns()` | `Any` — unchanged; plotly ships no stubs |
| `data.plots.returns(backend="matplotlib")` | `matplotlib.figure.Figure` |

Documented caveat: after `set_plot_backend("matplotlib")`, a call passing no `backend`
returns the new default's figure while still being *typed* as Plotly's. That is intrinsic
to any global-default design; pass `backend=` explicitly if you care about static types.

## Two things the gates caught that I had wrong

- **Parity failed on nulls.** `to_list()` turns a polars null into `None`, giving
  matplotlib a slow object-dtype array it cannot interpolate across. `to_numpy()` yields
  NaN, which matplotlib draws as a proper gap.
- **The pyplot guard flagged the matplotlib renderer itself** — its docstring has to
  *name* pyplot to explain why it avoids it. A text search was the wrong tool; the check
  now reads the parsed syntax tree, with a test proving the detector catches each import
  spelling while ignoring prose.

Also removes the temporary deptry `DEP002` ignore added in #940, exactly as its comment
instructed: there is now a real matplotlib import in `src/` for deptry to observe.

## Documented degradation

Hover tooltips and the date range-selector are interactive and have no matplotlib
equivalent. They are silently absent — a warning on every call would be noise and would
break someone's `-W error` CI. `test_hover_is_dropped_rather_than_emulated` records it as
a deliberate choice rather than an unstated gap.

## Verification

`make all` green: **fmt, deps, test, docs-coverage, security, license, typecheck
(mypy --strict *and* ty), rhiza-test**.

- 1,559 passed, 5 skipped (kaleido, no local Chrome)
- **100% line + branch coverage**, 0 `# pragma: no cover`, 0 `noqa` added
- **67 snapshots passed without regeneration** — the Plotly path is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)