### PR TITLE
Port the periodic charts to both backends (#628)

### DIFF
--- a/src/jquantstats/_plots/_data/_periodic.py
+++ b/src/jquantstats/_plots/_data/_periodic.py
@@ -2,57 +2,24 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
-import plotly.graph_objects as go
-import polars as pl
-
-from ._styling import _apply_base_layout, _bar_colors, _ticker_colors, _yearly_bar_colors
+from .._render import render
+from .._specs import (
+    daily_returns_spec,
+    monthly_heatmap_spec,
+    monthly_returns_spec,
+    yearly_returns_spec,
+)
 
 if TYPE_CHECKING:
+    from matplotlib.figure import Figure as MplFigure
+    from plotly.graph_objects import Figure as PlotlyFigure
+
     from jquantstats._protocol import DataLike
 
-
-def _period_agg_exprs(tickers: list[str], compounded: bool) -> list[pl.Expr]:
-    """Per-ticker aggregation expressions for a period bucket.
-
-    Args:
-        tickers: Asset column names to aggregate.
-        compounded: Compound returns within the bucket when True, sum them
-            when False.
-
-    Returns:
-        One aliased expression per ticker.
-    """
-    if compounded:
-        return [((1.0 + pl.col(t)).product() - 1.0).alias(t) for t in tickers]
-    return [pl.col(t).sum().alias(t) for t in tickers]
-
-
-def _monthly_heatmap_matrix(
-    monthly: pl.DataFrame, years: list[int]
-) -> tuple[list[list[float | None]], list[list[str]]]:
-    """Build the year-by-month value and label grids for the monthly heatmap.
-
-    Args:
-        monthly: Aggregated frame with ``_year``, ``_month`` and ``ret`` columns.
-        years: Sorted unique years, defining the row order of the output grids.
-
-    Returns:
-        A ``(z, text)`` tuple: ``z`` holds returns scaled to percent (``None``
-        for missing cells) and ``text`` the formatted per-cell labels.
-
-    """
-    year_idx = {y: i for i, y in enumerate(years)}
-    z: list[list[float | None]] = [[None] * 12 for _ in years]
-    text: list[list[str]] = [[""] * 12 for _ in years]
-    for row in monthly.iter_rows(named=True):
-        yi = year_idx[row["_year"]]
-        mi = row["_month"] - 1
-        val = row["ret"]
-        z[yi][mi] = val * 100 if val is not None else None
-        text[yi][mi] = f"{val:.1%}" if val is not None else ""
-    return z, text
+    from .._backend import Backend
+    from .._render import Figure
 
 
 class _PeriodicPlotsMixin:
@@ -62,7 +29,13 @@ class _PeriodicPlotsMixin:
 
     _data: DataLike
 
-    def daily_returns(self, title: str = "Daily Returns") -> go.Figure:
+    @overload
+    def daily_returns(self, title: str = ..., *, backend: Literal["plotly"] | None = ...) -> PlotlyFigure: ...
+
+    @overload
+    def daily_returns(self, title: str = ..., *, backend: Literal["matplotlib"]) -> MplFigure: ...
+
+    def daily_returns(self, title: str = "Daily Returns", *, backend: Backend | None = None) -> Figure:
         """Daily returns as a bar chart.
 
         Each bar is coloured green for positive returns and red for negative
@@ -72,124 +45,102 @@ class _PeriodicPlotsMixin:
 
         Args:
             title: Chart title. Defaults to ``"Daily Returns"``.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly bar chart.
+            Figure: A bar chart.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        colors = _ticker_colors(tickers)
-        single = len(tickers) == 1
+        return render(daily_returns_spec(self._data, title=title), backend)
 
-        fig = go.Figure()
-        for ticker in tickers:
-            values = df[ticker].to_list()
-            bar_colors = _bar_colors(values, colors[ticker], single_asset=single)
+    @overload
+    def yearly_returns(
+        self, title: str = ..., compounded: bool = ..., *, backend: Literal["plotly"] | None = ...
+    ) -> PlotlyFigure: ...
 
-            fig.add_trace(
-                go.Bar(
-                    x=df[date_col],
-                    y=df[ticker],
-                    name=ticker,
-                    marker={"color": bar_colors, "line": {"width": 0}},
-                    opacity=0.85,
-                    hovertemplate=f"{ticker}: %{{y:.2%}}",
-                )
-            )
+    @overload
+    def yearly_returns(
+        self, title: str = ..., compounded: bool = ..., *, backend: Literal["matplotlib"]
+    ) -> MplFigure: ...
 
-        _apply_base_layout(fig, title)
-        fig.update_yaxes(title_text="Return", tickformat=".1%")
-        return fig
-
-    def yearly_returns(self, title: str = "Yearly Returns", compounded: bool = True) -> go.Figure:
+    def yearly_returns(
+        self,
+        title: str = "Yearly Returns",
+        compounded: bool = True,
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Annual compounded (or summed) returns as a grouped bar chart.
 
         Args:
             title: Chart title. Defaults to ``"Yearly Returns"``.
             compounded: Compound returns within each year. Defaults to True.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly grouped bar chart.
+            Figure: A grouped bar chart.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        colors = _ticker_colors(tickers)
+        return render(yearly_returns_spec(self._data, title=title, compounded=compounded), backend)
 
-        agg_exprs = _period_agg_exprs(tickers, compounded)
-        yearly = (
-            df.with_columns(pl.col(date_col).dt.year().alias("_year")).group_by("_year").agg(agg_exprs).sort("_year")
-        )
+    @overload
+    def monthly_returns(
+        self, title: str = ..., compounded: bool = ..., *, backend: Literal["plotly"] | None = ...
+    ) -> PlotlyFigure: ...
 
-        fig = go.Figure()
-        for ticker in tickers:
-            bar_colors = _yearly_bar_colors(yearly[ticker].to_list(), colors[ticker])
-            fig.add_trace(
-                go.Bar(
-                    x=yearly["_year"],
-                    y=yearly[ticker],
-                    name=ticker,
-                    marker={"color": bar_colors, "line": {"width": 0}},
-                    opacity=0.85,
-                    hovertemplate=f"{ticker}: %{{y:.2%}}",
-                )
-            )
+    @overload
+    def monthly_returns(
+        self, title: str = ..., compounded: bool = ..., *, backend: Literal["matplotlib"]
+    ) -> MplFigure: ...
 
-        _apply_base_layout(fig, title, with_range_selector=False)
-        fig.update_layout(barmode="group", xaxis_title="Year")
-        fig.update_yaxes(title_text="Annual Return", tickformat=".1%")
-        return fig
-
-    def monthly_returns(self, title: str = "Monthly Returns", compounded: bool = True) -> go.Figure:
+    def monthly_returns(
+        self,
+        title: str = "Monthly Returns",
+        compounded: bool = True,
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Monthly compounded (or summed) returns as a bar chart.
 
         Args:
             title: Chart title. Defaults to ``"Monthly Returns"``.
             compounded: Compound returns within each month. Defaults to True.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly bar chart.
+            Figure: A bar chart.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        colors = _ticker_colors(tickers)
-        single = len(tickers) == 1
+        return render(monthly_returns_spec(self._data, title=title, compounded=compounded), backend)
 
-        monthly = df.group_by_dynamic(
-            index_column=date_col, every="1mo", period="1mo", closed="right", label="right"
-        ).agg(_period_agg_exprs(tickers, compounded))
+    @overload
+    def monthly_heatmap(
+        self,
+        title: str = ...,
+        compounded: bool = ...,
+        asset: str | None = ...,
+        *,
+        backend: Literal["plotly"] | None = ...,
+    ) -> PlotlyFigure: ...
 
-        fig = go.Figure()
-        for ticker in tickers:
-            values = monthly[ticker].to_list()
-            bar_colors = _bar_colors(values, colors[ticker], single_asset=single)
-
-            fig.add_trace(
-                go.Bar(
-                    x=monthly[date_col],
-                    y=monthly[ticker],
-                    name=ticker,
-                    marker={"color": bar_colors, "line": {"width": 0}},
-                    opacity=0.85,
-                    hovertemplate=f"{ticker}: %{{y:.2%}}",
-                )
-            )
-
-        _apply_base_layout(fig, title)
-        fig.update_yaxes(title_text="Monthly Return", tickformat=".1%")
-        return fig
+    @overload
+    def monthly_heatmap(
+        self,
+        title: str = ...,
+        compounded: bool = ...,
+        asset: str | None = ...,
+        *,
+        backend: Literal["matplotlib"],
+    ) -> MplFigure: ...
 
     def monthly_heatmap(
         self,
         title: str = "Monthly Returns Heatmap",
         compounded: bool = True,
         asset: str | None = None,
-    ) -> go.Figure:
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Monthly returns calendar heatmap (year x month).
 
         One heatmap is produced per call for a single asset.  Green cells
@@ -200,53 +151,11 @@ class _PeriodicPlotsMixin:
             compounded: Compound intra-month returns. Defaults to True.
             asset: Asset column name to display.  Defaults to the first
                 non-date column in the dataset.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly heatmap.
+            Figure: A calendar heatmap.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        col = asset if asset in tickers else tickers[0]
-
-        month_names = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
-
-        agg_expr = ((1.0 + pl.col(col)).product() - 1.0).alias("ret") if compounded else pl.col(col).sum().alias("ret")
-        monthly = (
-            df.with_columns(
-                [
-                    pl.col(date_col).dt.year().alias("_year"),
-                    pl.col(date_col).dt.month().alias("_month"),
-                ]
-            )
-            .group_by(["_year", "_month"])
-            .agg(agg_expr.alias("ret"))
-            .sort(["_year", "_month"])
-        )
-
-        years = sorted(monthly["_year"].unique().to_list())
-        z, text = _monthly_heatmap_matrix(monthly, years)
-
-        fig = go.Figure(
-            go.Heatmap(
-                x=month_names,
-                y=[str(y) for y in years],
-                z=z,
-                text=text,
-                texttemplate="%{text}",
-                colorscale=[[0, "#d62728"], [0.5, "#ffffff"], [1, "#2ca02c"]],
-                zmid=0,
-                showscale=True,
-                colorbar={"title": "Return (%)"},
-                hovertemplate="<b>%{y} %{x}</b><br>Return: %{text}<extra></extra>",
-            )
-        )
-
-        fig.update_layout(
-            title=f"{title} — {col}",
-            height=max(300, 40 * len(years) + 100),
-            plot_bgcolor="white",
-            xaxis={"side": "top"},
-        )
-        return fig
+        spec = monthly_heatmap_spec(self._data, title=title, compounded=compounded, asset=asset)
+        return render(spec, backend)

--- a/src/jquantstats/_plots/_data/_styling.py
+++ b/src/jquantstats/_plots/_data/_styling.py
@@ -12,8 +12,10 @@ from typing import Any
 
 import plotly.graph_objects as go
 
+from .._style import bar_colors as _bar_colors
 from .._style import hex_to_rgba as _hex_to_rgba
 from .._style import ticker_colors as _ticker_colors
+from .._style import yearly_bar_colors as _yearly_bar_colors
 
 __all__ = [
     "_apply_base_layout",
@@ -91,33 +93,6 @@ def _apply_figsize(fig: go.Figure, figsize: tuple[int, int] | None) -> go.Figure
     if figsize is not None:
         fig.update_layout(width=figsize[0], height=figsize[1])
     return fig
-
-
-def _bar_colors(values: list[float | None], positive_color: str, single_asset: bool = False) -> list[str]:
-    """Return the shared positive/negative bar colors for a series of values."""
-    if single_asset:
-        return ["#2ca02c" if v is not None and v > 0 else "#d62728" for v in values]
-    negative_color = _hex_to_rgba(positive_color, alpha=0.4)
-    return [positive_color if v is not None and v > 0 else negative_color for v in values]
-
-
-def _yearly_bar_colors(values: list[float | None], positive_color: str) -> list[str]:
-    """Bar colors for the yearly-returns chart.
-
-    Deliberately distinct from `_bar_colors`: the yearly chart treats a flat
-    zero year as positive (``>= 0``) and fades negatives to alpha 0.5 rather
-    than 0.4, so the two cannot share an implementation without changing what
-    is rendered.
-
-    Args:
-        values: The per-year return values; ``None`` counts as negative.
-        positive_color: The asset's base color.
-
-    Returns:
-        One color string per value.
-    """
-    negative_color = _hex_to_rgba(positive_color, 0.5)
-    return [positive_color if v is not None and v >= 0 else negative_color for v in values]
 
 
 def _compute_drawdown_periods(prices: list[float], n: int) -> list[dict[str, Any]]:

--- a/src/jquantstats/_plots/_render/_mpl.py
+++ b/src/jquantstats/_plots/_render/_mpl.py
@@ -19,11 +19,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
 from matplotlib.axes import Axes
+from matplotlib.colors import LinearSegmentedColormap, TwoSlopeNorm, to_rgba
 from matplotlib.figure import Figure
 from matplotlib.ticker import StrMethodFormatter
 
-from .._spec import Axis, FigureSpec, LineSeries, TickFormat
+from .._spec import Axis, BarSeries, ColorScale, FigureSpec, HeatmapGrid, LineSeries, TickFormat
 
 if TYPE_CHECKING:
     from matplotlib.ticker import Formatter
@@ -39,11 +41,20 @@ _DPI = 100
 # width get this one.
 _DEFAULT_WIDTH_PX = 1000
 
-# Semantic tick format -> a str.format field spec.
+# Semantic tick format -> a str.format field spec. Python's format mini-language
+# covers percentages too, so `StrMethodFormatter` serves every case and no
+# separate `PercentFormatter` is needed.
 _FORMATS = {
     "float2": "{x:.2f}",
     "float4": "{x:.4f}",
+    "percent1": "{x:.1%}",
+    "percent2": "{x:.2%}",
     "currency0": "{x:,.0f}",
+}
+
+# Named colour ramp -> the colours it interpolates between.
+_COLORSCALES: dict[ColorScale, tuple[str, ...]] = {
+    "red_white_green": ("#d62728", "#ffffff", "#2ca02c"),
 }
 
 # Semantic dash style -> matplotlib's linestyle vocabulary.
@@ -86,11 +97,118 @@ def _draw_line(ax: Axes, line: LineSeries) -> None:
     ax.plot(
         line.x.to_numpy(),
         line.y.to_numpy(),
-        color=line.color,
+        color=mpl_color(line.color),
         linewidth=line.width,
         linestyle=_LINESTYLES[line.dash],
         label=line.name,
     )
+
+
+def mpl_color(color: str) -> str | tuple[float, float, float, float]:
+    """Translate a spec colour into something matplotlib accepts.
+
+    Specs spell translucent colours the CSS way — ``rgba(99, 110, 250, 0.4)``
+    — because that is what Plotly emits and the fidelity snapshots pin.
+    matplotlib does not parse that form, so it is converted here; plain hex
+    passes straight through.
+
+    Args:
+        color: A hex string or a CSS ``rgba()`` string.
+
+    Returns:
+        The colour as matplotlib understands it.
+
+    Examples:
+        >>> mpl_color("#636EFA")
+        '#636EFA'
+        >>> mpl_color("rgba(99, 110, 250, 0.4)")
+        (0.38823529411764707, 0.43137254901960786, 0.9803921568627451, 0.4)
+
+    """
+    if not color.startswith("rgba("):
+        return color
+    r, g, b, a = (part.strip() for part in color[len("rgba(") : -1].split(","))
+    return (int(r) / 255, int(g) / 255, int(b) / 255, float(a))
+
+
+def _faded(color: str, opacity: float) -> tuple[float, float, float, float]:
+    """Scale a colour's alpha by *opacity*.
+
+    Matches Plotly, which multiplies a trace's opacity by the alpha already in
+    its colour, rather than matplotlib's ``alpha=`` argument, which replaces it.
+
+    Args:
+        color: A hex or CSS ``rgba()`` colour.
+        opacity: Factor to scale the alpha channel by.
+
+    Returns:
+        The colour as RGBA floats, alpha scaled.
+
+    Examples:
+        >>> _faded("rgba(0, 0, 0, 0.4)", 0.5)
+        (0.0, 0.0, 0.0, 0.2)
+
+    """
+    r, g, b, a = to_rgba(mpl_color(color))
+    return (r, g, b, a * opacity)
+
+
+def _draw_bars(ax: Axes, bar: BarSeries) -> None:
+    """Draw one bar series onto *ax*.
+
+    Args:
+        ax: The axes to draw on.
+        bar: The series to draw.
+
+    """
+    # Opacity is folded into each colour rather than passed as `alpha=`.
+    # matplotlib's alpha argument *replaces* a colour's own alpha channel,
+    # whereas Plotly multiplies its trace opacity by it — so passing it
+    # separately would render the faded negative bars at the wrong strength.
+    ax.bar(
+        bar.x.to_numpy(),
+        bar.y.to_numpy(),
+        color=[_faded(c, bar.opacity) for c in bar.colors],
+        linewidth=0,
+        label=bar.name,
+    )
+
+
+def _draw_heatmap(fig: Figure, ax: Axes, grid: HeatmapGrid) -> None:
+    """Draw a value matrix onto *ax*, with per-cell labels and a colour bar.
+
+    Args:
+        fig: The figure owning *ax*, needed to attach the colour bar.
+        ax: The axes to draw on.
+        grid: The matrix to draw.
+
+    """
+    # None marks a month the data does not cover. NaN carries that through
+    # numpy, and a masked array keeps those cells unpainted rather than
+    # colouring them as if they were zero.
+    values = np.array([[float("nan") if v is None else v for v in row] for row in grid.z], dtype=float)
+    masked = np.ma.masked_invalid(values)
+
+    cmap = LinearSegmentedColormap.from_list(grid.colorscale, _COLORSCALES[grid.colorscale])
+    norm = None
+    if grid.zmid is not None and masked.count():
+        low, high = float(masked.min()), float(masked.max())
+        # TwoSlopeNorm needs the centre strictly inside the range; widen a
+        # one-sided or degenerate span so an all-positive year still renders.
+        low = min(low, grid.zmid - 1e-9)
+        high = max(high, grid.zmid + 1e-9)
+        norm = TwoSlopeNorm(vmin=low, vcenter=grid.zmid, vmax=high)
+
+    image = ax.imshow(masked, cmap=cmap, norm=norm, aspect="auto")
+
+    ax.set_xticks(range(len(grid.x_labels)), labels=list(grid.x_labels))
+    ax.set_yticks(range(len(grid.y_labels)), labels=list(grid.y_labels))
+    for row, labels in enumerate(grid.text):
+        for col, label in enumerate(labels):
+            if label:
+                ax.text(col, row, label, ha="center", va="center", fontsize=8)
+
+    fig.colorbar(image, ax=ax, label=grid.colorbar_title)
 
 
 def _apply_axis(ax: Axes, axis: Axis, *, vertical: bool) -> None:
@@ -113,6 +231,15 @@ def _apply_axis(ax: Axes, axis: Axis, *, vertical: bool) -> None:
     if axis.log:
         set_scale = ax.set_yscale if vertical else ax.set_xscale
         set_scale("log")
+    if axis.opposite_side:
+        # Each axis has its own vocabulary for "the far edge", which is why
+        # the spec says `opposite_side` rather than naming a compass point.
+        if vertical:
+            ax.yaxis.set_ticks_position("right")
+            ax.yaxis.set_label_position("right")
+        else:
+            ax.xaxis.set_ticks_position("top")
+            ax.xaxis.set_label_position("top")
 
 
 def render_mpl(spec: FigureSpec) -> Figure:
@@ -138,13 +265,27 @@ def render_mpl(spec: FigureSpec) -> Figure:
 
     for line in panel.lines:
         _draw_line(ax, line)
+    for bar in panel.bars:
+        _draw_bars(ax, bar)
+    if panel.heatmap is not None:
+        _draw_heatmap(fig, ax, panel.heatmap)
 
     ax.set_facecolor("white")
-    ax.grid(visible=True, color=_GRID_COLOR, linewidth=_GRID_WIDTH)
+    # Stated either way rather than leaning on ``rcParams["axes.grid"]``: that
+    # default is global and third-party libraries flip it on import (quantstats
+    # does), which would otherwise put a grid behind a matrix chart depending on
+    # what else the caller happened to import.
+    if spec.chrome == "timeseries":
+        ax.grid(visible=True, color=_GRID_COLOR, linewidth=_GRID_WIDTH)
+    else:
+        ax.grid(visible=False)
     _apply_axis(ax, panel.xaxis, vertical=False)
     _apply_axis(ax, panel.yaxis, vertical=True)
 
-    if panel.lines:
-        ax.legend(loc="upper left", frameon=False, ncols=len(panel.lines))
+    # Colour carries the value on a matrix chart, so its series names would
+    # label nothing; only series charts get a legend.
+    series_count = len(panel.lines) + len(panel.bars)
+    if series_count and spec.chrome == "timeseries":
+        ax.legend(loc="upper left", frameon=False, ncols=series_count)
     fig.suptitle(spec.title)
     return fig

--- a/src/jquantstats/_plots/_render/_plotly.py
+++ b/src/jquantstats/_plots/_render/_plotly.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import plotly.graph_objects as go
 
 from .._data._styling import _apply_base_layout, _apply_figsize
-from .._spec import Axis, FigureSpec, HoverSpec, LineSeries, TickFormat
+from .._spec import Axis, BarSeries, ColorScale, FigureSpec, HeatmapGrid, HoverSpec, LineSeries, TickFormat
 
 __all__ = ["render_plotly"]
 
@@ -25,11 +25,21 @@ __all__ = ["render_plotly"]
 _D3_FORMATS: dict[TickFormat, str] = {
     "float2": ".2f",
     "float4": ".4f",
+    "percent1": ".1%",
+    "percent2": ".2%",
     "currency0": ",.0f",
 }
 
 # Semantic dash style -> Plotly's `line.dash` vocabulary.
 _DASHES = {"solid": "solid", "dash": "dash"}
+
+# Named colour ramp -> Plotly's colorscale stops.
+_COLORSCALES: dict[ColorScale, list[list[float | str]]] = {
+    "red_white_green": [[0, "#d62728"], [0.5, "#ffffff"], [1, "#2ca02c"]],
+}
+
+# Bars are drawn without an outline throughout.
+_BAR_OUTLINE = {"width": 0}
 
 
 def _hovertemplate(hover: HoverSpec) -> str:
@@ -67,7 +77,55 @@ def _scatter(line: LineSeries) -> go.Scatter:
     return trace
 
 
-def _axis_kwargs(axis: Axis) -> dict[str, object]:
+def _bar(bar: BarSeries) -> go.Bar:
+    """Convert one bar series into a Plotly bar trace.
+
+    Args:
+        bar: The series to draw.
+
+    Returns:
+        go.Bar: The trace, with one colour per bar.
+
+    """
+    trace = go.Bar(
+        x=bar.x,
+        y=bar.y,
+        name=bar.name,
+        marker={"color": list(bar.colors), "line": _BAR_OUTLINE},
+        opacity=bar.opacity,
+    )
+    if bar.hover is not None:
+        trace.update(hovertemplate=_hovertemplate(bar.hover))
+    return trace
+
+
+def _heatmap(grid: HeatmapGrid) -> go.Heatmap:
+    """Convert a value matrix into a Plotly heatmap trace.
+
+    Args:
+        grid: The matrix to draw.
+
+    Returns:
+        go.Heatmap: The trace, labelled cell by cell.
+
+    """
+    trace = go.Heatmap(
+        x=list(grid.x_labels),
+        y=list(grid.y_labels),
+        z=[list(row) for row in grid.z],
+        text=[list(row) for row in grid.text],
+        texttemplate="%{text}",
+        colorscale=_COLORSCALES[grid.colorscale],
+        zmid=grid.zmid,
+        showscale=True,
+        colorbar={"title": grid.colorbar_title},
+    )
+    if grid.hover_label is not None:
+        trace.update(hovertemplate=f"<b>%{{y}} %{{x}}</b><br>{grid.hover_label}: %{{text}}<extra></extra>")
+    return trace
+
+
+def _axis_kwargs(axis: Axis, *, vertical: bool = False) -> dict[str, object]:
     """Collect the axis properties a spec actually asked for.
 
     Only requested properties are returned. Emitting a default for an untouched
@@ -76,6 +134,8 @@ def _axis_kwargs(axis: Axis) -> dict[str, object]:
 
     Args:
         axis: The axis configuration.
+        vertical: Whether this is the y-axis, which decides what
+            `~jquantstats._plots._spec.Axis.opposite_side` resolves to.
 
     Returns:
         dict[str, object]: Keyword arguments for ``update_xaxes`` /
@@ -91,6 +151,8 @@ def _axis_kwargs(axis: Axis) -> dict[str, object]:
         kwargs["tickformat"] = _D3_FORMATS[axis.tick_format]
     if axis.log:
         kwargs["type"] = "log"
+    if axis.opposite_side:
+        kwargs["side"] = "right" if vertical else "top"
     return kwargs
 
 
@@ -113,14 +175,26 @@ def render_plotly(spec: FigureSpec) -> go.Figure:
     fig = go.Figure()
     for line in panel.lines:
         fig.add_trace(_scatter(line))
+    for bar in panel.bars:
+        fig.add_trace(_bar(bar))
+    if panel.heatmap is not None:
+        fig.add_trace(_heatmap(panel.heatmap))
 
-    _apply_base_layout(fig, spec.title, height=spec.height, with_range_selector=spec.date_range_selector)
+    if spec.chrome == "timeseries":
+        _apply_base_layout(fig, spec.title, height=spec.height, with_range_selector=spec.date_range_selector)
+    else:
+        # A matrix chart: colour encodes the value, so a legend would name
+        # nothing and a shared-x hover has nothing to align. Only the title,
+        # height and background are set.
+        fig.update_layout(title=spec.title, height=spec.height, plot_bgcolor="white")
     _apply_figsize(fig, spec.figsize)
+    if spec.bar_mode is not None:
+        fig.update_layout(barmode=spec.bar_mode)
 
     x_kwargs = _axis_kwargs(panel.xaxis)
     if x_kwargs:
         fig.update_xaxes(**x_kwargs)
-    y_kwargs = _axis_kwargs(panel.yaxis)
+    y_kwargs = _axis_kwargs(panel.yaxis, vertical=True)
     if y_kwargs:
         fig.update_yaxes(**y_kwargs)
     return fig

--- a/src/jquantstats/_plots/_spec.py
+++ b/src/jquantstats/_plots/_spec.py
@@ -31,8 +31,12 @@ import polars as pl
 
 __all__ = [
     "Axis",
+    "BarSeries",
+    "Chrome",
+    "ColorScale",
     "Dash",
     "FigureSpec",
+    "HeatmapGrid",
     "HoverSpec",
     "LineSeries",
     "Panel",
@@ -41,14 +45,27 @@ __all__ = [
 
 #: How to render a number, named by intent rather than by any backend's syntax.
 #:
-#: ``float2``/``float4`` are fixed-point to that many decimals; ``currency0`` is
+#: ``float2``/``float4`` are fixed-point to that many decimals; ``percent1``/
+#: ``percent2`` scale to a percentage with that many decimals; ``currency0`` is
 #: a thousands-separated integer. Each renderer owns the mapping — Plotly wants
 #: ``".2f"``, matplotlib wants a ``Formatter`` — so neither vocabulary leaks in
 #: here.
-TickFormat = Literal["float2", "float4", "currency0"]
+TickFormat = Literal["float2", "float4", "percent1", "percent2", "currency0"]
 
 #: Line styles, kept to the set the charts actually use.
 Dash = Literal["solid", "dash"]
+
+#: Named colour ramps for matrix charts, resolved per backend.
+ColorScale = Literal["red_white_green"]
+
+#: How much furniture a chart carries.
+#:
+#: ``timeseries`` is the standard treatment shared by most charts: a legend,
+#: unified hover, a light grid and optionally the date range-selector.
+#: ``bare`` is for matrix charts, where colour encodes the value rather than
+#: the series — a legend would name nothing and a shared-x hover has no
+#: meaning, so only the title, height and background are set.
+Chrome = Literal["timeseries", "bare"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -104,6 +121,59 @@ class LineSeries:
 
 
 @dataclass(frozen=True, slots=True)
+class BarSeries:
+    """One set of bars drawn across a panel.
+
+    Attributes:
+        name: Legend entry for the series.
+        x: Bar positions — dates, or the category each bar sits at.
+        y: Bar heights.
+        colors: One colour per bar. Per-bar rather than per-series because
+            these charts colour a bar by the sign of its value.
+        opacity: Fill opacity.
+        hover: Tooltip description, or None to leave the backend's default.
+
+    """
+
+    name: str
+    x: pl.Series
+    y: pl.Series
+    colors: tuple[str, ...]
+    opacity: float = 0.85
+    hover: HoverSpec | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class HeatmapGrid:
+    """A matrix of values drawn as a coloured grid.
+
+    Attributes:
+        x_labels: Column headings, left to right.
+        y_labels: Row headings, top to bottom.
+        z: The values, as ``z[row][column]``. None marks a missing cell.
+        text: Per-cell labels drawn over the grid, parallel to *z*.
+        colorscale: The colour ramp to map values through.
+        zmid: Value anchored to the middle of a diverging ramp, or None to
+            span the data range.
+        colorbar_title: Heading for the colour scale legend.
+        hover_label: Word naming the quantity in the tooltip, or None for no
+            tooltip. Interactive-only, so matplotlib ignores it.
+
+    """
+
+    x_labels: tuple[str, ...]
+    y_labels: tuple[str, ...]
+    z: tuple[tuple[float | None, ...], ...]
+    text: tuple[tuple[str, ...], ...]
+    colorscale: ColorScale
+    # An int, so a whole-number anchor serialises as `0` rather than `0.0`;
+    # Plotly preserves the distinction and the fidelity snapshots compare it.
+    zmid: float | None = 0
+    colorbar_title: str = ""
+    hover_label: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class Axis:
     """Configuration for one axis of a panel.
 
@@ -116,6 +186,10 @@ class Axis:
         tick_format: How to render tick values, or None for the default.
         tick_prefix: Written before each tick value, e.g. a currency sign.
         log: Use a logarithmic scale.
+        opposite_side: Draw the axis on the far edge — the top for a
+            horizontal axis, the right for a vertical one. The monthly
+            calendar puts its months along the top, where they read as column
+            headings.
 
     """
 
@@ -123,6 +197,10 @@ class Axis:
     tick_format: TickFormat | None = None
     tick_prefix: str = ""
     log: bool = False
+    # Deliberately a flag rather than a compass point. Which edge counts as
+    # "opposite" depends on the axis, and naming it absolutely would admit
+    # nonsense a renderer would then have to police — an x-axis on the "left".
+    opposite_side: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -134,6 +212,8 @@ class Panel:
 
     Attributes:
         lines: Line series to draw.
+        bars: Bar series to draw.
+        heatmap: A value matrix to draw, or None.
         xaxis: Horizontal axis configuration.
         yaxis: Vertical axis configuration.
         title: Heading for this panel, used when a chart has several.
@@ -141,6 +221,8 @@ class Panel:
     """
 
     lines: tuple[LineSeries, ...] = ()
+    bars: tuple[BarSeries, ...] = ()
+    heatmap: HeatmapGrid | None = None
     xaxis: Axis = field(default_factory=Axis)
     yaxis: Axis = field(default_factory=Axis)
     title: str | None = None
@@ -159,6 +241,9 @@ class FigureSpec:
             inches so one public signature means the same thing either way.
         date_range_selector: Offer the Plotly range-selector buttons. Ignored
             by matplotlib, which has no interactive widgets.
+        chrome: How much surrounding furniture the chart carries.
+        bar_mode: How bars from different series share an x position, or None
+            for the backend's default.
 
     """
 
@@ -167,3 +252,5 @@ class FigureSpec:
     height: int = 600
     figsize: tuple[int, int] | None = None
     date_range_selector: bool = True
+    chrome: Chrome = "timeseries"
+    bar_mode: Literal["group", "overlay", "relative"] | None = None

--- a/src/jquantstats/_plots/_specs/__init__.py
+++ b/src/jquantstats/_plots/_specs/__init__.py
@@ -8,10 +8,20 @@ from ._cumulative import compare_spec as compare_spec
 from ._cumulative import cumulative_returns_spec as cumulative_returns_spec
 from ._cumulative import earnings_spec as earnings_spec
 from ._cumulative import log_returns_spec as log_returns_spec
+from ._periodic import daily_returns_spec as daily_returns_spec
+from ._periodic import monthly_heatmap_spec as monthly_heatmap_spec
+from ._periodic import monthly_returns_spec as monthly_returns_spec
+from ._periodic import period_agg_exprs as period_agg_exprs
+from ._periodic import yearly_returns_spec as yearly_returns_spec
 
 __all__ = [
     "compare_spec",
     "cumulative_returns_spec",
+    "daily_returns_spec",
     "earnings_spec",
     "log_returns_spec",
+    "monthly_heatmap_spec",
+    "monthly_returns_spec",
+    "period_agg_exprs",
+    "yearly_returns_spec",
 ]

--- a/src/jquantstats/_plots/_specs/_periodic.py
+++ b/src/jquantstats/_plots/_specs/_periodic.py
@@ -1,0 +1,267 @@
+"""Spec builders for the periodic bar charts and the monthly calendar.
+
+The bar charts colour each bar by the sign of its value rather than by series,
+which is why `~jquantstats._plots._spec.BarSeries` carries a colour per bar.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+from .._spec import Axis, BarSeries, FigureSpec, HeatmapGrid, HoverSpec, Panel
+from .._style import bar_colors, ticker_colors, yearly_bar_colors
+
+if TYPE_CHECKING:
+    from jquantstats._protocol import DataLike
+
+__all__ = [
+    "daily_returns_spec",
+    "monthly_heatmap_spec",
+    "monthly_returns_spec",
+    "yearly_returns_spec",
+]
+
+_MONTH_NAMES = ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+
+# A calendar row per year, plus room for the title and colour bar.
+_HEATMAP_ROW_PX = 40
+_HEATMAP_CHROME_PX = 100
+_HEATMAP_MIN_PX = 300
+
+
+def _split_columns(frame: pl.DataFrame) -> tuple[str, list[str]]:
+    """Separate the date column from the value columns.
+
+    Args:
+        frame: A frame whose first column is the date axis.
+
+    Returns:
+        tuple[str, list[str]]: The date column name and every other column.
+
+    """
+    date_col = frame.columns[0]
+    return date_col, [c for c in frame.columns if c != date_col]
+
+
+def period_agg_exprs(tickers: list[str], compounded: bool) -> list[pl.Expr]:
+    """Per-ticker aggregation expressions for a period bucket.
+
+    Args:
+        tickers: Asset column names to aggregate.
+        compounded: Compound returns within the bucket when True, sum them
+            when False.
+
+    Returns:
+        list[pl.Expr]: One aliased expression per ticker.
+
+    """
+    if compounded:
+        return [((1.0 + pl.col(t)).product() - 1.0).alias(t) for t in tickers]
+    return [pl.col(t).sum().alias(t) for t in tickers]
+
+
+def _sign_coloured_bars(
+    frame: pl.DataFrame,
+    x_col: str,
+    tickers: list[str],
+    colors: dict[str, str],
+    *,
+    single: bool,
+) -> tuple[BarSeries, ...]:
+    """Build one bar series per ticker, each bar coloured by its sign.
+
+    Args:
+        frame: The prepared frame holding the plotted values.
+        x_col: Column giving the bar positions.
+        tickers: Columns to draw, in order.
+        colors: Ticker to hex colour mapping.
+        single: Whether the dataset holds exactly one asset, which selects
+            the plain green/red palette over the faded per-asset one.
+
+    Returns:
+        tuple[BarSeries, ...]: One series per ticker, in the given order.
+
+    """
+    return tuple(
+        BarSeries(
+            name=ticker,
+            x=frame[x_col],
+            y=frame[ticker],
+            colors=tuple(bar_colors(frame[ticker].to_list(), colors[ticker], single_asset=single)),
+            hover=HoverSpec(label=ticker, value_format="percent2", date_header=False),
+        )
+        for ticker in tickers
+    )
+
+
+def daily_returns_spec(data: DataLike, title: str) -> FigureSpec:
+    """Describe the daily-returns bar chart.
+
+    Args:
+        data: The dataset to plot.
+        title: Chart title.
+
+    Returns:
+        FigureSpec: One bar series per asset, coloured by sign.
+
+    """
+    df = data.all
+    date_col, tickers = _split_columns(df)
+
+    panel = Panel(
+        bars=_sign_coloured_bars(df, date_col, tickers, ticker_colors(tickers), single=len(tickers) == 1),
+        yaxis=Axis(title="Return", tick_format="percent1"),
+    )
+    return FigureSpec(title=title, panels=(panel,))
+
+
+def yearly_returns_spec(data: DataLike, title: str, compounded: bool) -> FigureSpec:
+    """Describe the annual-returns grouped bar chart.
+
+    Args:
+        data: The dataset to plot.
+        title: Chart title.
+        compounded: Compound returns within each year.
+
+    Returns:
+        FigureSpec: One grouped bar series per asset, over a year axis.
+
+    """
+    df = data.all
+    date_col, tickers = _split_columns(df)
+    colors = ticker_colors(tickers)
+
+    yearly = (
+        df.with_columns(pl.col(date_col).dt.year().alias("_year"))
+        .group_by("_year")
+        .agg(period_agg_exprs(tickers, compounded))
+        .sort("_year")
+    )
+
+    panel = Panel(
+        bars=tuple(
+            BarSeries(
+                name=ticker,
+                x=yearly["_year"],
+                y=yearly[ticker],
+                # A flat zero year counts as positive here, unlike the other
+                # bar charts — see `yearly_bar_colors`.
+                colors=tuple(yearly_bar_colors(yearly[ticker].to_list(), colors[ticker])),
+                hover=HoverSpec(label=ticker, value_format="percent2", date_header=False),
+            )
+            for ticker in tickers
+        ),
+        xaxis=Axis(title="Year"),
+        yaxis=Axis(title="Annual Return", tick_format="percent1"),
+    )
+    # No range selector: the axis is calendar years, not a continuous date line.
+    return FigureSpec(title=title, panels=(panel,), date_range_selector=False, bar_mode="group")
+
+
+def monthly_returns_spec(data: DataLike, title: str, compounded: bool) -> FigureSpec:
+    """Describe the monthly-returns bar chart.
+
+    Args:
+        data: The dataset to plot.
+        title: Chart title.
+        compounded: Compound returns within each month.
+
+    Returns:
+        FigureSpec: One bar series per asset, coloured by sign.
+
+    """
+    df = data.all
+    date_col, tickers = _split_columns(df)
+
+    monthly = df.group_by_dynamic(index_column=date_col, every="1mo", period="1mo", closed="right", label="right").agg(
+        period_agg_exprs(tickers, compounded)
+    )
+
+    panel = Panel(
+        bars=_sign_coloured_bars(monthly, date_col, tickers, ticker_colors(tickers), single=len(tickers) == 1),
+        yaxis=Axis(title="Monthly Return", tick_format="percent1"),
+    )
+    return FigureSpec(title=title, panels=(panel,))
+
+
+def _heatmap_grids(
+    monthly: pl.DataFrame, years: list[int]
+) -> tuple[tuple[tuple[float | None, ...], ...], tuple[tuple[str, ...], ...]]:
+    """Build the year-by-month value and label grids.
+
+    Args:
+        monthly: Aggregated frame with ``_year``, ``_month`` and ``ret`` columns.
+        years: Sorted unique years, defining the row order of the output grids.
+
+    Returns:
+        A ``(z, text)`` pair: ``z`` holds returns scaled to percent, with None
+        for months the data does not cover, and ``text`` the formatted labels.
+
+    """
+    year_idx = {y: i for i, y in enumerate(years)}
+    z: list[list[float | None]] = [[None] * 12 for _ in years]
+    text: list[list[str]] = [[""] * 12 for _ in years]
+    for row in monthly.iter_rows(named=True):
+        yi = year_idx[row["_year"]]
+        mi = row["_month"] - 1
+        val = row["ret"]
+        z[yi][mi] = val * 100 if val is not None else None
+        text[yi][mi] = f"{val:.1%}" if val is not None else ""
+    return tuple(tuple(r) for r in z), tuple(tuple(r) for r in text)
+
+
+def monthly_heatmap_spec(data: DataLike, title: str, compounded: bool, asset: str | None) -> FigureSpec:
+    """Describe the monthly-returns calendar heatmap.
+
+    One asset per chart: the grid is already two-dimensional, so a second
+    asset would need a second grid.
+
+    Args:
+        data: The dataset to plot.
+        title: Chart title, which gains the asset name.
+        compounded: Compound returns within each month.
+        asset: Asset column to display, or None for the first.
+
+    Returns:
+        FigureSpec: A single year-by-month grid.
+
+    """
+    df = data.all
+    date_col, tickers = _split_columns(df)
+    col = asset if asset in tickers else tickers[0]
+
+    agg = ((1.0 + pl.col(col)).product() - 1.0) if compounded else pl.col(col).sum()
+    monthly = (
+        df.with_columns(
+            pl.col(date_col).dt.year().alias("_year"),
+            pl.col(date_col).dt.month().alias("_month"),
+        )
+        .group_by(["_year", "_month"])
+        .agg(agg.alias("ret"))
+        .sort(["_year", "_month"])
+    )
+
+    years = sorted(monthly["_year"].unique().to_list())
+    z, text = _heatmap_grids(monthly, years)
+
+    panel = Panel(
+        heatmap=HeatmapGrid(
+            x_labels=_MONTH_NAMES,
+            y_labels=tuple(str(y) for y in years),
+            z=z,
+            text=text,
+            colorscale="red_white_green",
+            colorbar_title="Return (%)",
+            hover_label="Return",
+        ),
+        # Months read as column headings, so they belong along the top.
+        xaxis=Axis(opposite_side=True),
+    )
+    return FigureSpec(
+        title=f"{title} — {col}",
+        panels=(panel,),
+        height=max(_HEATMAP_MIN_PX, _HEATMAP_ROW_PX * len(years) + _HEATMAP_CHROME_PX),
+        chrome="bare",
+    )

--- a/src/jquantstats/_plots/_style.py
+++ b/src/jquantstats/_plots/_style.py
@@ -12,7 +12,12 @@ from __future__ import annotations
 
 import plotly.express as px
 
-__all__ = ["hex_to_rgba", "ticker_colors"]
+__all__ = ["bar_colors", "hex_to_rgba", "ticker_colors", "yearly_bar_colors"]
+
+#: Green and red for a single-asset chart, where a bar's colour can carry the
+#: sign outright rather than having to stay identifiable as one asset among several.
+_POSITIVE = "#2ca02c"
+_NEGATIVE = "#d62728"
 
 
 def hex_to_rgba(hex_color: str, alpha: float = 0.5) -> str:
@@ -55,3 +60,52 @@ def ticker_colors(tickers: list[str]) -> dict[str, str]:
     """
     palette = px.colors.qualitative.Plotly
     return {ticker: palette[i % len(palette)] for i, ticker in enumerate(tickers)}
+
+
+def bar_colors(values: list[float | None], positive_color: str, single_asset: bool = False) -> list[str]:
+    """Colour each bar by the sign of its value.
+
+    With one asset the bars are plain green and red. With several, each keeps
+    its own palette colour and negatives are faded instead, so a bar stays
+    identifiable as belonging to its asset.
+
+    Args:
+        values: The plotted values; None counts as negative.
+        positive_color: The asset's base colour.
+        single_asset: Use the plain green/red palette.
+
+    Returns:
+        list[str]: One colour per value.
+
+    Examples:
+        >>> bar_colors([0.1, -0.1], "#636EFA", single_asset=True)
+        ['#2ca02c', '#d62728']
+
+    """
+    if single_asset:
+        return [_POSITIVE if v is not None and v > 0 else _NEGATIVE for v in values]
+    negative_color = hex_to_rgba(positive_color, alpha=0.4)
+    return [positive_color if v is not None and v > 0 else negative_color for v in values]
+
+
+def yearly_bar_colors(values: list[float | None], positive_color: str) -> list[str]:
+    """Colour each annual bar by the sign of its value.
+
+    Deliberately distinct from `bar_colors`: a flat zero year counts as
+    positive here (``>= 0``), and negatives fade to alpha 0.5 rather than 0.4.
+    The two cannot share an implementation without changing what is rendered.
+
+    Args:
+        values: The per-year return values; None counts as negative.
+        positive_color: The asset's base colour.
+
+    Returns:
+        list[str]: One colour per value.
+
+    Examples:
+        >>> yearly_bar_colors([0.0], "#636EFA")
+        ['#636EFA']
+
+    """
+    negative_color = hex_to_rgba(positive_color, 0.5)
+    return [positive_color if v is not None and v >= 0 else negative_color for v in values]

--- a/tests/test_jquantstats/test__plots/test_mpl_backend.py
+++ b/tests/test_jquantstats/test__plots/test_mpl_backend.py
@@ -12,19 +12,43 @@ Three concerns, in order:
 from __future__ import annotations
 
 import matplotlib.figure as mfigure
+import numpy as np
 import plotly.graph_objects as go
 import polars as pl
 import pytest
+from matplotlib.colors import TwoSlopeNorm, to_hex, to_rgba
 from matplotlib.ticker import StrMethodFormatter
 
 import jquantstats
 from jquantstats._plots import _backend
 from jquantstats._plots._render import render, render_plotly
-from jquantstats._plots._render._mpl import _DEFAULT_WIDTH_PX, _DPI, render_mpl
-from jquantstats._plots._spec import Axis, FigureSpec, LineSeries, Panel
+from jquantstats._plots._render._mpl import _DEFAULT_WIDTH_PX, _DPI, mpl_color, render_mpl
+from jquantstats._plots._spec import Axis, FigureSpec, HeatmapGrid, LineSeries, Panel
 from jquantstats.exceptions import MissingBackendError
 
-# Every cumulative chart, with arguments exercising the interesting branches.
+
+def _normalise_colour(colour: str) -> tuple[float, ...]:
+    """Reduce a colour to comparable RGBA floats.
+
+    The two backends spell the same colour differently — a spec carries
+    Plotly's CSS ``rgba(99, 110, 250, 0.4)``, while matplotlib reports a hex
+    string — so comparison goes through a common representation. It routes
+    through the renderer's own `mpl_color`, so this checks the real translation
+    rather than a second copy of it. Values are rounded because ``rgba()``
+    carries 8-bit channels while matplotlib keeps floats.
+    """
+    return tuple(round(channel, 2) for channel in to_rgba(mpl_color(colour)))
+
+
+def _scaled_colour(colour: str, opacity: float) -> tuple[float, ...]:
+    """Reduce a colour to comparable RGBA floats with its alpha scaled."""
+    r, g, b, a = to_rgba(mpl_color(colour))
+    return tuple(round(channel, 2) for channel in (r, g, b, a * opacity))
+
+
+# Every line chart migrated so far, with arguments exercising the interesting
+# branches. Parity is asserted per line series, so bar and matrix charts are
+# checked separately below.
 CUMULATIVE_CHARTS = [
     ("returns", {}),
     ("returns", {"log_scale": True}),
@@ -37,6 +61,16 @@ CUMULATIVE_CHARTS = [
     ("earnings", {"start_balance": 250_000}),
 ]
 _IDS = [f"{name}-{sorted(kwargs)}" for name, kwargs in CUMULATIVE_CHARTS]
+
+# The periodic bar charts.
+BAR_CHARTS = [
+    ("daily_returns", {}),
+    ("yearly_returns", {}),
+    ("yearly_returns", {"compounded": False}),
+    ("monthly_returns", {}),
+    ("monthly_returns", {"compounded": False}),
+]
+_BAR_IDS = [f"{name}-{sorted(kwargs)}" for name, kwargs in BAR_CHARTS]
 
 
 def _line(**overrides) -> LineSeries:
@@ -132,6 +166,156 @@ def test_backends_agree_on_colours(data, method: str, kwargs: dict) -> None:
     plotly_colors = [trace.line.color.lower() for trace in plotly_fig.data]
     mpl_colors = [line.get_color().lower() for line in mpl_fig.axes[0].get_lines()]
     assert plotly_colors == mpl_colors
+
+
+@pytest.mark.parametrize(("method", "kwargs"), BAR_CHARTS, ids=_BAR_IDS)
+def test_bar_backends_plot_the_same_numbers(data, method: str, kwargs: dict) -> None:
+    """Both backends draw identical bars for every periodic chart."""
+    plotly_fig = getattr(data.plots, method)(**kwargs, backend="plotly")
+    mpl_fig = getattr(data.plots, method)(**kwargs, backend="matplotlib")
+
+    containers = mpl_fig.axes[0].containers
+    assert len(containers) == len(plotly_fig.data)
+
+    for trace, container in zip(plotly_fig.data, containers, strict=True):
+        assert trace.name == container.get_label()
+        heights = [patch.get_height() for patch in container]
+        assert list(trace.y) == pytest.approx(heights, nan_ok=True)
+
+
+@pytest.mark.parametrize(("method", "kwargs"), BAR_CHARTS, ids=_BAR_IDS)
+def test_bar_backends_agree_on_per_bar_colours(data, method: str, kwargs: dict) -> None:
+    """Sign colouring is decided in the spec, so both backends match.
+
+    These charts colour each bar by the sign of its value rather than by
+    series, which is the reason `BarSeries` carries a colour per bar.
+
+    The two backends apply opacity differently: Plotly keeps it on the trace
+    and multiplies, while matplotlib has no equivalent, so the renderer folds
+    it into each colour's alpha. Comparison therefore scales Plotly's colours
+    by its trace opacity before matching.
+    """
+    plotly_fig = getattr(data.plots, method)(**kwargs, backend="plotly")
+    mpl_fig = getattr(data.plots, method)(**kwargs, backend="matplotlib")
+
+    for trace, container in zip(plotly_fig.data, mpl_fig.axes[0].containers, strict=True):
+        expected = [_scaled_colour(c, trace.opacity) for c in trace.marker.color]
+        actual = [_normalise_colour(to_hex(p.get_facecolor(), keep_alpha=True)) for p in container]
+        assert expected == actual
+
+
+def test_heatmap_backends_plot_the_same_matrix(data) -> None:
+    """The calendar grid holds the same values on both backends."""
+    plotly_fig = data.plots.monthly_heatmap(backend="plotly")
+    mpl_fig = data.plots.monthly_heatmap(backend="matplotlib")
+
+    expected = [list(row) for row in plotly_fig.data[0].z]
+    actual = mpl_fig.axes[0].images[0].get_array()
+
+    assert actual.shape == (len(expected), 12)
+    for row_index, row in enumerate(expected):
+        for col_index, value in enumerate(row):
+            cell = actual[row_index, col_index]
+            if value is None:
+                assert cell is np.ma.masked, "an uncovered month must stay unpainted"
+            else:
+                assert float(cell) == pytest.approx(value)
+
+
+def test_heatmap_titles_name_the_asset(data) -> None:
+    """One asset per calendar, so the title says which."""
+    asset = data.assets[0]
+    plotly_fig = data.plots.monthly_heatmap(asset=asset, backend="plotly")
+    mpl_fig = data.plots.monthly_heatmap(asset=asset, backend="matplotlib")
+
+    assert plotly_fig.layout.title.text.endswith(f"— {asset}")
+    assert mpl_fig.get_suptitle().endswith(f"— {asset}")
+
+
+def test_heatmap_puts_months_along_the_top(data) -> None:
+    """Months read as column headings on both backends."""
+    assert data.plots.monthly_heatmap(backend="plotly").layout.xaxis.side == "top"
+
+    mpl_fig = data.plots.monthly_heatmap(backend="matplotlib")
+    labels = [t.get_text() for t in mpl_fig.axes[0].get_xticklabels()]
+    assert labels[:3] == ["Jan", "Feb", "Mar"]
+    assert mpl_fig.axes[0].xaxis.get_ticks_position() == "top"
+
+
+def test_matrix_charts_carry_no_legend(data) -> None:
+    """Colour encodes the value, so a legend would name nothing."""
+    assert data.plots.monthly_heatmap(backend="matplotlib").axes[0].get_legend() is None
+
+
+def _grid_is_on(ax) -> bool:
+    """Whether *ax* draws grid lines.
+
+    Read from the ticks rather than ``xaxis.get_gridlines()``: those Line2D
+    artists exist and report themselves visible whether or not the grid is
+    actually enabled.
+    """
+    ticks = ax.xaxis.get_major_ticks()
+    return bool(ticks) and ticks[0].gridline.get_visible()
+
+
+def test_matrix_charts_carry_no_grid(data) -> None:
+    """A grid behind an opaque matrix would be hidden anyway."""
+    assert not _grid_is_on(data.plots.monthly_heatmap(backend="matplotlib").axes[0])
+
+
+def test_series_charts_keep_their_grid(data) -> None:
+    """The counterpart: a line or bar chart still gets its grid."""
+    assert _grid_is_on(data.plots.daily_returns(backend="matplotlib").axes[0])
+
+
+def test_heatmap_without_a_midpoint_spans_the_data_range() -> None:
+    """A grid may decline to anchor its colour ramp.
+
+    No calendar does — they all centre on zero so red and green read
+    symmetrically — but the spec can express it, so it must work.
+    """
+    grid = HeatmapGrid(
+        x_labels=("Jan", "Feb"),
+        y_labels=("2024",),
+        z=((1.0, 3.0),),
+        text=(("", ""),),
+        colorscale="red_white_green",
+        zmid=None,
+    )
+    fig = render_mpl(FigureSpec(title="T", panels=(Panel(heatmap=grid),), chrome="bare"))
+    assert not isinstance(fig.axes[0].images[0].norm, TwoSlopeNorm)
+
+
+def test_heatmap_with_a_midpoint_centres_the_ramp(data) -> None:
+    """Anchoring at zero is what makes red and green read symmetrically."""
+    norm = data.plots.monthly_heatmap(backend="matplotlib").axes[0].images[0].norm
+    assert isinstance(norm, TwoSlopeNorm)
+    assert norm.vcenter == 0
+
+
+def test_opposite_side_resolves_per_axis() -> None:
+    """The far edge is the top for an x-axis and the right for a y-axis.
+
+    Only the calendar's x-axis uses this in practice, so the vertical case is
+    covered here rather than left as an untested path.
+    """
+    panel = Panel(lines=(_line(),), xaxis=Axis(opposite_side=True), yaxis=Axis(opposite_side=True))
+    ax = render_mpl(_spec(panel)).axes[0]
+    assert ax.xaxis.get_ticks_position() == "top"
+    assert ax.yaxis.get_ticks_position() == "right"
+
+
+def test_heatmap_with_no_values_still_renders() -> None:
+    """An entirely empty calendar must not divide by an empty range."""
+    grid = HeatmapGrid(
+        x_labels=("Jan",),
+        y_labels=("2024",),
+        z=((None,),),
+        text=(("",),),
+        colorscale="red_white_green",
+    )
+    fig = render_mpl(FigureSpec(title="T", panels=(Panel(heatmap=grid),), chrome="bare"))
+    assert fig.axes[0].images[0].get_array().count() == 0
 
 
 def test_validation_is_backend_independent(data_no_benchmark) -> None:

--- a/tests/test_jquantstats/test__plots/test_spec_render.py
+++ b/tests/test_jquantstats/test__plots/test_spec_render.py
@@ -17,7 +17,7 @@ import pytest
 
 from jquantstats._plots._render import render_plotly
 from jquantstats._plots._render._plotly import _axis_kwargs, _hovertemplate
-from jquantstats._plots._spec import Axis, FigureSpec, HoverSpec, LineSeries, Panel
+from jquantstats._plots._spec import Axis, BarSeries, FigureSpec, HeatmapGrid, HoverSpec, LineSeries, Panel
 from jquantstats._plots._specs import (
     compare_spec,
     cumulative_returns_spec,
@@ -41,6 +41,18 @@ def _line(**overrides) -> LineSeries:
 def _spec(panel: Panel, **overrides) -> FigureSpec:
     """Build a single-panel figure spec, overriding selected fields."""
     return FigureSpec(**{"title": "T", "panels": (panel,), **overrides})
+
+
+def _grid(**overrides) -> HeatmapGrid:
+    """Build a minimal 1x2 heatmap grid, overriding selected fields."""
+    defaults = {
+        "x_labels": ("Jan", "Feb"),
+        "y_labels": ("2024",),
+        "z": ((1.0, -1.0),),
+        "text": (("1.0%", "-1.0%"),),
+        "colorscale": "red_white_green",
+    }
+    return HeatmapGrid(**{**defaults, **overrides})
 
 
 # ── the spec is backend-neutral ───────────────────────────────────────────────
@@ -128,6 +140,18 @@ def test_axis_translates_every_property() -> None:
     assert kwargs == {"title_text": "V", "tickprefix": "$", "tickformat": ",.0f", "type": "log"}
 
 
+def test_opposite_side_resolves_per_axis() -> None:
+    """The far edge is the top for an x-axis and the right for a y-axis.
+
+    The spec says `opposite_side` rather than naming a compass point precisely
+    so that it cannot express an x-axis on the "left"; each renderer resolves
+    it against the axis it is configuring.
+    """
+    assert _axis_kwargs(Axis(opposite_side=True))["side"] == "top"
+    assert _axis_kwargs(Axis(opposite_side=True), vertical=True)["side"] == "right"
+    assert "side" not in _axis_kwargs(Axis())
+
+
 # ── renderer ─────────────────────────────────────────────────────────────────
 
 
@@ -154,6 +178,42 @@ def test_line_without_hover_emits_no_hovertemplate() -> None:
     """A series may opt out of a tooltip entirely."""
     fig = render_plotly(_spec(Panel(lines=(_line(hover=None),))))
     assert "hovertemplate" not in json.loads(fig.to_json())["data"][0]
+
+
+def test_bar_without_hover_emits_no_hovertemplate() -> None:
+    """Bars may opt out of a tooltip too."""
+    bar = BarSeries(
+        name="AAPL",
+        x=pl.Series("x", [1, 2]),
+        y=pl.Series("y", [0.1, -0.2]),
+        colors=("#2ca02c", "#d62728"),
+    )
+    fig = render_plotly(_spec(Panel(bars=(bar,))))
+    assert "hovertemplate" not in json.loads(fig.to_json())["data"][0]
+
+
+def test_heatmap_without_hover_label_emits_no_hovertemplate() -> None:
+    """A matrix may opt out of a tooltip too."""
+    fig = render_plotly(_spec(Panel(heatmap=_grid(hover_label=None)), chrome="bare"))
+    assert "hovertemplate" not in json.loads(fig.to_json())["data"][0]
+
+
+def test_bare_chrome_omits_the_timeseries_furniture() -> None:
+    """A matrix chart gets no legend, unified hover or range selector."""
+    layout = json.loads(render_plotly(_spec(Panel(heatmap=_grid()), chrome="bare")).to_json())["layout"]
+    assert "hovermode" not in layout
+    assert "legend" not in layout
+    assert "rangeselector" not in layout.get("xaxis", {})
+    assert layout["plot_bgcolor"] == "white"
+
+
+def test_bar_mode_is_only_emitted_when_asked_for() -> None:
+    """Plotly's default grouping stands unless a spec overrides it."""
+    bar = BarSeries(name="A", x=pl.Series("x", [1]), y=pl.Series("y", [1.0]), colors=("#000000",))
+    without = json.loads(render_plotly(_spec(Panel(bars=(bar,)))).to_json())["layout"]
+    with_mode = json.loads(render_plotly(_spec(Panel(bars=(bar,)), bar_mode="group")).to_json())["layout"]
+    assert "barmode" not in without
+    assert with_mode["barmode"] == "group"
 
 
 def test_figsize_sets_width_and_height() -> None:


### PR DESCRIPTION
Fourth of the #628 series. `daily_returns`, `yearly_returns`, `monthly_returns` and
`monthly_heatmap` now render on either backend. **Plotly output is unchanged** — the
fidelity snapshots pass without regeneration.

> **Stacked on #944** → #943 → #940. Base is `feat/628-mpl-cumulative`, so this diff
> shows only the periodic work.

Progress: **8 of 29** charts migrated.

## New in the IR

- **`BarSeries`** — carries a colour per *bar*, not per series, because these charts
  colour by the sign of the value.
- **`HeatmapGrid`** — the calendar matrix, with per-cell labels and a named colour ramp.
- **`bar_mode`** for the grouped annual chart, **`Axis.opposite_side`** for the month
  headings.
- **`FigureSpec.chrome`** — six of the 29 charts hand-roll their layout rather than using
  the shared one, and the calendar is the first. Colour encodes the value there, so a
  legend names nothing and a shared-x hover has nothing to align. `"timeseries"` gets the
  standard furniture; `"bare"` gets title, height and background only. The other five
  arrive with their families.

## Three real bugs the gates caught

Each a genuine backend difference, not a test artefact:

1. **Opacity is applied differently.** Plotly *multiplies* a trace's opacity by its
   colour's alpha; matplotlib's `alpha=` argument **replaces** it. Passing it separately
   rendered the faded negative bars at 0.85 instead of 0.34. The renderer now folds
   opacity into each colour.
2. **matplotlib cannot parse Plotly's CSS `rgba(...)`.** The specs carry that spelling
   because it is what the snapshots pin, so the renderer translates it — next to the
   format-string translation, where that job belongs. The parity test routes through the
   *same* function, so it checks the real conversion rather than a second copy.
3. **Grid state is global.** The bare-chrome path relied on matplotlib's default
   `rcParams["axes.grid"]` being False. **Importing quantstats flips it to True
   process-wide**, putting a grid behind the calendar. Now stated either way — and this
   was a production bug, not just a test one: any caller importing seaborn or setting a
   style would have hit it.

## A typing error worth having

`ty` rejected `Axis.side` typed as `Literal["top","bottom","left","right"]`, because
matplotlib's x-axis accepts only top/bottom and its y-axis only left/right. It was right
that the field admitted nonsense — an x-axis on the `"left"`. Replaced with
`opposite_side: bool`, which has **no invalid states**; each renderer resolves it against
the axis it is configuring. Better IR than what I first wrote.

One more int-vs-float fidelity catch, mirroring the line width in #943: `zmid` was
written `0`, and a `0.0` default changed the serialised figure.

## Parity coverage

Extended the harness beyond line series:

- `test_bar_backends_plot_the_same_numbers` — bar heights across 5 chart variants
- `test_bar_backends_agree_on_per_bar_colours` — sign colouring, opacity accounted for
- `test_heatmap_backends_plot_the_same_matrix` — cell values, including that an uncovered
  month stays **unpainted** rather than being coloured as zero

## Verification

`make all` green: **fmt, deps, test, docs-coverage, security, license, typecheck
(mypy --strict *and* ty), rhiza-test**.

- 1,585 passed, 5 skipped (kaleido, no local Chrome)
- **100% line + branch coverage**, 0 `# pragma: no cover`, 0 `noqa` added
- **67 snapshots passed without regeneration**
- `_data/_periodic.py`: 80 statements → 16

🤖 Generated with [Claude Code](https://claude.com/claude-code)