### PR TITLE
Port the drawdown charts to both backends (#628)

### DIFF
--- a/src/jquantstats/_plots/_data/_drawdown.py
+++ b/src/jquantstats/_plots/_data/_drawdown.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
-import plotly.express as px
-import plotly.graph_objects as go
-import polars as pl
-
-from ._styling import _apply_base_layout, _compute_drawdown_periods, _hex_to_rgba, _ticker_colors
+from .._render import render
+from .._specs import drawdown_spec, drawdowns_periods_spec
 
 if TYPE_CHECKING:
+    from matplotlib.figure import Figure as MplFigure
+    from plotly.graph_objects import Figure as PlotlyFigure
+
     from jquantstats._protocol import DataLike
+
+    from .._backend import Backend
+    from .._render import Figure
 
 
 class _DrawdownPlotsMixin:
@@ -21,7 +24,13 @@ class _DrawdownPlotsMixin:
 
     _data: DataLike
 
-    def drawdown(self, title: str = "Drawdowns") -> go.Figure:
+    @overload
+    def drawdown(self, title: str = ..., *, backend: Literal["plotly"] | None = ...) -> PlotlyFigure: ...
+
+    @overload
+    def drawdown(self, title: str = ..., *, backend: Literal["matplotlib"]) -> MplFigure: ...
+
+    def drawdown(self, title: str = "Drawdowns", *, backend: Backend | None = None) -> Figure:
         """Underwater equity curve (drawdown) chart.
 
         Shows the percentage decline from the running peak for every column
@@ -29,48 +38,42 @@ class _DrawdownPlotsMixin:
 
         Args:
             title: Chart title. Defaults to ``"Drawdowns"``.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly filled-area chart.
+            Figure: A filled-area chart.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        colors = _ticker_colors(tickers)
+        return render(drawdown_spec(self._data, title=title), backend)
 
-        prices = df.with_columns([(1.0 + pl.col(t)).cum_prod().alias(t) for t in tickers])
+    @overload
+    def drawdowns_periods(
+        self,
+        n: int = ...,
+        title: str = ...,
+        asset: str | None = ...,
+        *,
+        backend: Literal["plotly"] | None = ...,
+    ) -> PlotlyFigure: ...
 
-        fig = go.Figure()
-        for ticker in tickers:
-            price_s = prices[ticker]
-            hwm = price_s.cum_max()
-            dd = ((price_s - hwm) / hwm).to_list()
-
-            fig.add_trace(
-                go.Scatter(
-                    x=prices[date_col],
-                    y=dd,
-                    mode="lines",
-                    fill="tozeroy",
-                    fillcolor=_hex_to_rgba(colors[ticker], 0.3),
-                    line={"color": colors[ticker], "width": 1.5},
-                    name=ticker,
-                    hovertemplate=f"{ticker}: %{{y:.2%}}",
-                )
-            )
-
-        fig.add_hline(y=0, line_width=1, line_color="gray")
-        _apply_base_layout(fig, title)
-        fig.update_yaxes(title_text="Drawdown", tickformat=".0%")
-        return fig
+    @overload
+    def drawdowns_periods(
+        self,
+        n: int = ...,
+        title: str = ...,
+        asset: str | None = ...,
+        *,
+        backend: Literal["matplotlib"],
+    ) -> MplFigure: ...
 
     def drawdowns_periods(
         self,
         n: int = 5,
         title: str = "Top Drawdown Periods",
         asset: str | None = None,
-    ) -> go.Figure:
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Cumulative returns chart with the worst *n* drawdown periods shaded.
 
         Identifies the *n* deepest drawdown periods and overlays coloured
@@ -81,52 +84,10 @@ class _DrawdownPlotsMixin:
             n: Number of worst drawdown periods to highlight. Defaults to 5.
             title: Chart title. Defaults to ``"Top Drawdown Periods"``.
             asset: Asset column name.  Defaults to the first non-date column.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly figure.
+            Figure: An equity curve with the worst episodes shaded.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        col = asset if asset in tickers else tickers[0]
-
-        price_series = (1.0 + df[col].cast(pl.Float64)).cum_prod()
-        price_list = price_series.to_list()
-        dates = df[date_col].to_list()
-
-        drawdown_periods = _compute_drawdown_periods(price_list, n)
-
-        dd_colors = px.colors.qualitative.Plotly
-
-        fig = go.Figure()
-        fig.add_trace(
-            go.Scatter(
-                x=dates,
-                y=price_list,
-                mode="lines",
-                name=col,
-                line={"color": "#1f77b4", "width": 2},
-                hovertemplate=f"<b>%{{x|%b %Y}}</b><br>{col}: %{{y:.2f}}x",
-            )
-        )
-
-        for i, period in enumerate(drawdown_periods):
-            start_date = dates[period["start_idx"]]
-            end_date = dates[min(period["end_idx"] + 1, len(dates) - 1)]
-            max_dd = period["max_drawdown"]
-            shade_color = _hex_to_rgba(dd_colors[i % len(dd_colors)], alpha=0.2)
-
-            fig.add_vrect(
-                x0=start_date,
-                x1=end_date,
-                fillcolor=shade_color,
-                line_width=0,
-                annotation_text=f"#{i + 1} {max_dd:.1%}",
-                annotation_position="top left",
-                annotation_font_size=10,
-            )
-
-        _apply_base_layout(fig, f"{title} — {col}")
-        fig.update_yaxes(title_text="Cumulative Return", tickformat=".2f")
-        return fig
+        return render(drawdowns_periods_spec(self._data, n=n, title=title, asset=asset), backend)

--- a/src/jquantstats/_plots/_data/_styling.py
+++ b/src/jquantstats/_plots/_data/_styling.py
@@ -21,7 +21,6 @@ __all__ = [
     "_apply_base_layout",
     "_apply_figsize",
     "_bar_colors",
-    "_compute_drawdown_periods",
     "_date_range_selector",
     "_hex_to_rgba",
     "_ticker_colors",
@@ -93,40 +92,3 @@ def _apply_figsize(fig: go.Figure, figsize: tuple[int, int] | None) -> go.Figure
     if figsize is not None:
         fig.update_layout(width=figsize[0], height=figsize[1])
     return fig
-
-
-def _compute_drawdown_periods(prices: list[float], n: int) -> list[dict[str, Any]]:
-    """Identify the top *n* drawdown periods from a cumulative price series.
-
-    Args:
-        prices: Cumulative price (NAV) values as a plain Python list.
-        n: Maximum number of drawdown periods to return.
-
-    Returns:
-        List of dicts with keys ``start_idx``, ``end_idx``, ``valley_idx``,
-        ``max_drawdown`` (fraction ≤ 0), sorted by severity (worst first).
-
-    """
-    length = len(prices)
-    hwm: list[float] = [0.0] * length
-    hwm[0] = prices[0]
-    for i in range(1, length):
-        hwm[i] = max(hwm[i - 1], prices[i])
-
-    in_dd = [prices[i] < hwm[i] for i in range(length)]
-    periods: list[dict[str, Any]] = []
-    i = 0
-    while i < length:
-        if not in_dd[i]:
-            i += 1
-            continue
-        start = i
-        while i < length and in_dd[i]:
-            i += 1
-        end = i - 1
-        valley = start + min(range(end - start + 1), key=lambda k: prices[start + k])
-        max_dd = (prices[valley] - hwm[valley]) / hwm[valley]
-        periods.append({"start_idx": start, "end_idx": end, "valley_idx": valley, "max_drawdown": max_dd})
-
-    periods.sort(key=lambda p: p["max_drawdown"])
-    return periods[:n]

--- a/src/jquantstats/_plots/_render/_mpl.py
+++ b/src/jquantstats/_plots/_render/_mpl.py
@@ -17,15 +17,27 @@ formats — is reproduced.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import polars as pl
 from matplotlib.axes import Axes
 from matplotlib.colors import LinearSegmentedColormap, TwoSlopeNorm, to_rgba
 from matplotlib.figure import Figure
 from matplotlib.ticker import StrMethodFormatter
 
-from .._spec import Axis, BarSeries, ColorScale, FigureSpec, HeatmapGrid, LineSeries, TickFormat
+from .._spec import (
+    Axis,
+    Band,
+    BarSeries,
+    ColorScale,
+    FigureSpec,
+    HeatmapGrid,
+    LineSeries,
+    RefLine,
+    TickFormat,
+    Values,
+)
 
 if TYPE_CHECKING:
     from matplotlib.ticker import Formatter
@@ -47,6 +59,7 @@ _DEFAULT_WIDTH_PX = 1000
 _FORMATS = {
     "float2": "{x:.2f}",
     "float4": "{x:.4f}",
+    "percent0": "{x:.0%}",
     "percent1": "{x:.1%}",
     "percent2": "{x:.2%}",
     "currency0": "{x:,.0f}",
@@ -80,6 +93,32 @@ def _tick_formatter(tick_format: TickFormat, prefix: str) -> Formatter:
     return StrMethodFormatter(f"{prefix}{_FORMATS[tick_format]}")
 
 
+def _as_array(values: Values) -> Any:
+    """Convert plotted values to a numpy array.
+
+    Specs carry either a polars Series or a plain list, whichever the chart
+    already used (see `~jquantstats._plots._spec.Values`). Going via numpy
+    rather than a list also turns a polars null into NaN, which matplotlib
+    draws as a gap; a list of ``None`` would instead force a slow object-dtype
+    array it cannot interpolate across.
+
+    Args:
+        values: A polars Series or a Python list.
+
+    Returns:
+        The values as a numpy array — floats where they convert, so ``None``
+        becomes NaN, and otherwise left as-is for x-axes holding dates.
+
+    """
+    if isinstance(values, pl.Series):
+        return values.to_numpy()
+    try:
+        return np.asarray(values, dtype=float)
+    except TypeError:
+        # A date axis: leave the objects alone, matplotlib understands them.
+        return np.asarray(values)
+
+
 def _draw_line(ax: Axes, line: LineSeries) -> None:
     """Draw one series onto *ax*.
 
@@ -91,17 +130,19 @@ def _draw_line(ax: Axes, line: LineSeries) -> None:
         line: The series to draw.
 
     """
-    # `to_numpy`, not `to_list`: a polars null becomes NaN in a float array but
-    # `None` in a list, and matplotlib draws a gap for the former while the
-    # latter forces a slow object-dtype array it cannot interpolate across.
+    x, y = _as_array(line.x), _as_array(line.y)
     ax.plot(
-        line.x.to_numpy(),
-        line.y.to_numpy(),
+        x,
+        y,
         color=mpl_color(line.color),
         linewidth=line.width,
         linestyle=_LINESTYLES[line.dash],
         label=line.name,
     )
+    if line.fill_color is not None:
+        # `where` keeps the fill out of the gaps a NaN leaves in the line,
+        # which otherwise get shaded as though the value were zero.
+        ax.fill_between(x, y, 0, color=mpl_color(line.fill_color), where=~np.isnan(y), linewidth=0)
 
 
 def mpl_color(color: str) -> str | tuple[float, float, float, float]:
@@ -166,12 +207,48 @@ def _draw_bars(ax: Axes, bar: BarSeries) -> None:
     # whereas Plotly multiplies its trace opacity by it — so passing it
     # separately would render the faded negative bars at the wrong strength.
     ax.bar(
-        bar.x.to_numpy(),
-        bar.y.to_numpy(),
+        _as_array(bar.x),
+        _as_array(bar.y),
         color=[_faded(c, bar.opacity) for c in bar.colors],
         linewidth=0,
         label=bar.name,
     )
+
+
+def _draw_ref_line(ax: Axes, ref: RefLine) -> None:
+    """Draw a fixed-value marker line onto *ax*.
+
+    Args:
+        ax: The axes to draw on.
+        ref: The line to draw.
+
+    """
+    draw = ax.axhline if ref.orientation == "h" else ax.axvline
+    draw(ref.value, color=mpl_color(ref.color), linewidth=ref.width, linestyle=_LINESTYLES[ref.dash])
+
+
+def _draw_band(ax: Axes, band: Band) -> None:
+    """Draw a shaded vertical span onto *ax*.
+
+    Args:
+        ax: The axes to draw on.
+        band: The span to draw.
+
+    """
+    ax.axvspan(band.x0, band.x1, color=mpl_color(band.color), linewidth=0)
+    if band.label is not None:
+        # Placed at the top of the span in axes coordinates, matching where
+        # Plotly puts its annotation.
+        ax.annotate(
+            band.label,
+            xy=(band.x0, 1.0),
+            xycoords=("data", "axes fraction"),
+            xytext=(2, -2),
+            textcoords="offset points",
+            ha="left",
+            va="top",
+            fontsize=band.label_size,
+        )
 
 
 def _draw_heatmap(fig: Figure, ax: Axes, grid: HeatmapGrid) -> None:
@@ -269,6 +346,10 @@ def render_mpl(spec: FigureSpec) -> Figure:
         _draw_bars(ax, bar)
     if panel.heatmap is not None:
         _draw_heatmap(fig, ax, panel.heatmap)
+    for ref in panel.ref_lines:
+        _draw_ref_line(ax, ref)
+    for band in panel.bands:
+        _draw_band(ax, band)
 
     ax.set_facecolor("white")
     # Stated either way rather than leaning on ``rcParams["axes.grid"]``: that

--- a/src/jquantstats/_plots/_render/_plotly.py
+++ b/src/jquantstats/_plots/_render/_plotly.py
@@ -17,7 +17,18 @@ from __future__ import annotations
 import plotly.graph_objects as go
 
 from .._data._styling import _apply_base_layout, _apply_figsize
-from .._spec import Axis, BarSeries, ColorScale, FigureSpec, HeatmapGrid, HoverSpec, LineSeries, TickFormat
+from .._spec import (
+    Axis,
+    Band,
+    BarSeries,
+    ColorScale,
+    FigureSpec,
+    HeatmapGrid,
+    HoverSpec,
+    LineSeries,
+    RefLine,
+    TickFormat,
+)
 
 __all__ = ["render_plotly"]
 
@@ -25,6 +36,7 @@ __all__ = ["render_plotly"]
 _D3_FORMATS: dict[TickFormat, str] = {
     "float2": ".2f",
     "float4": ".4f",
+    "percent0": ".0%",
     "percent1": ".1%",
     "percent2": ".2%",
     "currency0": ",.0f",
@@ -71,7 +83,11 @@ def _scatter(line: LineSeries) -> go.Scatter:
     if line.dash != "solid":
         style["dash"] = _DASHES[line.dash]
 
-    trace = go.Scatter(x=line.x, y=line.y, mode="lines", name=line.name, line=style)
+    fill: dict[str, object] = {}
+    if line.fill_color is not None:
+        fill = {"fill": "tozeroy", "fillcolor": line.fill_color}
+
+    trace = go.Scatter(x=line.x, y=line.y, mode="lines", name=line.name, line=style, **fill)
     if line.hover is not None:
         trace.update(hovertemplate=_hovertemplate(line.hover))
     return trace
@@ -123,6 +139,44 @@ def _heatmap(grid: HeatmapGrid) -> go.Heatmap:
     if grid.hover_label is not None:
         trace.update(hovertemplate=f"<b>%{{y}} %{{x}}</b><br>{grid.hover_label}: %{{text}}<extra></extra>")
     return trace
+
+
+def _add_ref_line(fig: go.Figure, ref: RefLine) -> None:
+    """Draw a fixed-value marker line onto *fig*.
+
+    Args:
+        fig: The figure to draw on.
+        ref: The line to draw.
+
+    """
+    # `dash` is left unstated when solid: that is Plotly's default, and naming
+    # it anyway would add a property to the serialised shape.
+    style: dict[str, object] = {"line_width": ref.width, "line_color": ref.color}
+    if ref.dash != "solid":
+        style["line_dash"] = _DASHES[ref.dash]
+
+    if ref.orientation == "h":
+        fig.add_hline(y=ref.value, **style)
+    else:
+        fig.add_vline(x=ref.value, **style)
+
+
+def _add_band(fig: go.Figure, band: Band) -> None:
+    """Draw a shaded vertical span onto *fig*.
+
+    Args:
+        fig: The figure to draw on.
+        band: The span to draw.
+
+    """
+    kwargs: dict[str, object] = {}
+    if band.label is not None:
+        kwargs = {
+            "annotation_text": band.label,
+            "annotation_position": "top left",
+            "annotation_font_size": band.label_size,
+        }
+    fig.add_vrect(x0=band.x0, x1=band.x1, fillcolor=band.color, line_width=0, **kwargs)
 
 
 def _axis_kwargs(axis: Axis, *, vertical: bool = False) -> dict[str, object]:
@@ -179,6 +233,10 @@ def render_plotly(spec: FigureSpec) -> go.Figure:
         fig.add_trace(_bar(bar))
     if panel.heatmap is not None:
         fig.add_trace(_heatmap(panel.heatmap))
+    for ref in panel.ref_lines:
+        _add_ref_line(fig, ref)
+    for band in panel.bands:
+        _add_band(fig, band)
 
     if spec.chrome == "timeseries":
         _apply_base_layout(fig, spec.title, height=spec.height, with_range_selector=spec.date_range_selector)

--- a/src/jquantstats/_plots/_spec.py
+++ b/src/jquantstats/_plots/_spec.py
@@ -25,12 +25,13 @@ convert at the point of use.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal, TypeAlias
 
 import polars as pl
 
 __all__ = [
     "Axis",
+    "Band",
     "BarSeries",
     "Chrome",
     "ColorScale",
@@ -40,8 +41,20 @@ __all__ = [
     "HoverSpec",
     "LineSeries",
     "Panel",
+    "RefLine",
     "TickFormat",
+    "Values",
 ]
+
+#: Plotted values: a polars Series, or a plain Python list.
+#:
+#: Both are accepted deliberately. Plotly serialises them differently — a Series
+#: becomes a compact binary buffer, a list a plain JSON array — and each chart's
+#: existing wire format is pinned by the fidelity snapshots. Builders therefore
+#: pass through whichever container the chart already used rather than
+#: normalising, so moving a chart onto this seam changes nothing. Renderers must
+#: accept either.
+Values: TypeAlias = "pl.Series | list[Any]"
 
 #: How to render a number, named by intent rather than by any backend's syntax.
 #:
@@ -50,7 +63,7 @@ __all__ = [
 #: a thousands-separated integer. Each renderer owns the mapping — Plotly wants
 #: ``".2f"``, matplotlib wants a ``Formatter`` — so neither vocabulary leaks in
 #: here.
-TickFormat = Literal["float2", "float4", "percent1", "percent2", "currency0"]
+TickFormat = Literal["float2", "float4", "percent0", "percent1", "percent2", "currency0"]
 
 #: Line styles, kept to the set the charts actually use.
 Dash = Literal["solid", "dash"]
@@ -104,19 +117,22 @@ class LineSeries:
         color: Line colour as ``#RRGGBB``; both backends accept that spelling.
         width: Stroke width.
         dash: Stroke pattern.
+        fill_color: Shade the area between the line and zero in this colour,
+            or None to leave the line unfilled. Used by the underwater curve.
         hover: Tooltip description, or None to leave the backend's default.
 
     """
 
     name: str
-    x: pl.Series
-    y: pl.Series
+    x: Values
+    y: Values
     color: str
     # Left as an int so a whole-number width serialises as `2` rather than
     # `2.0`. Plotly preserves the distinction in its JSON, and the fidelity
     # snapshots compare that JSON exactly.
     width: float = 2
     dash: Dash = "solid"
+    fill_color: str | None = None
     hover: HoverSpec | None = None
 
 
@@ -136,11 +152,54 @@ class BarSeries:
     """
 
     name: str
-    x: pl.Series
-    y: pl.Series
+    x: Values
+    y: Values
     colors: tuple[str, ...]
     opacity: float = 0.85
     hover: HoverSpec | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RefLine:
+    """A straight line marking a fixed value, such as break-even at zero.
+
+    Attributes:
+        value: Where to draw it, in data coordinates.
+        orientation: ``"h"`` for a horizontal line at *value*, ``"v"`` for a
+            vertical one.
+        color: Line colour.
+        width: Stroke width.
+        dash: Stroke pattern.
+
+    """
+
+    value: float
+    orientation: Literal["h", "v"] = "h"
+    color: str = "gray"
+    width: float = 1
+    dash: Dash = "solid"
+
+
+@dataclass(frozen=True, slots=True)
+class Band:
+    """A shaded vertical span marking a stretch of the x-axis.
+
+    Used to pick out the worst drawdown episodes on an equity curve.
+
+    Attributes:
+        x0: Where the span starts.
+        x1: Where it ends.
+        color: Fill colour, usually translucent so the line stays readable.
+        label: Text drawn at the top of the span, or None for no label.
+        label_size: Point size for that text.
+
+    """
+
+    x0: Any
+    x1: Any
+    color: str
+    label: str | None = None
+    label_size: int = 10
 
 
 @dataclass(frozen=True, slots=True)
@@ -214,6 +273,8 @@ class Panel:
         lines: Line series to draw.
         bars: Bar series to draw.
         heatmap: A value matrix to draw, or None.
+        ref_lines: Fixed-value marker lines.
+        bands: Shaded vertical spans, drawn behind the series.
         xaxis: Horizontal axis configuration.
         yaxis: Vertical axis configuration.
         title: Heading for this panel, used when a chart has several.
@@ -223,6 +284,8 @@ class Panel:
     lines: tuple[LineSeries, ...] = ()
     bars: tuple[BarSeries, ...] = ()
     heatmap: HeatmapGrid | None = None
+    ref_lines: tuple[RefLine, ...] = ()
+    bands: tuple[Band, ...] = ()
     xaxis: Axis = field(default_factory=Axis)
     yaxis: Axis = field(default_factory=Axis)
     title: str | None = None

--- a/src/jquantstats/_plots/_specs/__init__.py
+++ b/src/jquantstats/_plots/_specs/__init__.py
@@ -8,6 +8,9 @@ from ._cumulative import compare_spec as compare_spec
 from ._cumulative import cumulative_returns_spec as cumulative_returns_spec
 from ._cumulative import earnings_spec as earnings_spec
 from ._cumulative import log_returns_spec as log_returns_spec
+from ._drawdown import compute_drawdown_periods as compute_drawdown_periods
+from ._drawdown import drawdown_spec as drawdown_spec
+from ._drawdown import drawdowns_periods_spec as drawdowns_periods_spec
 from ._periodic import daily_returns_spec as daily_returns_spec
 from ._periodic import monthly_heatmap_spec as monthly_heatmap_spec
 from ._periodic import monthly_returns_spec as monthly_returns_spec
@@ -16,8 +19,11 @@ from ._periodic import yearly_returns_spec as yearly_returns_spec
 
 __all__ = [
     "compare_spec",
+    "compute_drawdown_periods",
     "cumulative_returns_spec",
     "daily_returns_spec",
+    "drawdown_spec",
+    "drawdowns_periods_spec",
     "earnings_spec",
     "log_returns_spec",
     "monthly_heatmap_spec",

--- a/src/jquantstats/_plots/_specs/_drawdown.py
+++ b/src/jquantstats/_plots/_specs/_drawdown.py
@@ -1,0 +1,177 @@
+"""Spec builders for the drawdown charts.
+
+Two views of the same thing: `drawdown_spec` plots the decline from the running
+peak directly, while `drawdowns_periods_spec` leaves the equity curve alone and
+shades the worst episodes on top of it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import plotly.express as px
+import polars as pl
+
+from .._spec import Axis, Band, FigureSpec, HoverSpec, LineSeries, Panel, RefLine
+from .._style import hex_to_rgba, ticker_colors
+
+if TYPE_CHECKING:
+    from jquantstats._protocol import DataLike
+
+__all__ = ["compute_drawdown_periods", "drawdown_spec", "drawdowns_periods_spec"]
+
+# The underwater curve's fill, and the shading over a drawdown episode. Both are
+# translucent so the line underneath stays readable.
+_FILL_ALPHA = 0.3
+_BAND_ALPHA = 0.2
+
+# The equity curve in the periods chart is a single fixed colour rather than a
+# palette entry: there is only ever one asset on it, so nothing to distinguish.
+_EQUITY_COLOR = "#1f77b4"
+
+
+def _split_columns(frame: pl.DataFrame) -> tuple[str, list[str]]:
+    """Separate the date column from the value columns.
+
+    Args:
+        frame: A frame whose first column is the date axis.
+
+    Returns:
+        tuple[str, list[str]]: The date column name and every other column.
+
+    """
+    date_col = frame.columns[0]
+    return date_col, [c for c in frame.columns if c != date_col]
+
+
+def compute_drawdown_periods(prices: list[float], n: int) -> list[dict[str, Any]]:
+    """Identify the *n* worst drawdown periods in a cumulative price series.
+
+    A period runs from the point the series falls below its running peak until
+    it recovers to it. Periods are ranked by depth, worst first.
+
+    Args:
+        prices: Cumulative price (NAV) values.
+        n: Maximum number of periods to return.
+
+    Returns:
+        list[dict[str, Any]]: Dicts with ``start_idx``, ``end_idx``,
+        ``valley_idx`` and ``max_drawdown`` (a fraction <= 0), worst first.
+
+    """
+    length = len(prices)
+    hwm: list[float] = [0.0] * length
+    hwm[0] = prices[0]
+    for i in range(1, length):
+        hwm[i] = max(hwm[i - 1], prices[i])
+
+    in_dd = [prices[i] < hwm[i] for i in range(length)]
+    periods: list[dict[str, Any]] = []
+    i = 0
+    while i < length:
+        if not in_dd[i]:
+            i += 1
+            continue
+        start = i
+        while i < length and in_dd[i]:
+            i += 1
+        end = i - 1
+        valley = start + min(range(end - start + 1), key=lambda k: prices[start + k])
+        max_dd = (prices[valley] - hwm[valley]) / hwm[valley]
+        periods.append({"start_idx": start, "end_idx": end, "valley_idx": valley, "max_drawdown": max_dd})
+
+    periods.sort(key=lambda p: p["max_drawdown"])
+    return periods[:n]
+
+
+def drawdown_spec(data: DataLike, title: str) -> FigureSpec:
+    """Describe the underwater equity curve.
+
+    Args:
+        data: The dataset to plot.
+        title: Chart title.
+
+    Returns:
+        FigureSpec: One filled series per column, with a break-even line.
+
+    """
+    df = data.all
+    date_col, tickers = _split_columns(df)
+    colors = ticker_colors(tickers)
+    prices = df.with_columns([(1.0 + pl.col(t)).cum_prod().alias(t) for t in tickers])
+
+    lines = []
+    for ticker in tickers:
+        price_s = prices[ticker]
+        hwm = price_s.cum_max()
+        lines.append(
+            LineSeries(
+                name=ticker,
+                x=prices[date_col],
+                y=((price_s - hwm) / hwm).to_list(),
+                color=colors[ticker],
+                width=1.5,
+                fill_color=hex_to_rgba(colors[ticker], _FILL_ALPHA),
+                hover=HoverSpec(label=ticker, value_format="percent2", date_header=False),
+            )
+        )
+
+    panel = Panel(
+        lines=tuple(lines),
+        ref_lines=(RefLine(value=0),),
+        yaxis=Axis(title="Drawdown", tick_format="percent0"),
+    )
+    return FigureSpec(title=title, panels=(panel,))
+
+
+def drawdowns_periods_spec(data: DataLike, n: int, title: str, asset: str | None) -> FigureSpec:
+    """Describe the equity curve with its worst drawdown episodes shaded.
+
+    One asset per chart: overlapping shaded spans from several assets would be
+    unreadable.
+
+    Args:
+        data: The dataset to plot.
+        n: How many of the worst episodes to shade.
+        title: Chart title, which gains the asset name.
+        asset: Asset column to display, or None for the first.
+
+    Returns:
+        FigureSpec: The equity curve, with one band per episode.
+
+    """
+    df = data.all
+    date_col, tickers = _split_columns(df)
+    col = asset if asset in tickers else tickers[0]
+
+    price_list = (1.0 + df[col].cast(pl.Float64)).cum_prod().to_list()
+    dates = df[date_col].to_list()
+    palette = px.colors.qualitative.Plotly
+
+    bands = []
+    for i, period in enumerate(compute_drawdown_periods(price_list, n)):
+        bands.append(
+            Band(
+                x0=dates[period["start_idx"]],
+                # Extend to the next point so the span covers the final day of
+                # the episode rather than stopping at its left edge.
+                x1=dates[min(period["end_idx"] + 1, len(dates) - 1)],
+                color=hex_to_rgba(palette[i % len(palette)], alpha=_BAND_ALPHA),
+                label=f"#{i + 1} {period['max_drawdown']:.1%}",
+            )
+        )
+
+    panel = Panel(
+        lines=(
+            LineSeries(
+                name=col,
+                x=dates,
+                y=price_list,
+                color=_EQUITY_COLOR,
+                hover=HoverSpec(label=col, value_format="float2", suffix="x"),
+            ),
+        ),
+        bands=tuple(bands),
+        yaxis=Axis(title="Cumulative Return", tick_format="float2"),
+    )
+    return FigureSpec(title=f"{title} — {col}", panels=(panel,))

--- a/tests/test_jquantstats/test__plots/test_mpl_backend.py
+++ b/tests/test_jquantstats/test__plots/test_mpl_backend.py
@@ -23,7 +23,7 @@ import jquantstats
 from jquantstats._plots import _backend
 from jquantstats._plots._render import render, render_plotly
 from jquantstats._plots._render._mpl import _DEFAULT_WIDTH_PX, _DPI, mpl_color, render_mpl
-from jquantstats._plots._spec import Axis, FigureSpec, HeatmapGrid, LineSeries, Panel
+from jquantstats._plots._spec import Axis, Band, FigureSpec, HeatmapGrid, LineSeries, Panel, RefLine
 from jquantstats.exceptions import MissingBackendError
 
 
@@ -44,6 +44,16 @@ def _scaled_colour(colour: str, opacity: float) -> tuple[float, ...]:
     """Reduce a colour to comparable RGBA floats with its alpha scaled."""
     r, g, b, a = to_rgba(mpl_color(colour))
     return tuple(round(channel, 2) for channel in (r, g, b, a * opacity))
+
+
+def _floats(values) -> list[float]:
+    """Normalise plotted values for comparison, missing points becoming NaN.
+
+    Plotly reports a missing point as ``None`` when the spec carried a plain
+    list and as NaN when it carried a Series, while matplotlib always reports
+    NaN. That is a difference in representation, not in what is drawn.
+    """
+    return [float("nan") if value is None else float(value) for value in values]
 
 
 # Every line chart migrated so far, with arguments exercising the interesting
@@ -154,7 +164,7 @@ def test_backends_plot_the_same_numbers(data, method: str, kwargs: dict) -> None
 
     for trace, line in zip(plotly_fig.data, mpl_lines, strict=True):
         assert trace.name == line.get_label()
-        assert list(trace.y) == pytest.approx(list(line.get_ydata()), nan_ok=True)
+        assert _floats(trace.y) == pytest.approx(_floats(line.get_ydata()), nan_ok=True)
 
 
 @pytest.mark.parametrize(("method", "kwargs"), CUMULATIVE_CHARTS, ids=_IDS)
@@ -180,7 +190,7 @@ def test_bar_backends_plot_the_same_numbers(data, method: str, kwargs: dict) -> 
     for trace, container in zip(plotly_fig.data, containers, strict=True):
         assert trace.name == container.get_label()
         heights = [patch.get_height() for patch in container]
-        assert list(trace.y) == pytest.approx(heights, nan_ok=True)
+        assert _floats(trace.y) == pytest.approx(_floats(heights), nan_ok=True)
 
 
 @pytest.mark.parametrize(("method", "kwargs"), BAR_CHARTS, ids=_BAR_IDS)
@@ -293,6 +303,30 @@ def test_heatmap_with_a_midpoint_centres_the_ramp(data) -> None:
     assert norm.vcenter == 0
 
 
+def test_band_without_a_label_draws_no_text() -> None:
+    """A span may shade without naming itself."""
+    panel = Panel(lines=(_line(),), bands=(Band(x0=1, x1=2, color="rgba(0, 0, 0, 0.2)"),))
+    ax = render_mpl(_spec(panel)).axes[0]
+    assert len(ax.patches) == 1
+    assert not ax.texts
+
+
+def test_vertical_and_dashed_reference_lines_render() -> None:
+    """Both marker orientations and stroke patterns reach the axes.
+
+    The drawdown charts only use a solid horizontal line, so the other
+    variants are covered here rather than left untested.
+    """
+    refs = (RefLine(value=0), RefLine(value=2, orientation="v", dash="dash"))
+    ax = render_mpl(_spec(Panel(lines=(_line(),), ref_lines=refs))).axes[0]
+
+    horizontals = [ln for ln in ax.get_lines() if list(ln.get_ydata()) == [0, 0]]
+    verticals = [ln for ln in ax.get_lines() if list(ln.get_xdata()) == [2, 2]]
+    assert horizontals
+    assert verticals
+    assert verticals[0].get_linestyle() == "--"
+
+
 def test_opposite_side_resolves_per_axis() -> None:
     """The far edge is the top for an x-axis and the right for a y-axis.
 
@@ -316,6 +350,65 @@ def test_heatmap_with_no_values_still_renders() -> None:
     )
     fig = render_mpl(FigureSpec(title="T", panels=(Panel(heatmap=grid),), chrome="bare"))
     assert fig.axes[0].images[0].get_array().count() == 0
+
+
+def test_drawdown_backends_plot_the_same_curves(data) -> None:
+    """The underwater curve matches, reference line excluded.
+
+    matplotlib's ``axhline`` is itself a Line2D, so it has to be filtered out
+    before the series line up with Plotly's traces.
+    """
+    plotly_fig = data.plots.drawdown(backend="plotly")
+    mpl_fig = data.plots.drawdown(backend="matplotlib")
+
+    series = [line for line in mpl_fig.axes[0].get_lines() if line.get_label() in {t.name for t in plotly_fig.data}]
+    assert len(series) == len(plotly_fig.data)
+
+    for trace, line in zip(plotly_fig.data, series, strict=True):
+        assert _floats(trace.y) == pytest.approx(_floats(line.get_ydata()), nan_ok=True)
+
+
+def test_drawdown_is_filled_on_both_backends(data) -> None:
+    """The area between the curve and zero is shaded, not just outlined."""
+    plotly_fig = data.plots.drawdown(backend="plotly")
+    assert all(trace.fill == "tozeroy" for trace in plotly_fig.data)
+
+    mpl_fig = data.plots.drawdown(backend="matplotlib")
+    assert len(mpl_fig.axes[0].collections) == len(plotly_fig.data)
+
+
+def test_drawdown_marks_break_even_on_both_backends(data) -> None:
+    """A line at zero separates the underwater region from the surface."""
+    plotly_fig = data.plots.drawdown(backend="plotly")
+    assert any(shape.y0 == 0 for shape in plotly_fig.layout.shapes)
+
+    mpl_fig = data.plots.drawdown(backend="matplotlib")
+    flat = [ln for ln in mpl_fig.axes[0].get_lines() if list(ln.get_ydata()) == [0, 0]]
+    assert flat, "expected a horizontal reference line at zero"
+
+
+@pytest.mark.parametrize("n", [1, 3, 5])
+def test_drawdown_periods_shade_the_same_episodes(data, n: int) -> None:
+    """Both backends shade the same number of episodes, and label them."""
+    plotly_fig = data.plots.drawdowns_periods(n=n, backend="plotly")
+    mpl_fig = data.plots.drawdowns_periods(n=n, backend="matplotlib")
+
+    plotly_bands = [s for s in plotly_fig.layout.shapes if s.type == "rect"]
+    mpl_bands = mpl_fig.axes[0].patches
+
+    assert len(plotly_bands) == len(mpl_bands) <= n
+    assert len(mpl_fig.axes[0].texts) == len(mpl_bands)
+
+
+def test_drawdown_period_labels_match(data) -> None:
+    """The rank-and-depth labels read the same on both backends."""
+    plotly_fig = data.plots.drawdowns_periods(n=3, backend="plotly")
+    mpl_fig = data.plots.drawdowns_periods(n=3, backend="matplotlib")
+
+    plotly_labels = [a.text for a in plotly_fig.layout.annotations]
+    mpl_labels = [t.get_text() for t in mpl_fig.axes[0].texts]
+    assert plotly_labels == mpl_labels
+    assert mpl_labels[0].startswith("#1 ")
 
 
 def test_validation_is_backend_independent(data_no_benchmark) -> None:

--- a/tests/test_jquantstats/test__plots/test_spec_render.py
+++ b/tests/test_jquantstats/test__plots/test_spec_render.py
@@ -17,7 +17,17 @@ import pytest
 
 from jquantstats._plots._render import render_plotly
 from jquantstats._plots._render._plotly import _axis_kwargs, _hovertemplate
-from jquantstats._plots._spec import Axis, BarSeries, FigureSpec, HeatmapGrid, HoverSpec, LineSeries, Panel
+from jquantstats._plots._spec import (
+    Axis,
+    Band,
+    BarSeries,
+    FigureSpec,
+    HeatmapGrid,
+    HoverSpec,
+    LineSeries,
+    Panel,
+    RefLine,
+)
 from jquantstats._plots._specs import (
     compare_spec,
     cumulative_returns_spec,
@@ -205,6 +215,55 @@ def test_bare_chrome_omits_the_timeseries_furniture() -> None:
     assert "legend" not in layout
     assert "rangeselector" not in layout.get("xaxis", {})
     assert layout["plot_bgcolor"] == "white"
+
+
+def test_horizontal_reference_line_sits_at_its_value() -> None:
+    """A break-even marker is a horizontal line at the given value."""
+    fig = render_plotly(_spec(Panel(lines=(_line(),), ref_lines=(RefLine(value=0),))))
+    (shape,) = fig.layout.shapes
+    assert (shape.y0, shape.y1) == (0, 0)
+    assert shape.line.dash is None, "solid is the default and is left unstated"
+
+
+def test_vertical_reference_line_sits_at_its_value() -> None:
+    """The same marker can run the other way."""
+    fig = render_plotly(_spec(Panel(lines=(_line(),), ref_lines=(RefLine(value=2, orientation="v"),))))
+    (shape,) = fig.layout.shapes
+    assert (shape.x0, shape.x1) == (2, 2)
+
+
+def test_dashed_reference_line_states_its_dash() -> None:
+    """A non-default stroke pattern is emitted."""
+    fig = render_plotly(_spec(Panel(lines=(_line(),), ref_lines=(RefLine(value=1, dash="dash"),))))
+    assert fig.layout.shapes[0].line.dash == "dash"
+
+
+def test_band_without_a_label_draws_no_annotation() -> None:
+    """A span may shade without naming itself."""
+    fig = render_plotly(_spec(Panel(lines=(_line(),), bands=(Band(x0=1, x1=2, color="rgba(0,0,0,0.2)"),))))
+    assert not fig.layout.annotations
+    assert len(fig.layout.shapes) == 1
+
+
+def test_band_with_a_label_annotates_it() -> None:
+    """A labelled span carries its text."""
+    band = Band(x0=1, x1=2, color="rgba(0,0,0,0.2)", label="#1 -12.3%")
+    fig = render_plotly(_spec(Panel(lines=(_line(),), bands=(band,))))
+    assert [a.text for a in fig.layout.annotations] == ["#1 -12.3%"]
+
+
+def test_unfilled_lines_omit_the_fill_properties() -> None:
+    """Only the underwater curve is filled; the rest stay outlines."""
+    payload = json.loads(render_plotly(_spec(Panel(lines=(_line(),)))).to_json())["data"][0]
+    assert "fill" not in payload
+    assert "fillcolor" not in payload
+
+
+def test_filled_lines_shade_to_zero() -> None:
+    """A fill colour shades the area between the line and zero."""
+    fig = render_plotly(_spec(Panel(lines=(_line(fill_color="rgba(0,0,0,0.3)"),))))
+    assert fig.data[0].fill == "tozeroy"
+    assert fig.data[0].fillcolor == "rgba(0,0,0,0.3)"
 
 
 def test_bar_mode_is_only_emitted_when_asked_for() -> None:


### PR DESCRIPTION
Fifth of the #628 series. `drawdown` and `drawdowns_periods` now render on either
backend. **Plotly output is unchanged** — the fidelity snapshots passed first time,
without regeneration.

> **Stacked on #945** → #944 → #943 → #940.

Progress: **10 of 29** charts migrated.

## New in the IR

- **`LineSeries.fill_color`** — the underwater curve shades between the line and zero.
- **`RefLine`** — the break-even marker, with orientation and dash.
- **`Band`** — a shaded vertical span with an optional label, for the worst drawdown
  episodes.
- A `percent0` tick format.

## The interesting discovery: `Values`

These two charts hand Plotly plain Python **lists** where the earlier ones handed it
polars **Series** — and Plotly serialises the two differently:

```
list   -> [0.0, -0.1, -0.05]
Series -> {'dtype': 'f8', 'bdata': 'AAAAAAAAAACamZmZmZm5v5qZ...'}
```

So the IR cannot normalise. It has to carry whichever container the chart already used,
or the wire format changes and the snapshots (correctly) fail. `Values` is that union,
documented with the reason, and both renderers accept either.

Normalising everything to Series would arguably be *better* — smaller payloads, one
representation — but it changes serialised output for two charts, and this series holds
the line that only the final PR re-records snapshots. Worth revisiting once every family
has moved; noted in the commit rather than done quietly here.

## Two things that needed care in the matplotlib renderer

1. **`fill_between` shades straight across a NaN** unless told otherwise, so a gap in the
   data would be filled as though the value were zero. Passing `where=` on the non-NaN
   mask keeps the gap.
2. **`_as_array` has to cope with dates as well as floats.** `drawdowns_periods` passes a
   list of `date` objects for x. Floats convert with `dtype=float` (turning `None` into
   NaN, which matplotlib draws as a gap); dates raise `TypeError` and fall through to an
   object array, which matplotlib understands.

The parity comparison needed a `_floats` helper too: Plotly reports a missing point as
`None` when the spec carried a list and as NaN when it carried a Series, while matplotlib
always reports NaN. Representation, not a difference in what is drawn.

## Tidying that came with the move

`_compute_drawdown_periods` moves from `_data/_styling.py` into the drawdown spec module,
where it belongs — it was always pure data prep sitting in a styling file. `_styling.py`
is now **94 lines, down from 168**, and holds only Plotly layout.

## Verification

`make all` green: **fmt, deps, test, docs-coverage, security, license, typecheck
(mypy --strict *and* ty), rhiza-test**.

- 1,602 passed, 5 skipped (kaleido, no local Chrome)
- **100% line + branch coverage**, 0 `# pragma: no cover`, 0 `noqa` added
- **67 snapshots passed without regeneration**
- `_data/_drawdown.py`: 46 statements → 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)