### PR TITLE
Port the rolling charts to both backends (#628)

### DIFF
--- a/src/jquantstats/_plots/_data/_rolling.py
+++ b/src/jquantstats/_plots/_data/_rolling.py
@@ -2,39 +2,24 @@
 
 from __future__ import annotations
 
-import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
-import plotly.graph_objects as go
-import polars as pl
-
-from jquantstats.exceptions import NoBenchmarkError
-
-from ._styling import _apply_base_layout, _apply_figsize, _ticker_colors
+from .._render import render
+from .._specs import (
+    rolling_beta_spec,
+    rolling_sharpe_spec,
+    rolling_sortino_spec,
+    rolling_volatility_spec,
+)
 
 if TYPE_CHECKING:
+    from matplotlib.figure import Figure as MplFigure
+    from plotly.graph_objects import Figure as PlotlyFigure
+
     from jquantstats._protocol import DataLike
 
-
-def _rolling_beta_expr(asset: str, bench_col: str, window: int) -> pl.Expr:
-    """Trailing-window OLS beta of *asset* against *bench_col*.
-
-    Beta is ``cov(asset, bench) / var(bench)``, expanded into rolling means so
-    the whole estimate is a single Polars expression.
-
-    Args:
-        asset: Asset column name.
-        bench_col: Benchmark column name.
-        window: Trailing window size in rows.
-
-    Returns:
-        An expression aliased ``beta``.
-    """
-    mean_x = pl.col(asset).rolling_mean(window_size=window)
-    mean_y = pl.col(bench_col).rolling_mean(window_size=window)
-    mean_xy = (pl.col(asset) * pl.col(bench_col)).rolling_mean(window_size=window)
-    mean_y2 = (pl.col(bench_col) ** 2).rolling_mean(window_size=window)
-    return ((mean_xy - mean_x * mean_y) / (mean_y2 - mean_y**2)).alias("beta")
+    from .._backend import Backend
+    from .._render import Figure
 
 
 class _RollingPlotsMixin:
@@ -44,32 +29,34 @@ class _RollingPlotsMixin:
 
     _data: DataLike
 
-    def _beta_assets(self, df: pl.DataFrame, date_col: str, bench_col: str) -> list[str]:
-        """Asset columns to plot beta for.
+    @overload
+    def rolling_sharpe(
+        self,
+        rolling_period: int = ...,
+        periods_per_year: int = ...,
+        title: str = ...,
+        *,
+        backend: Literal["plotly"] | None = ...,
+    ) -> PlotlyFigure: ...
 
-        Prefers the explicit ``returns`` frame when the data exposes one, and
-        otherwise falls back to every column of *df* that is neither the date
-        nor the benchmark.
-
-        Args:
-            df: The combined index/returns/benchmark frame.
-            date_col: Name of the date column.
-            bench_col: Name of the benchmark column.
-
-        Returns:
-            The asset column names.
-        """
-        returns_df = getattr(self._data, "returns", None)
-        if returns_df is not None:
-            return list(returns_df.columns)
-        return [c for c in df.columns if c != date_col and c != bench_col]
+    @overload
+    def rolling_sharpe(
+        self,
+        rolling_period: int = ...,
+        periods_per_year: int = ...,
+        title: str = ...,
+        *,
+        backend: Literal["matplotlib"],
+    ) -> MplFigure: ...
 
     def rolling_sharpe(
         self,
         rolling_period: int = 126,
         periods_per_year: int = 252,
         title: str = "Rolling Sharpe Ratio",
-    ) -> go.Figure:
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Rolling annualised Sharpe ratio over time.
 
         Computes ``rolling_mean / rolling_std * sqrt(periods_per_year)`` with a
@@ -80,52 +67,43 @@ class _RollingPlotsMixin:
             rolling_period: Trailing window size. Defaults to 126 (6 months).
             periods_per_year: Annualisation factor. Defaults to 252.
             title: Chart title. Defaults to ``"Rolling Sharpe Ratio"``.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly line chart.
+            Figure: A line chart.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        colors = _ticker_colors(tickers)
-        scale = math.sqrt(periods_per_year)
+        spec = rolling_sharpe_spec(self._data, rolling_period, periods_per_year, title)
+        return render(spec, backend)
 
-        rolling = df.with_columns(
-            [
-                (
-                    pl.col(t).rolling_mean(window_size=rolling_period)
-                    / pl.col(t).rolling_std(window_size=rolling_period)
-                    * scale
-                ).alias(t)
-                for t in tickers
-            ]
-        )
+    @overload
+    def rolling_sortino(
+        self,
+        rolling_period: int = ...,
+        periods_per_year: int = ...,
+        title: str = ...,
+        *,
+        backend: Literal["plotly"] | None = ...,
+    ) -> PlotlyFigure: ...
 
-        fig = go.Figure()
-        for ticker in tickers:
-            fig.add_trace(
-                go.Scatter(
-                    x=rolling[date_col],
-                    y=rolling[ticker],
-                    mode="lines",
-                    name=ticker,
-                    line={"color": colors[ticker], "width": 1.5},
-                    hovertemplate=f"{ticker}: %{{y:.2f}}",
-                )
-            )
-
-        fig.add_hline(y=0, line_width=1, line_color="gray", line_dash="dash")
-        _apply_base_layout(fig, title)
-        fig.update_yaxes(title_text=f"Sharpe ({rolling_period}-period rolling)")
-        return fig
+    @overload
+    def rolling_sortino(
+        self,
+        rolling_period: int = ...,
+        periods_per_year: int = ...,
+        title: str = ...,
+        *,
+        backend: Literal["matplotlib"],
+    ) -> MplFigure: ...
 
     def rolling_sortino(
         self,
         rolling_period: int = 126,
         periods_per_year: int = 252,
         title: str = "Rolling Sortino Ratio",
-    ) -> go.Figure:
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Rolling annualised Sortino ratio over time.
 
         Computes ``rolling_mean / rolling_downside_std * sqrt(periods_per_year)``
@@ -135,55 +113,43 @@ class _RollingPlotsMixin:
             rolling_period: Trailing window size. Defaults to 126 (6 months).
             periods_per_year: Annualisation factor. Defaults to 252.
             title: Chart title. Defaults to ``"Rolling Sortino Ratio"``.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly line chart.
+            Figure: A line chart.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        colors = _ticker_colors(tickers)
-        scale = math.sqrt(periods_per_year)
+        spec = rolling_sortino_spec(self._data, rolling_period, periods_per_year, title)
+        return render(spec, backend)
 
-        exprs = []
-        for t in tickers:
-            mean_r = pl.col(t).rolling_mean(window_size=rolling_period)
-            downside = (
-                pl.when(pl.col(t) < 0)
-                .then(pl.col(t) ** 2)
-                .otherwise(0.0)
-                .rolling_mean(window_size=rolling_period)
-                .sqrt()
-            )
-            exprs.append((mean_r / downside * scale).alias(t))
+    @overload
+    def rolling_volatility(
+        self,
+        rolling_period: int = ...,
+        periods_per_year: int = ...,
+        title: str = ...,
+        *,
+        backend: Literal["plotly"] | None = ...,
+    ) -> PlotlyFigure: ...
 
-        rolling = df.with_columns(exprs)
-
-        fig = go.Figure()
-        for ticker in tickers:
-            fig.add_trace(
-                go.Scatter(
-                    x=rolling[date_col],
-                    y=rolling[ticker],
-                    mode="lines",
-                    name=ticker,
-                    line={"color": colors[ticker], "width": 1.5},
-                    hovertemplate=f"{ticker}: %{{y:.2f}}",
-                )
-            )
-
-        fig.add_hline(y=0, line_width=1, line_color="gray", line_dash="dash")
-        _apply_base_layout(fig, title)
-        fig.update_yaxes(title_text=f"Sortino ({rolling_period}-period rolling)")
-        return fig
+    @overload
+    def rolling_volatility(
+        self,
+        rolling_period: int = ...,
+        periods_per_year: int = ...,
+        title: str = ...,
+        *,
+        backend: Literal["matplotlib"],
+    ) -> MplFigure: ...
 
     def rolling_volatility(
         self,
         rolling_period: int = 126,
         periods_per_year: int = 252,
         title: str = "Rolling Volatility",
-    ) -> go.Figure:
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Rolling annualised volatility over time.
 
         Computes ``rolling_std * sqrt(periods_per_year)`` for every column in
@@ -193,37 +159,36 @@ class _RollingPlotsMixin:
             rolling_period: Trailing window size. Defaults to 126 (6 months).
             periods_per_year: Annualisation factor. Defaults to 252.
             title: Chart title. Defaults to ``"Rolling Volatility"``.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly line chart.
+            Figure: A line chart.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        colors = _ticker_colors(tickers)
-        scale = math.sqrt(periods_per_year)
+        spec = rolling_volatility_spec(self._data, rolling_period, periods_per_year, title)
+        return render(spec, backend)
 
-        rolling = df.with_columns(
-            [(pl.col(t).rolling_std(window_size=rolling_period) * scale).alias(t) for t in tickers]
-        )
+    @overload
+    def rolling_beta(
+        self,
+        rolling_period: int = ...,
+        rolling_period2: int | None = ...,
+        title: str = ...,
+        figsize: tuple[int, int] | None = ...,
+        *,
+        backend: Literal["plotly"] | None = ...,
+    ) -> PlotlyFigure: ...
 
-        fig = go.Figure()
-        for ticker in tickers:
-            fig.add_trace(
-                go.Scatter(
-                    x=rolling[date_col],
-                    y=rolling[ticker],
-                    mode="lines",
-                    name=ticker,
-                    line={"color": colors[ticker], "width": 1.5},
-                    hovertemplate=f"{ticker}: %{{y:.2%}}",
-                )
-            )
-
-        _apply_base_layout(fig, title)
-        fig.update_yaxes(title_text=f"Volatility ({rolling_period}-period rolling)", tickformat=".0%")
-        return fig
+    @overload
+    def rolling_beta(
+        self,
+        rolling_period: int = ...,
+        rolling_period2: int | None = ...,
+        title: str = ...,
+        figsize: tuple[int, int] | None = ...,
+        *,
+        backend: Literal["matplotlib"],
+    ) -> MplFigure: ...
 
     def rolling_beta(
         self,
@@ -231,7 +196,9 @@ class _RollingPlotsMixin:
         rolling_period2: int | None = 252,
         title: str = "Rolling Beta",
         figsize: tuple[int, int] | None = None,
-    ) -> go.Figure:
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Rolling beta versus the benchmark.
 
         Plots one line per asset per window size.  Beta is estimated via the
@@ -244,45 +211,14 @@ class _RollingPlotsMixin:
                 chart. Defaults to 252. Pass ``None`` to omit.
             title: Chart title. Defaults to ``"Rolling Beta"``.
             figsize: Optional ``(width, height)`` in pixels.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly line chart.
+            Figure: A line chart.
 
         Raises:
-            AttributeError: If no benchmark columns are present in the data.
+            NoBenchmarkError: If no benchmark columns are present in the data.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-
-        benchmark_df = getattr(self._data, "benchmark", None)
-        if benchmark_df is None:
-            raise NoBenchmarkError
-
-        bench_col = benchmark_df.columns[0]
-        assets = self._beta_assets(df, date_col, bench_col)
-        colors = _ticker_colors(assets)
-        windows = [w for w in (rolling_period, rolling_period2) if w is not None]
-        line_styles = ["solid", "dash"]
-
-        fig = go.Figure()
-        for asset in assets:
-            for w, dash in zip(windows, line_styles, strict=False):
-                beta_df = df.with_columns(_rolling_beta_expr(asset, bench_col, w))
-                label = f"{asset} ({w}d)"
-                fig.add_trace(
-                    go.Scatter(
-                        x=beta_df[date_col],
-                        y=beta_df["beta"],
-                        mode="lines",
-                        name=label,
-                        line={"color": colors[asset], "width": 1.5, "dash": dash},
-                        hovertemplate=f"{label}: %{{y:.2f}}",
-                    )
-                )
-
-        fig.add_hline(y=1, line_width=1, line_color="gray", line_dash="dash")
-        _apply_base_layout(fig, title)
-        _apply_figsize(fig, figsize)
-        fig.update_yaxes(title_text="Beta")
-        return fig
+        spec = rolling_beta_spec(self._data, rolling_period, rolling_period2, title, figsize)
+        return render(spec, backend)

--- a/src/jquantstats/_plots/_data/_styling.py
+++ b/src/jquantstats/_plots/_data/_styling.py
@@ -49,7 +49,7 @@ def _date_range_selector() -> dict[str, Any]:
 def _apply_base_layout(
     fig: go.Figure,
     title: str,
-    height: int = 600,
+    height: int | None = 600,
     with_range_selector: bool = True,
 ) -> go.Figure:
     """Apply the standard jquantstats Plotly layout to a figure.
@@ -60,7 +60,8 @@ def _apply_base_layout(
     Args:
         fig: The Plotly figure to style in-place.
         title: Chart title.
-        height: Figure height in pixels. Defaults to 600.
+        height: Figure height in pixels. Defaults to 600. None leaves the
+            height unset, which Plotly treats as "size to the container".
         with_range_selector: Attach a date range-selector to ``xaxis``.
             Defaults to True.
 

--- a/src/jquantstats/_plots/_portfolio/_rolling.py
+++ b/src/jquantstats/_plots/_portfolio/_rolling.py
@@ -6,15 +6,22 @@ Split out of the former single-module `_plots/_portfolio.py`; composed into
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
-import plotly.graph_objects as go
-import polars as pl
-
-from .._data._styling import _apply_base_layout
+from .._render import render
+from .._specs import (
+    annual_sharpe_spec,
+    portfolio_rolling_sharpe_spec,
+    portfolio_rolling_volatility_spec,
+)
 
 if TYPE_CHECKING:
+    from matplotlib.figure import Figure as MplFigure
+    from plotly.graph_objects import Figure as PlotlyFigure
+
+    from .._backend import Backend
     from .._protocol import PortfolioLike
+    from .._render import Figure
 
 
 class _RollingPortfolioPlotsMixin:
@@ -24,50 +31,13 @@ class _RollingPortfolioPlotsMixin:
 
     _portfolio: PortfolioLike
 
-    @staticmethod
-    def _validate_window(window: int) -> None:
-        """Reject a non-positive or non-integer rolling window.
+    @overload
+    def rolling_sharpe_plot(self, window: int = ..., *, backend: Literal["plotly"] | None = ...) -> PlotlyFigure: ...
 
-        Args:
-            window: The candidate rolling-window size.
+    @overload
+    def rolling_sharpe_plot(self, window: int = ..., *, backend: Literal["matplotlib"]) -> MplFigure: ...
 
-        Raises:
-            ValueError: If ``window`` is not a positive integer.
-        """
-        if not isinstance(window, int) or window <= 0:
-            raise ValueError(f"window must be a positive integer, got {window!r}")  # noqa: TRY003
-
-    @staticmethod
-    def _line_per_column(rolling: pl.DataFrame) -> go.Figure:
-        """Render one line trace per non-date column of *rolling*.
-
-        Shared by `rolling_sharpe_plot` and `rolling_volatility_plot`, which
-        differ only in the metric they fetch and the labels they apply.
-
-        Args:
-            rolling: A frame with an optional ``date`` column and one column
-                per asset.
-
-        Returns:
-            A Figure carrying the traces, with no layout applied yet.
-        """
-        fig = go.Figure()
-        date_col = rolling["date"] if "date" in rolling.columns else None
-        for col in rolling.columns:
-            if col == "date":
-                continue
-            fig.add_trace(
-                go.Scatter(
-                    x=date_col,
-                    y=rolling[col],
-                    mode="lines",
-                    name=col,
-                    line={"width": 1},
-                )
-            )
-        return fig
-
-    def rolling_sharpe_plot(self, window: int = 63) -> go.Figure:
+    def rolling_sharpe_plot(self, window: int = 63, *, backend: Backend | None = None) -> Figure:
         """Plot rolling annualised Sharpe ratio over time.
 
         Computes the rolling Sharpe for each asset column using the given
@@ -75,23 +45,26 @@ class _RollingPortfolioPlotsMixin:
 
         Args:
             window: Rolling-window size in periods. Defaults to 63.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            A Plotly Figure with one trace per asset.
+            Figure: A chart with one line per asset.
 
         Raises:
             ValueError: If ``window`` is not a positive integer.
+
         """
-        self._validate_window(window)
+        return render(portfolio_rolling_sharpe_spec(self._portfolio, window), backend)
 
-        fig = self._line_per_column(self._portfolio.stats.rolling_sharpe(rolling_period=window))
-        fig.add_hline(y=0, line_width=1, line_dash="dash", line_color="gray")
+    @overload
+    def rolling_volatility_plot(
+        self, window: int = ..., *, backend: Literal["plotly"] | None = ...
+    ) -> PlotlyFigure: ...
 
-        _apply_base_layout(fig, f"Rolling Sharpe Ratio ({window}-period window)")
-        fig.update_yaxes(title_text="Sharpe ratio")
-        return fig
+    @overload
+    def rolling_volatility_plot(self, window: int = ..., *, backend: Literal["matplotlib"]) -> MplFigure: ...
 
-    def rolling_volatility_plot(self, window: int = 63) -> go.Figure:
+    def rolling_volatility_plot(self, window: int = 63, *, backend: Backend | None = None) -> Figure:
         """Plot rolling annualised volatility over time.
 
         Computes the rolling volatility for each asset column using the given
@@ -99,57 +72,35 @@ class _RollingPortfolioPlotsMixin:
 
         Args:
             window: Rolling-window size in periods. Defaults to 63.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            A Plotly Figure with one trace per asset.
+            Figure: A chart with one line per asset.
 
         Raises:
             ValueError: If ``window`` is not a positive integer.
+
         """
-        self._validate_window(window)
+        return render(portfolio_rolling_volatility_spec(self._portfolio, window), backend)
 
-        fig = self._line_per_column(self._portfolio.stats.rolling_volatility(rolling_period=window))
+    @overload
+    def annual_sharpe_plot(self, *, backend: Literal["plotly"] | None = ...) -> PlotlyFigure: ...
 
-        _apply_base_layout(fig, f"Rolling Volatility ({window}-period window)")
-        fig.update_yaxes(title_text="Annualised volatility")
-        return fig
+    @overload
+    def annual_sharpe_plot(self, *, backend: Literal["matplotlib"]) -> MplFigure: ...
 
-    def annual_sharpe_plot(self) -> go.Figure:
+    def annual_sharpe_plot(self, *, backend: Backend | None = None) -> Figure:
         """Plot annualised Sharpe ratio broken down by calendar year.
 
         Computes the Sharpe ratio for each calendar year from the portfolio
         returns and renders a grouped bar chart with one bar per year per
         asset.
 
+        Args:
+            backend: Renderer to use. Defaults to the ambient selection.
+
         Returns:
-            A Plotly Figure with one bar group per asset.
+            Figure: A grouped bar chart, one bar group per asset.
+
         """
-        breakdown = self._portfolio.stats.annual_breakdown()
-
-        # Extract the sharpe row for each year
-        sharpe_rows = breakdown.filter(pl.col("metric") == "sharpe")
-        asset_cols = [c for c in sharpe_rows.columns if c not in ("year", "metric")]
-
-        fig = go.Figure()
-        for asset in asset_cols:
-            fig.add_trace(
-                go.Bar(
-                    x=sharpe_rows["year"],
-                    y=sharpe_rows[asset],
-                    name=asset,
-                )
-            )
-
-        fig.add_hline(y=0, line_width=1, line_color="gray")
-
-        fig.update_layout(
-            title="Annual Sharpe Ratio by Year",
-            barmode="group",
-            hovermode="x unified",
-            plot_bgcolor="white",
-            legend={"orientation": "h", "yanchor": "bottom", "y": 1.02, "xanchor": "right", "x": 1},
-        )
-        fig.update_yaxes(title_text="Sharpe ratio")
-        fig.update_xaxes(showgrid=True, gridwidth=0.5, gridcolor="lightgrey", title_text="Year")
-        fig.update_yaxes(showgrid=True, gridwidth=0.5, gridcolor="lightgrey")
-        return fig
+        return render(annual_sharpe_spec(self._portfolio), backend)

--- a/src/jquantstats/_plots/_render/_mpl.py
+++ b/src/jquantstats/_plots/_render/_mpl.py
@@ -48,10 +48,11 @@ __all__ = ["render_mpl"]
 # `figsize=(920, 420)` frames the same chart on either backend.
 _DPI = 100
 
-# Width for a spec that names none. Plotly lets a figure size itself to its
-# container; matplotlib needs a number up front, so charts that never set a
-# width get this one.
+# Sizes for a spec that names none. Plotly lets a figure size itself to its
+# container; matplotlib needs numbers up front, so charts that never fix a
+# dimension get these.
 _DEFAULT_WIDTH_PX = 1000
+_DEFAULT_HEIGHT_PX = 600
 
 # Semantic tick format -> a str.format field spec. Python's format mini-language
 # covers percentages too, so `StrMethodFormatter` serves every case and no
@@ -71,7 +72,7 @@ _COLORSCALES: dict[ColorScale, tuple[str, ...]] = {
 }
 
 # Semantic dash style -> matplotlib's linestyle vocabulary.
-_LINESTYLES = {"solid": "-", "dash": "--"}
+_LINESTYLES = {"solid": "-", "dash": "--", None: "-"}
 
 # The Plotly charts draw on white with a light grey grid; mirror that here so a
 # figure is recognisably the same chart whichever backend drew it.
@@ -130,14 +131,20 @@ def _draw_line(ax: Axes, line: LineSeries) -> None:
         line: The series to draw.
 
     """
-    x, y = _as_array(line.x), _as_array(line.y)
+    y = _as_array(line.y)
+    # A series with no x is drawn against its own index, which is what
+    # Plotly does with an unset `x` too.
+    x = np.arange(len(y)) if line.x is None else _as_array(line.x)
+    # A line that names no colour is left to matplotlib's own colour cycle,
+    # matching how Plotly treats an unset `line.color`.
+    styling: dict[str, Any] = {} if line.color is None else {"color": mpl_color(line.color)}
     ax.plot(
         x,
         y,
-        color=mpl_color(line.color),
         linewidth=line.width,
         linestyle=_LINESTYLES[line.dash],
         label=line.name,
+        **styling,
     )
     if line.fill_color is not None:
         # `where` keeps the fill out of the gaps a NaN leaves in the line,
@@ -202,17 +209,19 @@ def _draw_bars(ax: Axes, bar: BarSeries) -> None:
         bar: The series to draw.
 
     """
-    # Opacity is folded into each colour rather than passed as `alpha=`.
-    # matplotlib's alpha argument *replaces* a colour's own alpha channel,
-    # whereas Plotly multiplies its trace opacity by it — so passing it
-    # separately would render the faded negative bars at the wrong strength.
-    ax.bar(
-        _as_array(bar.x),
-        _as_array(bar.y),
-        color=[_faded(c, bar.opacity) for c in bar.colors],
-        linewidth=0,
-        label=bar.name,
-    )
+    styling: dict[str, Any] = {}
+    if bar.colors is not None:
+        # Opacity is folded into each colour rather than passed as `alpha=`.
+        # matplotlib's alpha argument *replaces* a colour's own alpha channel,
+        # whereas Plotly multiplies its trace opacity by it — so passing it
+        # separately would render the faded negative bars at the wrong strength.
+        styling["color"] = [_faded(c, bar.opacity if bar.opacity is not None else 1.0) for c in bar.colors]
+    elif bar.opacity is not None:
+        # No colours named, so there is no alpha to fold into and nothing to
+        # get wrong: matplotlib's own argument is the right tool.
+        styling["alpha"] = bar.opacity
+
+    ax.bar(_as_array(bar.x), _as_array(bar.y), linewidth=0, label=bar.name, **styling)
 
 
 def _draw_ref_line(ax: Axes, ref: RefLine) -> None:
@@ -337,7 +346,7 @@ def render_mpl(spec: FigureSpec) -> Figure:
     (panel,) = spec.panels
 
     width, height = spec.figsize if spec.figsize is not None else (_DEFAULT_WIDTH_PX, spec.height)
-    fig = Figure(figsize=(width / _DPI, height / _DPI), dpi=_DPI)
+    fig = Figure(figsize=(width / _DPI, (height or _DEFAULT_HEIGHT_PX) / _DPI), dpi=_DPI)
     ax = fig.subplots()
 
     for line in panel.lines:

--- a/src/jquantstats/_plots/_render/_plotly.py
+++ b/src/jquantstats/_plots/_render/_plotly.py
@@ -79,8 +79,11 @@ def _scatter(line: LineSeries) -> go.Scatter:
         go.Scatter: The trace, styled per the series.
 
     """
-    style: dict[str, object] = {"color": line.color, "width": line.width}
-    if line.dash != "solid":
+    style: dict[str, object] = {}
+    if line.color is not None:
+        style["color"] = line.color
+    style["width"] = line.width
+    if line.dash is not None:
         style["dash"] = _DASHES[line.dash]
 
     fill: dict[str, object] = {}
@@ -103,13 +106,15 @@ def _bar(bar: BarSeries) -> go.Bar:
         go.Bar: The trace, with one colour per bar.
 
     """
-    trace = go.Bar(
-        x=bar.x,
-        y=bar.y,
-        name=bar.name,
-        marker={"color": list(bar.colors), "line": _BAR_OUTLINE},
-        opacity=bar.opacity,
-    )
+    # A chart that names no colours takes Plotly's palette, and says nothing
+    # about markers or opacity at all.
+    styling: dict[str, object] = {}
+    if bar.colors is not None:
+        styling["marker"] = {"color": list(bar.colors), "line": _BAR_OUTLINE}
+    if bar.opacity is not None:
+        styling["opacity"] = bar.opacity
+
+    trace = go.Bar(x=bar.x, y=bar.y, name=bar.name, **styling)
     if bar.hover is not None:
         trace.update(hovertemplate=_hovertemplate(bar.hover))
     return trace
@@ -149,10 +154,10 @@ def _add_ref_line(fig: go.Figure, ref: RefLine) -> None:
         ref: The line to draw.
 
     """
-    # `dash` is left unstated when solid: that is Plotly's default, and naming
-    # it anyway would add a property to the serialised shape.
+    # An unset dash is left unstated rather than sent as "solid": that would
+    # add a property to the serialised shape which the chart never had.
     style: dict[str, object] = {"line_width": ref.width, "line_color": ref.color}
-    if ref.dash != "solid":
+    if ref.dash is not None:
         style["line_dash"] = _DASHES[ref.dash]
 
     if ref.orientation == "h":

--- a/src/jquantstats/_plots/_spec.py
+++ b/src/jquantstats/_plots/_spec.py
@@ -66,6 +66,11 @@ Values: TypeAlias = "pl.Series | list[Any]"
 TickFormat = Literal["float2", "float4", "percent0", "percent1", "percent2", "currency0"]
 
 #: Line styles, kept to the set the charts actually use.
+#:
+#: A field typed ``Dash | None`` treats None as *say nothing* and leave the
+#: backend's default, which is distinct from asking for ``"solid"``
+#: explicitly. Some charts state it and some do not, and Plotly records the
+#: difference in its serialised output.
 Dash = Literal["solid", "dash"]
 
 #: Named colour ramps for matrix charts, resolved per backend.
@@ -112,11 +117,13 @@ class LineSeries:
 
     Attributes:
         name: Legend entry for the series.
-        x: Horizontal positions, typically the date column.
+        x: Horizontal positions, typically the date column, or None to let the
+            backend number the points.
         y: Vertical positions.
-        color: Line colour as ``#RRGGBB``; both backends accept that spelling.
+        color: Line colour as ``#RRGGBB``, or None to take the backend's next
+            palette colour.
         width: Stroke width.
-        dash: Stroke pattern.
+        dash: Stroke pattern, or None to leave the backend's default.
         fill_color: Shade the area between the line and zero in this colour,
             or None to leave the line unfilled. Used by the underwater curve.
         hover: Tooltip description, or None to leave the backend's default.
@@ -124,14 +131,14 @@ class LineSeries:
     """
 
     name: str
-    x: Values
     y: Values
-    color: str
+    x: Values | None = None
+    color: str | None = None
     # Left as an int so a whole-number width serialises as `2` rather than
     # `2.0`. Plotly preserves the distinction in its JSON, and the fidelity
     # snapshots compare that JSON exactly.
     width: float = 2
-    dash: Dash = "solid"
+    dash: Dash | None = None
     fill_color: str | None = None
     hover: HoverSpec | None = None
 
@@ -144,9 +151,10 @@ class BarSeries:
         name: Legend entry for the series.
         x: Bar positions — dates, or the category each bar sits at.
         y: Bar heights.
-        colors: One colour per bar. Per-bar rather than per-series because
-            these charts colour a bar by the sign of its value.
-        opacity: Fill opacity.
+        colors: One colour per bar, or None to take the backend's palette.
+            Per-bar rather than per-series because several of these charts
+            colour a bar by the sign of its value.
+        opacity: Fill opacity, or None for the backend's default.
         hover: Tooltip description, or None to leave the backend's default.
 
     """
@@ -154,8 +162,8 @@ class BarSeries:
     name: str
     x: Values
     y: Values
-    colors: tuple[str, ...]
-    opacity: float = 0.85
+    colors: tuple[str, ...] | None = None
+    opacity: float | None = None
     hover: HoverSpec | None = None
 
 
@@ -169,7 +177,7 @@ class RefLine:
             vertical one.
         color: Line colour.
         width: Stroke width.
-        dash: Stroke pattern.
+        dash: Stroke pattern, or None to leave the backend's default.
 
     """
 
@@ -177,7 +185,7 @@ class RefLine:
     orientation: Literal["h", "v"] = "h"
     color: str = "gray"
     width: float = 1
-    dash: Dash = "solid"
+    dash: Dash | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -298,7 +306,7 @@ class FigureSpec:
     Attributes:
         title: Chart title.
         panels: The panels to draw, top to bottom.
-        height: Figure height in pixels.
+        height: Figure height in pixels, or None to let the backend size it.
         figsize: Optional ``(width, height)`` in pixels, overriding *height*.
             Pixels for both backends; the matplotlib renderer converts to
             inches so one public signature means the same thing either way.
@@ -312,7 +320,7 @@ class FigureSpec:
 
     title: str
     panels: tuple[Panel, ...]
-    height: int = 600
+    height: int | None = 600
     figsize: tuple[int, int] | None = None
     date_range_selector: bool = True
     chrome: Chrome = "timeseries"

--- a/src/jquantstats/_plots/_specs/__init__.py
+++ b/src/jquantstats/_plots/_specs/__init__.py
@@ -16,8 +16,18 @@ from ._periodic import monthly_heatmap_spec as monthly_heatmap_spec
 from ._periodic import monthly_returns_spec as monthly_returns_spec
 from ._periodic import period_agg_exprs as period_agg_exprs
 from ._periodic import yearly_returns_spec as yearly_returns_spec
+from ._rolling import annual_sharpe_spec as annual_sharpe_spec
+from ._rolling import portfolio_rolling_sharpe_spec as portfolio_rolling_sharpe_spec
+from ._rolling import portfolio_rolling_volatility_spec as portfolio_rolling_volatility_spec
+from ._rolling import rolling_beta_expr as rolling_beta_expr
+from ._rolling import rolling_beta_spec as rolling_beta_spec
+from ._rolling import rolling_sharpe_spec as rolling_sharpe_spec
+from ._rolling import rolling_sortino_spec as rolling_sortino_spec
+from ._rolling import rolling_volatility_spec as rolling_volatility_spec
+from ._rolling import validate_window as validate_window
 
 __all__ = [
+    "annual_sharpe_spec",
     "compare_spec",
     "compute_drawdown_periods",
     "cumulative_returns_spec",
@@ -29,5 +39,13 @@ __all__ = [
     "monthly_heatmap_spec",
     "monthly_returns_spec",
     "period_agg_exprs",
+    "portfolio_rolling_sharpe_spec",
+    "portfolio_rolling_volatility_spec",
+    "rolling_beta_expr",
+    "rolling_beta_spec",
+    "rolling_sharpe_spec",
+    "rolling_sortino_spec",
+    "rolling_volatility_spec",
+    "validate_window",
     "yearly_returns_spec",
 ]

--- a/src/jquantstats/_plots/_specs/_cumulative.py
+++ b/src/jquantstats/_plots/_specs/_cumulative.py
@@ -49,7 +49,7 @@ def _lines(
     prefix: str = "",
     suffix: str = "",
     width: float = 2,
-    dash: Dash = "solid",
+    dash: Dash | None = None,
 ) -> list[LineSeries]:
     """Build one line series per ticker, all sharing a style.
 

--- a/src/jquantstats/_plots/_specs/_periodic.py
+++ b/src/jquantstats/_plots/_specs/_periodic.py
@@ -23,6 +23,9 @@ __all__ = [
     "yearly_returns_spec",
 ]
 
+# Bars are drawn slightly translucent so overlapping series stay readable.
+_BAR_OPACITY = 0.85
+
 _MONTH_NAMES = ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
 
 # A calendar row per year, plus room for the title and colour bar.
@@ -90,6 +93,7 @@ def _sign_coloured_bars(
             x=frame[x_col],
             y=frame[ticker],
             colors=tuple(bar_colors(frame[ticker].to_list(), colors[ticker], single_asset=single)),
+            opacity=_BAR_OPACITY,
             hover=HoverSpec(label=ticker, value_format="percent2", date_header=False),
         )
         for ticker in tickers
@@ -149,6 +153,7 @@ def yearly_returns_spec(data: DataLike, title: str, compounded: bool) -> FigureS
                 # A flat zero year counts as positive here, unlike the other
                 # bar charts — see `yearly_bar_colors`.
                 colors=tuple(yearly_bar_colors(yearly[ticker].to_list(), colors[ticker])),
+                opacity=_BAR_OPACITY,
                 hover=HoverSpec(label=ticker, value_format="percent2", date_header=False),
             )
             for ticker in tickers

--- a/src/jquantstats/_plots/_specs/_rolling.py
+++ b/src/jquantstats/_plots/_specs/_rolling.py
@@ -1,0 +1,416 @@
+"""Spec builders for the rolling-window and per-year risk charts.
+
+Both facades are served from here. `Data.plots` computes its own rolling
+metrics from the returns frame; `Portfolio.plots` asks its stats facade for
+them. The marks are the same either way, which is why they share a module.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+from jquantstats.exceptions import NoBenchmarkError
+
+from .._spec import Axis, BarSeries, Dash, FigureSpec, HoverSpec, LineSeries, Panel, RefLine, TickFormat
+from .._style import ticker_colors
+
+if TYPE_CHECKING:
+    from jquantstats._protocol import DataLike
+
+    from .._protocol import PortfolioLike
+
+__all__ = [
+    "annual_sharpe_spec",
+    "portfolio_rolling_sharpe_spec",
+    "portfolio_rolling_volatility_spec",
+    "rolling_beta_expr",
+    "rolling_beta_spec",
+    "rolling_sharpe_spec",
+    "rolling_sortino_spec",
+    "rolling_volatility_spec",
+    "validate_window",
+]
+
+# Rolling metrics are noisier than the cumulative curves, so they are drawn
+# finer to keep several overlapping series legible.
+_ROLLING_WIDTH = 1.5
+
+# The portfolio facade's rolling charts are finer still and take the backend's
+# palette rather than naming colours.
+_PORTFOLIO_WIDTH = 1
+
+
+def _split_columns(frame: pl.DataFrame) -> tuple[str, list[str]]:
+    """Separate the date column from the value columns.
+
+    Args:
+        frame: A frame whose first column is the date axis.
+
+    Returns:
+        tuple[str, list[str]]: The date column name and every other column.
+
+    """
+    date_col = frame.columns[0]
+    return date_col, [c for c in frame.columns if c != date_col]
+
+
+def validate_window(window: int) -> None:
+    """Reject a non-positive or non-integer rolling window.
+
+    Lives in the builder rather than a renderer so both backends reject the
+    same inputs with the same message.
+
+    Args:
+        window: The candidate rolling-window size.
+
+    Raises:
+        ValueError: If *window* is not a positive integer.
+
+    """
+    if not isinstance(window, int) or window <= 0:
+        raise ValueError(f"window must be a positive integer, got {window!r}")  # noqa: TRY003
+
+
+def rolling_beta_expr(asset: str, bench_col: str, window: int) -> pl.Expr:
+    """Trailing-window OLS beta of *asset* against *bench_col*.
+
+    Beta is ``cov(asset, bench) / var(bench)``, expanded into rolling means so
+    the whole estimate is a single Polars expression.
+
+    Args:
+        asset: Asset column name.
+        bench_col: Benchmark column name.
+        window: Trailing window size in rows.
+
+    Returns:
+        pl.Expr: An expression aliased ``beta``.
+
+    """
+    mean_x = pl.col(asset).rolling_mean(window_size=window)
+    mean_y = pl.col(bench_col).rolling_mean(window_size=window)
+    mean_xy = (pl.col(asset) * pl.col(bench_col)).rolling_mean(window_size=window)
+    mean_y2 = (pl.col(bench_col) ** 2).rolling_mean(window_size=window)
+    return ((mean_xy - mean_x * mean_y) / (mean_y2 - mean_y**2)).alias("beta")
+
+
+def _metric_lines(
+    frame: pl.DataFrame,
+    date_col: str,
+    tickers: list[str],
+    value_format: TickFormat,
+) -> tuple[LineSeries, ...]:
+    """Build one line per ticker from an already-computed metric frame.
+
+    Args:
+        frame: The frame holding the rolling metric, one column per ticker.
+        date_col: Name of the date column.
+        tickers: Columns to draw, in order.
+        value_format: How tooltip values are rendered.
+
+    Returns:
+        tuple[LineSeries, ...]: One series per ticker.
+
+    """
+    colors = ticker_colors(tickers)
+    return tuple(
+        LineSeries(
+            name=ticker,
+            x=frame[date_col],
+            y=frame[ticker],
+            color=colors[ticker],
+            width=_ROLLING_WIDTH,
+            hover=HoverSpec(label=ticker, value_format=value_format, date_header=False),
+        )
+        for ticker in tickers
+    )
+
+
+def rolling_sharpe_spec(data: DataLike, rolling_period: int, periods_per_year: int, title: str) -> FigureSpec:
+    """Describe the rolling Sharpe-ratio chart.
+
+    Args:
+        data: The dataset to plot.
+        rolling_period: Trailing window size in rows.
+        periods_per_year: Annualisation factor.
+        title: Chart title.
+
+    Returns:
+        FigureSpec: One line per column, with a break-even marker.
+
+    """
+    df = data.all
+    date_col, tickers = _split_columns(df)
+    scale = math.sqrt(periods_per_year)
+
+    rolling = df.with_columns(
+        [
+            (
+                pl.col(t).rolling_mean(window_size=rolling_period)
+                / pl.col(t).rolling_std(window_size=rolling_period)
+                * scale
+            ).alias(t)
+            for t in tickers
+        ]
+    )
+
+    panel = Panel(
+        lines=_metric_lines(rolling, date_col, tickers, "float2"),
+        ref_lines=(RefLine(value=0, dash="dash"),),
+        yaxis=Axis(title=f"Sharpe ({rolling_period}-period rolling)"),
+    )
+    return FigureSpec(title=title, panels=(panel,))
+
+
+def rolling_sortino_spec(data: DataLike, rolling_period: int, periods_per_year: int, title: str) -> FigureSpec:
+    """Describe the rolling Sortino-ratio chart.
+
+    Sortino divides by downside deviation rather than total volatility, so only
+    negative returns contribute to the denominator.
+
+    Args:
+        data: The dataset to plot.
+        rolling_period: Trailing window size in rows.
+        periods_per_year: Annualisation factor.
+        title: Chart title.
+
+    Returns:
+        FigureSpec: One line per column, with a break-even marker.
+
+    """
+    df = data.all
+    date_col, tickers = _split_columns(df)
+    scale = math.sqrt(periods_per_year)
+
+    exprs = []
+    for t in tickers:
+        mean_r = pl.col(t).rolling_mean(window_size=rolling_period)
+        downside = (
+            pl.when(pl.col(t) < 0).then(pl.col(t) ** 2).otherwise(0.0).rolling_mean(window_size=rolling_period).sqrt()
+        )
+        exprs.append((mean_r / downside * scale).alias(t))
+
+    rolling = df.with_columns(exprs)
+
+    panel = Panel(
+        lines=_metric_lines(rolling, date_col, tickers, "float2"),
+        ref_lines=(RefLine(value=0, dash="dash"),),
+        yaxis=Axis(title=f"Sortino ({rolling_period}-period rolling)"),
+    )
+    return FigureSpec(title=title, panels=(panel,))
+
+
+def rolling_volatility_spec(data: DataLike, rolling_period: int, periods_per_year: int, title: str) -> FigureSpec:
+    """Describe the rolling-volatility chart.
+
+    Args:
+        data: The dataset to plot.
+        rolling_period: Trailing window size in rows.
+        periods_per_year: Annualisation factor.
+        title: Chart title.
+
+    Returns:
+        FigureSpec: One line per column. Volatility cannot be negative, so
+        there is no break-even marker.
+
+    """
+    df = data.all
+    date_col, tickers = _split_columns(df)
+    scale = math.sqrt(periods_per_year)
+
+    rolling = df.with_columns([(pl.col(t).rolling_std(window_size=rolling_period) * scale).alias(t) for t in tickers])
+
+    panel = Panel(
+        lines=_metric_lines(rolling, date_col, tickers, "percent2"),
+        yaxis=Axis(title=f"Volatility ({rolling_period}-period rolling)", tick_format="percent0"),
+    )
+    return FigureSpec(title=title, panels=(panel,))
+
+
+def _beta_assets(data: DataLike, df: pl.DataFrame, date_col: str, bench_col: str) -> list[str]:
+    """Asset columns to plot beta for.
+
+    Prefers the explicit ``returns`` frame when the data exposes one, and
+    otherwise falls back to every column that is neither the date nor the
+    benchmark.
+
+    Args:
+        data: The dataset being plotted.
+        df: The combined index/returns/benchmark frame.
+        date_col: Name of the date column.
+        bench_col: Name of the benchmark column.
+
+    Returns:
+        list[str]: The asset column names.
+
+    """
+    returns_df = getattr(data, "returns", None)
+    if returns_df is not None:
+        return list(returns_df.columns)
+    return [c for c in df.columns if c != date_col and c != bench_col]
+
+
+def rolling_beta_spec(
+    data: DataLike,
+    rolling_period: int,
+    rolling_period2: int | None,
+    title: str,
+    figsize: tuple[int, int] | None,
+) -> FigureSpec:
+    """Describe the rolling-beta chart.
+
+    Args:
+        data: The dataset to plot. Must carry a benchmark.
+        rolling_period: Primary trailing window size.
+        rolling_period2: Optional second window, overlaid dashed, or None.
+        title: Chart title.
+        figsize: Optional ``(width, height)`` in pixels.
+
+    Returns:
+        FigureSpec: One line per asset per window, with a marker at beta = 1.
+
+    Raises:
+        NoBenchmarkError: If the data carries no benchmark columns.
+
+    """
+    df = data.all
+    date_col, _ = _split_columns(df)
+
+    benchmark_df = getattr(data, "benchmark", None)
+    if benchmark_df is None:
+        raise NoBenchmarkError
+
+    bench_col = benchmark_df.columns[0]
+    assets = _beta_assets(data, df, date_col, bench_col)
+    colors = ticker_colors(assets)
+    windows = [w for w in (rolling_period, rolling_period2) if w is not None]
+
+    lines = []
+    for asset in assets:
+        # The shorter window is solid and the longer one dashed, so the pair
+        # for one asset reads as the same colour at two horizons.
+        dashes: tuple[Dash, ...] = ("solid", "dash")
+        for window, dash in zip(windows, dashes, strict=False):
+            beta_df = df.with_columns(rolling_beta_expr(asset, bench_col, window))
+            label = f"{asset} ({window}d)"
+            lines.append(
+                LineSeries(
+                    name=label,
+                    x=beta_df[date_col],
+                    y=beta_df["beta"],
+                    color=colors[asset],
+                    width=_ROLLING_WIDTH,
+                    dash=dash,
+                    hover=HoverSpec(label=label, value_format="float2", date_header=False),
+                )
+            )
+
+    panel = Panel(
+        lines=tuple(lines),
+        # Beta of 1 means moving with the benchmark, which is the reference
+        # worth marking rather than zero.
+        ref_lines=(RefLine(value=1, dash="dash"),),
+        yaxis=Axis(title="Beta"),
+    )
+    return FigureSpec(title=title, panels=(panel,), figsize=figsize)
+
+
+def _portfolio_metric_lines(rolling: pl.DataFrame) -> tuple[LineSeries, ...]:
+    """Build one line per non-date column of a portfolio metric frame.
+
+    These charts name no colours, taking the backend's palette instead, and
+    carry no tooltips.
+
+    Args:
+        rolling: A frame with an optional ``date`` column and one column per
+            asset.
+
+    Returns:
+        tuple[LineSeries, ...]: One series per asset column.
+
+    """
+    dates = rolling["date"] if "date" in rolling.columns else None
+    return tuple(
+        LineSeries(name=col, x=dates, y=rolling[col], width=_PORTFOLIO_WIDTH)
+        for col in rolling.columns
+        if col != "date"
+    )
+
+
+def portfolio_rolling_sharpe_spec(portfolio: PortfolioLike, window: int) -> FigureSpec:
+    """Describe the portfolio's rolling Sharpe-ratio chart.
+
+    Args:
+        portfolio: The portfolio to plot.
+        window: Rolling-window size in periods.
+
+    Returns:
+        FigureSpec: One line per asset, with a break-even marker.
+
+    Raises:
+        ValueError: If *window* is not a positive integer.
+
+    """
+    validate_window(window)
+    panel = Panel(
+        lines=_portfolio_metric_lines(portfolio.stats.rolling_sharpe(rolling_period=window)),
+        ref_lines=(RefLine(value=0, dash="dash"),),
+        yaxis=Axis(title="Sharpe ratio"),
+    )
+    return FigureSpec(title=f"Rolling Sharpe Ratio ({window}-period window)", panels=(panel,))
+
+
+def portfolio_rolling_volatility_spec(portfolio: PortfolioLike, window: int) -> FigureSpec:
+    """Describe the portfolio's rolling-volatility chart.
+
+    Args:
+        portfolio: The portfolio to plot.
+        window: Rolling-window size in periods.
+
+    Returns:
+        FigureSpec: One line per asset. Volatility cannot be negative, so there
+        is no break-even marker.
+
+    Raises:
+        ValueError: If *window* is not a positive integer.
+
+    """
+    validate_window(window)
+    panel = Panel(
+        lines=_portfolio_metric_lines(portfolio.stats.rolling_volatility(rolling_period=window)),
+        yaxis=Axis(title="Annualised volatility"),
+    )
+    return FigureSpec(title=f"Rolling Volatility ({window}-period window)", panels=(panel,))
+
+
+def annual_sharpe_spec(portfolio: PortfolioLike) -> FigureSpec:
+    """Describe the per-calendar-year Sharpe breakdown.
+
+    Args:
+        portfolio: The portfolio to plot.
+
+    Returns:
+        FigureSpec: A grouped bar chart, one bar per year per asset.
+
+    """
+    breakdown = portfolio.stats.annual_breakdown()
+    sharpe_rows = breakdown.filter(pl.col("metric") == "sharpe")
+    asset_cols = [c for c in sharpe_rows.columns if c not in ("year", "metric")]
+
+    panel = Panel(
+        bars=tuple(BarSeries(name=asset, x=sharpe_rows["year"], y=sharpe_rows[asset]) for asset in asset_cols),
+        ref_lines=(RefLine(value=0),),
+        xaxis=Axis(title="Year"),
+        yaxis=Axis(title="Sharpe ratio"),
+    )
+    return FigureSpec(
+        title="Annual Sharpe Ratio by Year",
+        panels=(panel,),
+        # Calendar years, so no range selector; and this chart never fixed a
+        # height, letting the container size it.
+        date_range_selector=False,
+        height=None,
+        bar_mode="group",
+    )

--- a/tests/test_jquantstats/test__plots/test_mpl_backend.py
+++ b/tests/test_jquantstats/test__plots/test_mpl_backend.py
@@ -23,8 +23,8 @@ import jquantstats
 from jquantstats._plots import _backend
 from jquantstats._plots._render import render, render_plotly
 from jquantstats._plots._render._mpl import _DEFAULT_WIDTH_PX, _DPI, mpl_color, render_mpl
-from jquantstats._plots._spec import Axis, Band, FigureSpec, HeatmapGrid, LineSeries, Panel, RefLine
-from jquantstats.exceptions import MissingBackendError
+from jquantstats._plots._spec import Axis, Band, BarSeries, FigureSpec, HeatmapGrid, LineSeries, Panel, RefLine
+from jquantstats.exceptions import MissingBackendError, NoBenchmarkError
 
 
 def _normalise_colour(colour: str) -> tuple[float, ...]:
@@ -303,6 +303,31 @@ def test_heatmap_with_a_midpoint_centres_the_ramp(data) -> None:
     assert norm.vcenter == 0
 
 
+def test_line_without_x_is_drawn_against_its_index() -> None:
+    """A series may omit its x-axis.
+
+    The portfolio rolling charts pass whatever their metric frame carries, so
+    a frame without a date column yields `x=None`. Plotly numbers the points
+    itself; matplotlib is given the same numbering explicitly.
+    """
+    ax = render_mpl(_spec(Panel(lines=(_line(x=None),)))).axes[0]
+    assert list(ax.get_lines()[0].get_xdata()) == [0, 1, 2]
+
+
+def test_palette_bars_can_still_be_translucent() -> None:
+    """Opacity works without named colours.
+
+    The bar charts always name their colours and the annual breakdown names
+    none *and* sets no opacity, so this combination has no chart behind it —
+    but the spec can express it, and folding opacity into a colour is
+    impossible when the colour comes from the backend's palette. matplotlib's
+    own ``alpha`` is the right tool there.
+    """
+    bar = BarSeries(name="A", x=pl.Series("x", [1, 2]), y=pl.Series("y", [1.0, 2.0]), opacity=0.5)
+    ax = render_mpl(_spec(Panel(bars=(bar,)))).axes[0]
+    assert ax.containers[0][0].get_alpha() == 0.5
+
+
 def test_band_without_a_label_draws_no_text() -> None:
     """A span may shade without naming itself."""
     panel = Panel(lines=(_line(),), bands=(Band(x0=1, x1=2, color="rgba(0, 0, 0, 0.2)"),))
@@ -350,6 +375,94 @@ def test_heatmap_with_no_values_still_renders() -> None:
     )
     fig = render_mpl(FigureSpec(title="T", panels=(Panel(heatmap=grid),), chrome="bare"))
     assert fig.axes[0].images[0].get_array().count() == 0
+
+
+@pytest.mark.parametrize(
+    ("method", "kwargs"),
+    [
+        ("rolling_sharpe", {}),
+        ("rolling_sharpe", {"rolling_period": 63}),
+        ("rolling_sortino", {}),
+        ("rolling_volatility", {}),
+        ("rolling_beta", {}),
+        ("rolling_beta", {"rolling_period2": None}),
+        ("rolling_beta", {"figsize": (900, 400)}),
+    ],
+    ids=lambda v: str(sorted(v)) if isinstance(v, dict) else v,
+)
+def test_rolling_backends_plot_the_same_numbers(data, method: str, kwargs: dict) -> None:
+    """Both backends draw identical rolling metrics.
+
+    Reference lines are Line2D artists on the matplotlib side, so the series
+    are matched by name rather than by position.
+    """
+    plotly_fig = getattr(data.plots, method)(**kwargs, backend="plotly")
+    mpl_fig = getattr(data.plots, method)(**kwargs, backend="matplotlib")
+
+    names = [trace.name for trace in plotly_fig.data]
+    series = {ln.get_label(): ln for ln in mpl_fig.axes[0].get_lines() if ln.get_label() in set(names)}
+    assert sorted(series) == sorted(names)
+
+    for trace in plotly_fig.data:
+        assert _floats(trace.y) == pytest.approx(_floats(series[trace.name].get_ydata()), nan_ok=True)
+
+
+@pytest.mark.parametrize("window", [21, 63])
+def test_portfolio_rolling_backends_agree(pf, window: int) -> None:
+    """The portfolio facade's rolling charts match across backends too."""
+    for method in ("rolling_sharpe_plot", "rolling_volatility_plot"):
+        plotly_fig = getattr(pf.plots, method)(window=window, backend="plotly")
+        mpl_fig = getattr(pf.plots, method)(window=window, backend="matplotlib")
+
+        names = {trace.name for trace in plotly_fig.data}
+        series = {ln.get_label(): ln for ln in mpl_fig.axes[0].get_lines() if ln.get_label() in names}
+        assert set(series) == names
+
+        for trace in plotly_fig.data:
+            assert _floats(trace.y) == pytest.approx(_floats(series[trace.name].get_ydata()), nan_ok=True)
+
+
+def test_portfolio_rolling_charts_take_the_backend_palette(pf) -> None:
+    """These charts name no colours, unlike the Data ones.
+
+    The spec leaves `LineSeries.color` unset, so each backend assigns from its
+    own palette rather than the shared one.
+    """
+    spec_lines = pf.plots.rolling_sharpe_plot(backend="plotly").data
+    assert all(trace.line.color is None for trace in spec_lines)
+
+    mpl_fig = pf.plots.rolling_sharpe_plot(backend="matplotlib")
+    assert all(line.get_color() for line in mpl_fig.axes[0].get_lines())
+
+
+def test_annual_sharpe_backends_plot_the_same_bars(pf) -> None:
+    """The per-year breakdown matches, and takes the backend palette."""
+    plotly_fig = pf.plots.annual_sharpe_plot(backend="plotly")
+    mpl_fig = pf.plots.annual_sharpe_plot(backend="matplotlib")
+
+    containers = mpl_fig.axes[0].containers
+    assert len(containers) == len(plotly_fig.data)
+
+    for trace, container in zip(plotly_fig.data, containers, strict=True):
+        assert trace.name == container.get_label()
+        assert trace.marker.color is None, "no colours named; the backend picks"
+        heights = [patch.get_height() for patch in container]
+        assert _floats(trace.y) == pytest.approx(_floats(heights), nan_ok=True)
+
+
+def test_rolling_window_validation_is_backend_independent(pf) -> None:
+    """A bad window is rejected in the builder, before any renderer runs."""
+    for backend in ("plotly", "matplotlib"):
+        for method in ("rolling_sharpe_plot", "rolling_volatility_plot"):
+            with pytest.raises(ValueError, match="window must be a positive integer"):
+                getattr(pf.plots, method)(window=0, backend=backend)
+
+
+def test_rolling_beta_requires_a_benchmark_on_both_backends(data_no_benchmark) -> None:
+    """Validation lives above the dispatch, so both backends raise alike."""
+    for backend in ("plotly", "matplotlib"):
+        with pytest.raises(NoBenchmarkError):
+            data_no_benchmark.plots.rolling_beta(backend=backend)
 
 
 def test_drawdown_backends_plot_the_same_curves(data) -> None:

--- a/tests/test_jquantstats/test__plots/test_spec_render.py
+++ b/tests/test_jquantstats/test__plots/test_spec_render.py
@@ -172,10 +172,21 @@ def test_render_rejects_multi_panel_specs() -> None:
         render_plotly(FigureSpec(title="T", panels=(panel, panel)))
 
 
-def test_solid_lines_omit_the_dash_property() -> None:
-    """`solid` is Plotly's default, so it is left unstated."""
-    fig = render_plotly(_spec(Panel(lines=(_line(dash="solid"),))))
+def test_unset_dash_omits_the_property() -> None:
+    """A line that says nothing about its dash gets nothing emitted."""
+    fig = render_plotly(_spec(Panel(lines=(_line(dash=None),))))
     assert "dash" not in json.loads(fig.to_json())["data"][0]["line"]
+
+
+def test_explicitly_solid_dash_is_stated() -> None:
+    """Asking for solid is not the same as saying nothing.
+
+    Some charts write ``dash="solid"`` and some omit the property entirely.
+    Plotly records the difference, so the spec has to be able to express both:
+    None means "leave it alone", ``"solid"`` means "state it".
+    """
+    fig = render_plotly(_spec(Panel(lines=(_line(dash="solid"),))))
+    assert json.loads(fig.to_json())["data"][0]["line"]["dash"] == "solid"
 
 
 def test_dashed_lines_state_the_dash_property() -> None:


### PR DESCRIPTION
Sixth of the #628 series, and the first to touch **`PortfolioPlots`**. Seven methods move
at once — four on `Data` (rolling sharpe, sortino, volatility, beta) and three on
`Portfolio` (rolling sharpe, rolling volatility, annual sharpe) — because they draw the
same marks and differ only in where the numbers come from.

**Plotly output is unchanged.**

> **Stacked on #946** → #945 → #944 → #943 → #940.

Progress: **17 of 29** charts migrated.

## The portfolio charts leave things unset

These are the first charts that *decline* to choose, and the IR grew to say so. Four
fields became optional, all meaning "say nothing, let the backend decide":

| Field | Why |
|---|---|
| `LineSeries.color` | the portfolio rolling charts take the backend's palette |
| `LineSeries.x` | their metric frame may carry no date column |
| `BarSeries.colors` / `opacity` | the annual breakdown names neither |
| `FigureSpec.height` | the annual breakdown never fixed one |

## `Dash` had to widen too — and the gate is what found it

`rolling_beta` writes `dash="solid"` **explicitly**, while `returns()` omits the property
entirely. Plotly records the difference, so a single `dash: Dash` field could not express
both. It is now `Dash | None`: **None means "say nothing", `"solid"` means "state it"**.
Same for `RefLine.dash`.

That is the third field this series has widened for the same reason, and the pattern is
now predictable enough to expect: **whenever two charts differ only in whether they
*mention* a property, the IR needs a `None` to separate "unset" from "set to the
default".** Worth knowing before the remaining families land.

## Three bugs in the matplotlib renderer

Each surfaced by a different gate, none by inspection:

- `mpl_color(None)` crashed on an unset colour — *parity test*
- `height / _DPI` crashed on an unset height — *parity test*
- `_as_array(line.x)` and `_apply_base_layout(height=...)` both rejected the widened
  types — *ty*

`_apply_base_layout` gains `height: int | None`. Plotly already treats `None` as "leave
it alone", so no other caller changes.

## Shrinkage

| File | Before | After |
|---|---|---|
| `_data/_rolling.py` | 89 stmts | **19** |
| `_portfolio/_rolling.py` | 47 stmts | **13** |
| `_data/_styling.py` | 55 stmts (orig.) | **22** — only the Plotly base layout and range-selector config remain |

## Verification

`make all` green: **fmt, deps, test, docs-coverage, security, license, typecheck
(mypy --strict *and* ty), rhiza-test**.

- 1,619 passed, 5 skipped (kaleido, no local Chrome)
- **100% line + branch coverage**, 0 `# pragma: no cover`, 0 `noqa` added
- **67 snapshots passed without regeneration**

🤖 Generated with [Claude Code](https://claude.com/claude-code)