### PR TITLE
Port the distribution and Monte Carlo charts to both backends (#628)

### DIFF
--- a/src/jquantstats/_plots/_data/_distribution.py
+++ b/src/jquantstats/_plots/_data/_distribution.py
@@ -1,17 +1,20 @@
-"""Return-distribution charts (histogram and per-period box plots)."""
+"""Return-distribution charts (overlaid histograms and by-period box plots)."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
-import plotly.graph_objects as go
-import polars as pl
-from plotly.subplots import make_subplots
-
-from ._styling import _apply_base_layout, _ticker_colors
+from .._render import render
+from .._specs import distribution_spec, histogram_spec
 
 if TYPE_CHECKING:
+    from matplotlib.figure import Figure as MplFigure
+    from plotly.graph_objects import Figure as PlotlyFigure
+
     from jquantstats._protocol import DataLike
+
+    from .._backend import Backend
+    from .._render import Figure
 
 
 class _DistributionPlotsMixin:
@@ -21,7 +24,21 @@ class _DistributionPlotsMixin:
 
     _data: DataLike
 
-    def histogram(self, title: str = "Returns Distribution", bins: int = 50) -> go.Figure:
+    @overload
+    def histogram(
+        self, title: str = ..., bins: int = ..., *, backend: Literal["plotly"] | None = ...
+    ) -> PlotlyFigure: ...
+
+    @overload
+    def histogram(self, title: str = ..., bins: int = ..., *, backend: Literal["matplotlib"]) -> MplFigure: ...
+
+    def histogram(
+        self,
+        title: str = "Returns Distribution",
+        bins: int = 50,
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Overlaid return histograms, one per series.
 
         Each asset (and the benchmark, when present) is drawn as a
@@ -32,41 +49,31 @@ class _DistributionPlotsMixin:
         Args:
             title: Chart title. Defaults to ``"Returns Distribution"``.
             bins: Number of histogram bins. Defaults to 50.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly histogram figure.
+            Figure: A histogram figure.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        colors = _ticker_colors(tickers)
+        return render(histogram_spec(self._data, title=title, bins=bins), backend)
 
-        fig = go.Figure()
-        for ticker in tickers:
-            values = df[ticker].drop_nulls().to_list()
-            fig.add_trace(
-                go.Histogram(
-                    x=values,
-                    name=ticker,
-                    nbinsx=bins,
-                    marker_color=colors[ticker],
-                    opacity=0.6,
-                    hovertemplate=f"{ticker}: %{{x:.2%}}<extra></extra>",
-                )
-            )
+    @overload
+    def distribution(
+        self, title: str = ..., compounded: bool = ..., *, backend: Literal["plotly"] | None = ...
+    ) -> PlotlyFigure: ...
 
-        _apply_base_layout(fig, title, with_range_selector=False)
-        fig.update_layout(barmode="overlay")
-        fig.update_xaxes(title_text="Return", tickformat=".1%")
-        fig.update_yaxes(title_text="Count")
-        return fig
+    @overload
+    def distribution(
+        self, title: str = ..., compounded: bool = ..., *, backend: Literal["matplotlib"]
+    ) -> MplFigure: ...
 
     def distribution(
         self,
         title: str = "Return Distribution by Period",
         compounded: bool = True,
-    ) -> go.Figure:
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Return distributions across daily, weekly, monthly, quarterly and yearly periods.
 
         Renders a box plot for each aggregation period so the user can compare
@@ -76,69 +83,10 @@ class _DistributionPlotsMixin:
         Args:
             title: Chart title. Defaults to ``"Return Distribution by Period"``.
             compounded: Compound returns within each period. Defaults to True.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly figure with one subplot per asset.
+            Figure: A figure with one panel per asset.
 
         """
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        colors = _ticker_colors(tickers)
-
-        periods = [
-            ("Daily", None),
-            ("Weekly", "1w"),
-            ("Monthly", "1mo"),
-            ("Quarterly", "3mo"),
-            ("Yearly", "1y"),
-        ]
-
-        n_assets = len(tickers)
-        fig = make_subplots(
-            rows=1,
-            cols=n_assets,
-            subplot_titles=tickers,
-            shared_yaxes=True,
-        )
-
-        for col_idx, ticker in enumerate(tickers, start=1):
-            for period_name, trunc in periods:
-                if trunc is None:
-                    values = df[ticker].drop_nulls().to_list()
-                else:
-                    agg_expr = (
-                        ((1.0 + pl.col(ticker)).product() - 1.0).alias("ret")
-                        if compounded
-                        else pl.col(ticker).sum().alias("ret")
-                    )
-                    agg_df = (
-                        df.with_columns(pl.col(date_col).dt.truncate(trunc).alias("_period"))
-                        .group_by("_period")
-                        .agg(agg_expr)
-                    )
-                    values = agg_df["ret"].drop_nulls().to_list()
-
-                fig.add_trace(
-                    go.Box(
-                        y=values,
-                        name=period_name,
-                        marker_color=colors[ticker],
-                        showlegend=(col_idx == 1),
-                        legendgroup=period_name,
-                        boxpoints="outliers",
-                        hovertemplate=f"{period_name}: %{{y:.2%}}<extra></extra>",
-                    ),
-                    row=1,
-                    col=col_idx,
-                )
-
-        fig.update_layout(
-            title=title,
-            height=500,
-            plot_bgcolor="white",
-            legend={"orientation": "h", "yanchor": "bottom", "y": 1.05, "xanchor": "right", "x": 1},
-        )
-        fig.update_yaxes(tickformat=".1%", showgrid=True, gridwidth=0.5, gridcolor="lightgrey")
-        fig.update_xaxes(showgrid=False)
-        return fig
+        return render(distribution_spec(self._data, title=title, compounded=compounded), backend)

--- a/src/jquantstats/_plots/_data/_montecarlo.py
+++ b/src/jquantstats/_plots/_data/_montecarlo.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
-import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
-import numpy as np
-import plotly.graph_objects as go
-import polars as pl
-
-from ._styling import _apply_base_layout, _apply_figsize, _hex_to_rgba, _ticker_colors
+from .._render import render
+from .._specs import montecarlo_distribution_spec, montecarlo_spec
 
 if TYPE_CHECKING:
+    from matplotlib.figure import Figure as MplFigure
+    from plotly.graph_objects import Figure as PlotlyFigure
+
     from jquantstats._protocol import DataLike
+
+    from .._backend import Backend
+    from .._render import Figure
 
 
 class _MonteCarloPlotsMixin:
@@ -22,13 +24,37 @@ class _MonteCarloPlotsMixin:
 
     _data: DataLike
 
+    @overload
+    def montecarlo(
+        self,
+        n: int = ...,
+        period: int = ...,
+        title: str = ...,
+        figsize: tuple[int, int] | None = ...,
+        *,
+        backend: Literal["plotly"] | None = ...,
+    ) -> PlotlyFigure: ...
+
+    @overload
+    def montecarlo(
+        self,
+        n: int = ...,
+        period: int = ...,
+        title: str = ...,
+        figsize: tuple[int, int] | None = ...,
+        *,
+        backend: Literal["matplotlib"],
+    ) -> MplFigure: ...
+
     def montecarlo(
         self,
         n: int = 100,
         period: int = 252,
         title: str = "Monte Carlo Simulation",
         figsize: tuple[int, int] | None = None,
-    ) -> go.Figure:
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Fan chart of Monte Carlo simulated cumulative return paths.
 
         For each asset column, draws ``n`` bootstrapped paths sampled with
@@ -40,70 +66,40 @@ class _MonteCarloPlotsMixin:
             period: Number of observations per path. Defaults to 252.
             title: Chart title. Defaults to ``"Monte Carlo Simulation"``.
             figsize: Optional figure ``(width, height)`` in pixels.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly fan chart.
+            Figure: A fan chart.
+
+        Raises:
+            ValueError: If ``n`` or ``period`` is not a positive integer.
 
         """
-        if n <= 0:
-            raise ValueError("n must be a positive integer")  # noqa: TRY003
-        if period <= 0:
-            raise ValueError("period must be a positive integer")  # noqa: TRY003
+        return render(montecarlo_spec(self._data, n, period, title, figsize), backend)
 
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        colors = _ticker_colors(tickers)
+    @overload
+    def montecarlo_distribution(
+        self,
+        n: int = ...,
+        period: int = ...,
+        metric: str = ...,
+        title: str = ...,
+        figsize: tuple[int, int] | None = ...,
+        *,
+        backend: Literal["plotly"] | None = ...,
+    ) -> PlotlyFigure: ...
 
-        sample_len = min(period, df.height)
-        dates = df[date_col].tail(sample_len).to_list()
-        rng = np.random.default_rng(seed=42)
-
-        fig = go.Figure()
-        for ticker in tickers:
-            trailing_returns = (
-                df[ticker].tail(sample_len - 1).fill_null(0.0).cast(pl.Float64).to_numpy()
-                if sample_len > 1
-                else np.array([], dtype=np.float64)
-            )
-
-            for i in range(n):
-                draws = (
-                    rng.choice(trailing_returns, size=sample_len - 1, replace=True)
-                    if sample_len > 1
-                    else np.array([], dtype=np.float64)
-                )
-                sim_path = np.cumprod(np.concatenate(([1.0], 1.0 + draws)))
-                fig.add_trace(
-                    go.Scatter(
-                        x=dates,
-                        y=sim_path,
-                        mode="lines",
-                        name=f"{ticker} Sim",
-                        legendgroup=f"{ticker}_sim",
-                        showlegend=(i == 0),
-                        line={"color": _hex_to_rgba(colors[ticker], alpha=0.12), "width": 1},
-                        hovertemplate=f"{ticker} Sim: %{{y:.2f}}x<extra></extra>",
-                    )
-                )
-
-            observed_path = np.cumprod(np.concatenate(([1.0], 1.0 + trailing_returns)))
-            fig.add_trace(
-                go.Scatter(
-                    x=dates,
-                    y=observed_path,
-                    mode="lines",
-                    name=f"{ticker} Observed",
-                    legendgroup=f"{ticker}_obs",
-                    line={"color": colors[ticker], "width": 2.5},
-                    hovertemplate=f"{ticker} Observed: %{{y:.2f}}x<extra></extra>",
-                )
-            )
-
-        _apply_base_layout(fig, title)
-        fig.update_yaxes(title_text="Cumulative Return", tickformat=".2f")
-        _apply_figsize(fig, figsize)
-        return fig
+    @overload
+    def montecarlo_distribution(
+        self,
+        n: int = ...,
+        period: int = ...,
+        metric: str = ...,
+        title: str = ...,
+        figsize: tuple[int, int] | None = ...,
+        *,
+        backend: Literal["matplotlib"],
+    ) -> MplFigure: ...
 
     def montecarlo_distribution(
         self,
@@ -112,7 +108,9 @@ class _MonteCarloPlotsMixin:
         metric: str = "sharpe",
         title: str = "Monte Carlo Distribution",
         figsize: tuple[int, int] | None = None,
-    ) -> go.Figure:
+        *,
+        backend: Backend | None = None,
+    ) -> Figure:
         """Distribution of Monte Carlo simulation metrics.
 
         Computes one metric per simulated path and shows the resulting
@@ -131,73 +129,15 @@ class _MonteCarloPlotsMixin:
                 or ``"cagr"``.
             title: Chart title. Defaults to ``"Monte Carlo Distribution"``.
             figsize: Optional figure ``(width, height)`` in pixels.
+            backend: Renderer to use. Defaults to the ambient selection.
 
         Returns:
-            go.Figure: Interactive Plotly histogram figure.
+            Figure: A histogram figure.
+
+        Raises:
+            ValueError: If ``n`` or ``period`` is not a positive integer, or
+                ``metric`` is not one of the supported names.
 
         """
-        if n <= 0:
-            raise ValueError("n must be a positive integer")  # noqa: TRY003
-        if period <= 0:
-            raise ValueError("period must be a positive integer")  # noqa: TRY003
-
-        metric_key = metric.strip().lower()
-        if metric_key not in {"sharpe", "drawdown", "cagr"}:
-            raise ValueError("metric must be one of: sharpe, drawdown, cagr")  # noqa: TRY003
-        periods_per_year = 252.0
-
-        def _metric_value(returns: np.ndarray) -> float:
-            """Compute the selected metric for a simulated return path."""
-            if metric_key == "sharpe":
-                std = returns.std(ddof=1)
-                return float(math.sqrt(periods_per_year) * returns.mean() / std) if std > 0 else 0.0
-            if metric_key == "drawdown":
-                path = np.cumprod(1.0 + returns)
-                hwm = np.maximum.accumulate(path)
-                dd = (path - hwm) / hwm
-                return float(dd.min()) if dd.size else 0.0
-            total_return = float(np.prod(1.0 + returns))
-            return float(total_return ** (periods_per_year / len(returns)) - 1.0) if len(returns) > 0 else 0.0
-
-        df = self._data.all
-        date_col = df.columns[0]
-        tickers = [c for c in df.columns if c != date_col]
-        colors = _ticker_colors(tickers)
-        sample_len = min(period, df.height)
-        rng = np.random.default_rng(seed=42)
-
-        fig = go.Figure()
-        for ticker in tickers:
-            hist_returns = df[ticker].tail(sample_len).fill_null(0.0).cast(pl.Float64).to_numpy()
-            if hist_returns.size == 0:  # pragma: no cover
-                continue
-
-            simulated_metrics = [
-                _metric_value(rng.choice(hist_returns, size=sample_len, replace=True)) for _ in range(n)
-            ]
-            observed_metric = _metric_value(hist_returns)
-
-            fig.add_trace(
-                go.Histogram(
-                    x=simulated_metrics,
-                    name=ticker,
-                    marker_color=colors[ticker],
-                    opacity=0.6,
-                    hovertemplate=f"{ticker}: %{{x:.4f}}<extra></extra>",
-                )
-            )
-            fig.add_vline(
-                x=observed_metric,
-                line={"color": colors[ticker], "width": 2, "dash": "dash"},
-                annotation_text=f"{ticker} observed",
-                annotation_position="top right",
-                annotation_font_size=10,
-            )
-
-        metric_title = {"sharpe": "Sharpe Ratio", "drawdown": "Max Drawdown", "cagr": "CAGR"}[metric_key]
-        _apply_base_layout(fig, title, with_range_selector=False)
-        fig.update_layout(barmode="overlay")
-        fig.update_xaxes(title_text=metric_title)
-        fig.update_yaxes(title_text="Count")
-        _apply_figsize(fig, figsize)
-        return fig
+        spec = montecarlo_distribution_spec(self._data, n, period, metric, title, figsize)
+        return render(spec, backend)

--- a/src/jquantstats/_plots/_render/_mpl.py
+++ b/src/jquantstats/_plots/_render/_mpl.py
@@ -30,10 +30,13 @@ from .._spec import (
     Axis,
     Band,
     BarSeries,
+    BoxSeries,
     ColorScale,
     FigureSpec,
     HeatmapGrid,
+    HistogramSeries,
     LineSeries,
+    Panel,
     RefLine,
     TickFormat,
     Values,
@@ -234,6 +237,21 @@ def _draw_ref_line(ax: Axes, ref: RefLine) -> None:
     """
     draw = ax.axhline if ref.orientation == "h" else ax.axvline
     draw(ref.value, color=mpl_color(ref.color), linewidth=ref.width, linestyle=_LINESTYLES[ref.dash])
+    if ref.label is not None:
+        # Anchored to the line in data coordinates and to the top of the axes,
+        # matching where Plotly places its annotation.
+        anchor = (0.0, ref.value) if ref.orientation == "h" else (ref.value, 1.0)
+        coords = ("axes fraction", "data") if ref.orientation == "h" else ("data", "axes fraction")
+        ax.annotate(
+            ref.label,
+            xy=anchor,
+            xycoords=coords,
+            xytext=(-2, -2),
+            textcoords="offset points",
+            ha="right",
+            va="top",
+            fontsize=ref.label_size,
+        )
 
 
 def _draw_band(ax: Axes, band: Band) -> None:
@@ -258,6 +276,48 @@ def _draw_band(ax: Axes, band: Band) -> None:
             va="top",
             fontsize=band.label_size,
         )
+
+
+def _draw_histogram(ax: Axes, hist: HistogramSeries) -> None:
+    """Draw one histogram series onto *ax*.
+
+    Args:
+        ax: The axes to draw on.
+        hist: The series to bin and draw.
+
+    """
+    # `bins=None` is matplotlib's own "use the default count", so an unset bin
+    # count passes straight through rather than needing a separate call.
+    ax.hist(
+        _as_array(hist.values),
+        bins=hist.bins,
+        color=mpl_color(hist.color),
+        alpha=hist.opacity,
+        label=hist.name,
+    )
+
+
+def _draw_boxes(ax: Axes, boxes: tuple[BoxSeries, ...]) -> None:
+    """Draw a panel's box-and-whisker series onto *ax*.
+
+    Drawn together rather than one at a time: matplotlib positions boxes by
+    index within a single call, and wants the category labels alongside.
+
+    Args:
+        ax: The axes to draw on.
+        boxes: The series to summarise, left to right.
+
+    """
+    if not boxes:
+        return
+    artists = ax.boxplot(
+        [_as_array(box.values) for box in boxes],
+        tick_labels=[box.name for box in boxes],
+        showfliers=True,
+        patch_artist=True,
+    )
+    for patch, box in zip(artists["boxes"], boxes, strict=True):
+        patch.set_facecolor(mpl_color(box.color))
 
 
 def _draw_heatmap(fig: Figure, ax: Axes, grid: HeatmapGrid) -> None:
@@ -332,27 +392,40 @@ def render_mpl(spec: FigureSpec) -> Figure:
     """Render *spec* as a static matplotlib figure.
 
     Args:
-        spec: The chart to draw. Must describe exactly one panel; multi-panel
-            charts arrive with the dashboards.
+        spec: The chart to draw.
 
     Returns:
         Figure: The rendered figure. It is not registered with pyplot, so the
         caller owns it and nothing accumulates between calls.
 
-    Raises:
-        ValueError: If *spec* does not contain exactly one panel.
-
     """
-    (panel,) = spec.panels
-
     width, height = spec.figsize if spec.figsize is not None else (_DEFAULT_WIDTH_PX, spec.height)
     fig = Figure(figsize=(width / _DPI, (height or _DEFAULT_HEIGHT_PX) / _DPI), dpi=_DPI)
-    ax = fig.subplots()
+    axes = fig.subplots(ncols=len(spec.panels), sharey=spec.shared_y, squeeze=False)[0]
 
+    for ax, panel in zip(axes, spec.panels, strict=True):
+        _draw_panel(fig, ax, panel, spec)
+    fig.suptitle(spec.title)
+    return fig
+
+
+def _draw_panel(fig: Figure, ax: Axes, panel: Panel, spec: FigureSpec) -> None:
+    """Draw one panel's marks and configure its axes.
+
+    Args:
+        fig: The figure owning *ax*, needed to attach a colour bar.
+        ax: The axes to draw on.
+        panel: The panel to draw.
+        spec: The chart being rendered, for its figure-wide chrome.
+
+    """
     for line in panel.lines:
         _draw_line(ax, line)
     for bar in panel.bars:
         _draw_bars(ax, bar)
+    for hist in panel.histograms:
+        _draw_histogram(ax, hist)
+    _draw_boxes(ax, panel.boxes)
     if panel.heatmap is not None:
         _draw_heatmap(fig, ax, panel.heatmap)
     for ref in panel.ref_lines:
@@ -365,17 +438,22 @@ def render_mpl(spec: FigureSpec) -> Figure:
     # default is global and third-party libraries flip it on import (quantstats
     # does), which would otherwise put a grid behind a matrix chart depending on
     # what else the caller happened to import.
-    if spec.chrome == "timeseries":
-        ax.grid(visible=True, color=_GRID_COLOR, linewidth=_GRID_WIDTH)
-    else:
+    if spec.chrome == "bare":
         ax.grid(visible=False)
+    elif spec.chrome == "panels":
+        # Horizontal rules help compare box heights across panels; vertical
+        # ones would only clutter what is a categorical axis.
+        ax.grid(visible=True, axis="y", color=_GRID_COLOR, linewidth=_GRID_WIDTH)
+    else:
+        ax.grid(visible=True, color=_GRID_COLOR, linewidth=_GRID_WIDTH)
+
+    if panel.title is not None:
+        ax.set_title(panel.title)
     _apply_axis(ax, panel.xaxis, vertical=False)
     _apply_axis(ax, panel.yaxis, vertical=True)
 
     # Colour carries the value on a matrix chart, so its series names would
     # label nothing; only series charts get a legend.
-    series_count = len(panel.lines) + len(panel.bars)
-    if series_count and spec.chrome == "timeseries":
+    series_count = len(panel.lines) + len(panel.bars) + len(panel.histograms)
+    if series_count and spec.chrome != "bare":
         ax.legend(loc="upper left", frameon=False, ncols=series_count)
-    fig.suptitle(spec.title)
-    return fig

--- a/src/jquantstats/_plots/_render/_plotly.py
+++ b/src/jquantstats/_plots/_render/_plotly.py
@@ -15,17 +15,21 @@ property the full-fidelity snapshot tests exist to pin.
 from __future__ import annotations
 
 import plotly.graph_objects as go
+from plotly.subplots import make_subplots
 
 from .._data._styling import _apply_base_layout, _apply_figsize
 from .._spec import (
     Axis,
     Band,
     BarSeries,
+    BoxSeries,
     ColorScale,
     FigureSpec,
     HeatmapGrid,
+    HistogramSeries,
     HoverSpec,
     LineSeries,
+    Panel,
     RefLine,
     TickFormat,
 )
@@ -65,8 +69,9 @@ def _hovertemplate(hover: HoverSpec) -> str:
 
     """
     header = "<b>%{x|%b %Y}</b><br>" if hover.date_header else ""
-    value = f"%{{y:{_D3_FORMATS[hover.value_format]}}}"
-    return f"{header}{hover.label}: {hover.prefix}{value}{hover.suffix}"
+    value = f"%{{{hover.axis}:{_D3_FORMATS[hover.value_format]}}}"
+    extra = "<extra></extra>" if hover.hide_extra else ""
+    return f"{header}{hover.label}: {hover.prefix}{value}{hover.suffix}{extra}"
 
 
 def _scatter(line: LineSeries) -> go.Scatter:
@@ -90,7 +95,13 @@ def _scatter(line: LineSeries) -> go.Scatter:
     if line.fill_color is not None:
         fill = {"fill": "tozeroy", "fillcolor": line.fill_color}
 
-    trace = go.Scatter(x=line.x, y=line.y, mode="lines", name=line.name, line=style, **fill)
+    grouping: dict[str, object] = {}
+    if line.legend_group is not None:
+        grouping["legendgroup"] = line.legend_group
+    if line.show_legend is not None:
+        grouping["showlegend"] = line.show_legend
+
+    trace = go.Scatter(x=line.x, y=line.y, mode="lines", name=line.name, line=style, **fill, **grouping)
     if line.hover is not None:
         trace.update(hovertemplate=_hovertemplate(line.hover))
     return trace
@@ -117,6 +128,49 @@ def _bar(bar: BarSeries) -> go.Bar:
     trace = go.Bar(x=bar.x, y=bar.y, name=bar.name, **styling)
     if bar.hover is not None:
         trace.update(hovertemplate=_hovertemplate(bar.hover))
+    return trace
+
+
+def _histogram(hist: HistogramSeries) -> go.Histogram:
+    """Convert one histogram series into a Plotly histogram trace.
+
+    Args:
+        hist: The series to bin and draw.
+
+    Returns:
+        go.Histogram: The trace.
+
+    """
+    binning: dict[str, object] = {} if hist.bins is None else {"nbinsx": hist.bins}
+    trace = go.Histogram(
+        x=hist.values,
+        name=hist.name,
+        marker_color=hist.color,
+        opacity=hist.opacity,
+        **binning,
+    )
+    if hist.hover is not None:
+        trace.update(hovertemplate=_hovertemplate(hist.hover))
+    return trace
+
+
+def _box(box: BoxSeries) -> go.Box:
+    """Convert one box-and-whisker series into a Plotly box trace.
+
+    Args:
+        box: The series to summarise.
+
+    Returns:
+        go.Box: The trace, showing outliers individually.
+
+    """
+    grouping: dict[str, object] = {"showlegend": box.show_legend}
+    if box.legend_group is not None:
+        grouping["legendgroup"] = box.legend_group
+
+    trace = go.Box(y=box.values, name=box.name, marker_color=box.color, boxpoints="outliers", **grouping)
+    if box.hover is not None:
+        trace.update(hovertemplate=_hovertemplate(box.hover))
     return trace
 
 
@@ -159,6 +213,12 @@ def _add_ref_line(fig: go.Figure, ref: RefLine) -> None:
     style: dict[str, object] = {"line_width": ref.width, "line_color": ref.color}
     if ref.dash is not None:
         style["line_dash"] = _DASHES[ref.dash]
+    if ref.label is not None:
+        style |= {
+            "annotation_text": ref.label,
+            "annotation_position": "top right",
+            "annotation_font_size": ref.label_size,
+        }
 
     if ref.orientation == "h":
         fig.add_hline(y=ref.value, **style)
@@ -225,39 +285,113 @@ def render_plotly(spec: FigureSpec) -> go.Figure:
     Returns:
         go.Figure: The rendered figure.
 
-    Raises:
-        ValueError: If *spec* does not contain exactly one panel.
+    """
+    fig = _blank_figure(spec)
+    for index, panel in enumerate(spec.panels, start=1):
+        # A single-panel figure has no subplot grid, so the traces carry no
+        # position; a side-by-side one places each panel in its own column.
+        at = {} if spec.arrangement == "single" else {"row": 1, "col": index}
+        _draw_panel(fig, panel, at)
+
+    _apply_layout(fig, spec)
+    _apply_axes(fig, spec)
+    return fig
+
+
+def _blank_figure(spec: FigureSpec) -> go.Figure:
+    """Create the figure a spec's panels will be drawn onto.
+
+    Args:
+        spec: The chart being rendered.
+
+    Returns:
+        go.Figure: An empty figure, with a subplot grid when the spec has one.
 
     """
-    (panel,) = spec.panels
+    if spec.arrangement == "single":
+        return go.Figure()
+    return make_subplots(
+        rows=1,
+        cols=len(spec.panels),
+        subplot_titles=[panel.title for panel in spec.panels],
+        shared_yaxes=spec.shared_y,
+    )
 
-    fig = go.Figure()
+
+def _draw_panel(fig: go.Figure, panel: Panel, at: dict[str, int]) -> None:
+    """Draw one panel's marks onto *fig*.
+
+    Args:
+        fig: The figure to draw on.
+        panel: The panel to draw.
+        at: Subplot position, empty for a single-panel figure.
+
+    """
     for line in panel.lines:
-        fig.add_trace(_scatter(line))
+        fig.add_trace(_scatter(line), **at)
     for bar in panel.bars:
-        fig.add_trace(_bar(bar))
+        fig.add_trace(_bar(bar), **at)
+    for hist in panel.histograms:
+        fig.add_trace(_histogram(hist), **at)
+    for box in panel.boxes:
+        fig.add_trace(_box(box), **at)
     if panel.heatmap is not None:
-        fig.add_trace(_heatmap(panel.heatmap))
+        fig.add_trace(_heatmap(panel.heatmap), **at)
     for ref in panel.ref_lines:
         _add_ref_line(fig, ref)
     for band in panel.bands:
         _add_band(fig, band)
 
+
+def _apply_layout(fig: go.Figure, spec: FigureSpec) -> None:
+    """Apply the figure-wide layout for *spec*'s chrome.
+
+    Args:
+        fig: The figure to lay out.
+        spec: The chart being rendered.
+
+    """
     if spec.chrome == "timeseries":
         _apply_base_layout(fig, spec.title, height=spec.height, with_range_selector=spec.date_range_selector)
+    elif spec.chrome == "panels":
+        # Small multiples: the legend names the categories repeated in every
+        # panel, so it sits a little clear of the subplot titles.
+        fig.update_layout(
+            title=spec.title,
+            height=spec.height,
+            plot_bgcolor="white",
+            legend={"orientation": "h", "yanchor": "bottom", "y": 1.05, "xanchor": "right", "x": 1},
+        )
+        # Horizontal rules help compare box heights across panels; vertical
+        # ones would only clutter what is a categorical axis.
+        fig.update_yaxes(showgrid=True, gridwidth=0.5, gridcolor="lightgrey")
+        fig.update_xaxes(showgrid=False)
     else:
         # A matrix chart: colour encodes the value, so a legend would name
         # nothing and a shared-x hover has nothing to align. Only the title,
         # height and background are set.
         fig.update_layout(title=spec.title, height=spec.height, plot_bgcolor="white")
+
     _apply_figsize(fig, spec.figsize)
     if spec.bar_mode is not None:
         fig.update_layout(barmode=spec.bar_mode)
 
+
+def _apply_axes(fig: go.Figure, spec: FigureSpec) -> None:
+    """Apply axis configuration across *spec*'s panels.
+
+    Panels of a side-by-side chart share their axis settings, so the first
+    panel's configuration is applied to all of them.
+
+    Args:
+        fig: The figure to configure.
+        spec: The chart being rendered.
+
+    """
+    panel = spec.panels[0]
     x_kwargs = _axis_kwargs(panel.xaxis)
     if x_kwargs:
         fig.update_xaxes(**x_kwargs)
     y_kwargs = _axis_kwargs(panel.yaxis, vertical=True)
     if y_kwargs:
         fig.update_yaxes(**y_kwargs)
-    return fig

--- a/src/jquantstats/_plots/_spec.py
+++ b/src/jquantstats/_plots/_spec.py
@@ -27,17 +27,21 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal, TypeAlias
 
+import numpy as np
 import polars as pl
 
 __all__ = [
+    "Arrangement",
     "Axis",
     "Band",
     "BarSeries",
+    "BoxSeries",
     "Chrome",
     "ColorScale",
     "Dash",
     "FigureSpec",
     "HeatmapGrid",
+    "HistogramSeries",
     "HoverSpec",
     "LineSeries",
     "Panel",
@@ -46,15 +50,15 @@ __all__ = [
     "Values",
 ]
 
-#: Plotted values: a polars Series, or a plain Python list.
+#: Plotted values: a polars Series, a numpy array, or a plain Python list.
 #:
-#: Both are accepted deliberately. Plotly serialises them differently — a Series
-#: becomes a compact binary buffer, a list a plain JSON array — and each chart's
+#: All three are accepted deliberately. Plotly serialises a Series or an array
+#: to a compact binary buffer and a list to a plain JSON array, and each chart's
 #: existing wire format is pinned by the fidelity snapshots. Builders therefore
 #: pass through whichever container the chart already used rather than
 #: normalising, so moving a chart onto this seam changes nothing. Renderers must
-#: accept either.
-Values: TypeAlias = "pl.Series | list[Any]"
+#: accept any of them.
+Values: TypeAlias = "pl.Series | np.ndarray[Any, Any] | list[Any]"
 
 #: How to render a number, named by intent rather than by any backend's syntax.
 #:
@@ -83,7 +87,17 @@ ColorScale = Literal["red_white_green"]
 #: ``bare`` is for matrix charts, where colour encodes the value rather than
 #: the series — a legend would name nothing and a shared-x hover has no
 #: meaning, so only the title, height and background are set.
-Chrome = Literal["timeseries", "bare"]
+#: ``panels`` is the small-multiples treatment: one panel per asset sharing a
+#: scale, with the legend naming the categories repeated in each panel rather
+#: than the panels themselves.
+Chrome = Literal["timeseries", "bare", "panels"]
+
+#: How a chart's panels are laid out.
+#:
+#: ``side_by_side`` places them in a row sharing the vertical scale, so the
+#: same measurement can be compared across assets. Stacked panels arrive with
+#: the dashboards.
+Arrangement = Literal["single", "side_by_side"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -101,6 +115,10 @@ class HoverSpec:
         suffix: Written immediately after the value, e.g. ``"x"`` to mark a
             growth multiple.
         date_header: Show the x-value as a bold ``Mon YYYY`` heading above.
+        axis: Which coordinate carries the value. Histograms bin along x, so
+            their tooltip reads the x-value; everything else reads y.
+        hide_extra: Suppress the trace-name box Plotly appends beside the
+            tooltip.
 
     """
 
@@ -109,6 +127,8 @@ class HoverSpec:
     prefix: str = ""
     suffix: str = ""
     date_header: bool = True
+    axis: Literal["x", "y"] = "y"
+    hide_extra: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -127,6 +147,12 @@ class LineSeries:
         fill_color: Shade the area between the line and zero in this colour,
             or None to leave the line unfilled. Used by the underwater curve.
         hover: Tooltip description, or None to leave the backend's default.
+        show_legend: Whether to give this series its own legend entry, or None
+            to say nothing and leave the backend's default. The fan charts
+            state it on every path — True for the first of a bundle, False for
+            the rest — so that hundreds of lines produce one entry.
+        legend_group: Name tying several series together, so toggling the
+            legend shows or hides them as one.
 
     """
 
@@ -140,6 +166,54 @@ class LineSeries:
     width: float = 2
     dash: Dash | None = None
     fill_color: str | None = None
+    hover: HoverSpec | None = None
+    show_legend: bool | None = None
+    legend_group: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class HistogramSeries:
+    """One set of binned values drawn as a histogram.
+
+    Attributes:
+        name: Legend entry for the series.
+        values: The observations to bin.
+        color: Bar colour.
+        bins: Requested bin count, or None for the backend's own choice.
+        opacity: Fill opacity. These charts overlay several series, so the
+            default is translucent.
+        hover: Tooltip description, or None to leave the backend's default.
+
+    """
+
+    name: str
+    values: Values
+    color: str
+    bins: int | None = None
+    opacity: float = 0.6
+    hover: HoverSpec | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BoxSeries:
+    """One box-and-whisker summary of a set of values.
+
+    Attributes:
+        name: Category label, shown on the axis and in the legend.
+        values: The observations to summarise.
+        color: Box colour.
+        show_legend: Give this series its own legend entry. With one panel per
+            asset the same categories repeat, so only the first panel does.
+        legend_group: Name tying the same category across panels together.
+        hover: Tooltip description, or None to leave the backend's default.
+
+    """
+
+    name: str
+    values: Values
+    color: str
+    show_legend: bool = True
+    legend_group: str | None = None
     hover: HoverSpec | None = None
 
 
@@ -178,6 +252,8 @@ class RefLine:
         color: Line colour.
         width: Stroke width.
         dash: Stroke pattern, or None to leave the backend's default.
+        label: Text naming the line, or None for no label.
+        label_size: Point size for that text.
 
     """
 
@@ -186,6 +262,8 @@ class RefLine:
     color: str = "gray"
     width: float = 1
     dash: Dash | None = None
+    label: str | None = None
+    label_size: int = 10
 
 
 @dataclass(frozen=True, slots=True)
@@ -280,6 +358,8 @@ class Panel:
     Attributes:
         lines: Line series to draw.
         bars: Bar series to draw.
+        histograms: Histogram series to draw.
+        boxes: Box-and-whisker series to draw.
         heatmap: A value matrix to draw, or None.
         ref_lines: Fixed-value marker lines.
         bands: Shaded vertical spans, drawn behind the series.
@@ -291,6 +371,8 @@ class Panel:
 
     lines: tuple[LineSeries, ...] = ()
     bars: tuple[BarSeries, ...] = ()
+    histograms: tuple[HistogramSeries, ...] = ()
+    boxes: tuple[BoxSeries, ...] = ()
     heatmap: HeatmapGrid | None = None
     ref_lines: tuple[RefLine, ...] = ()
     bands: tuple[Band, ...] = ()
@@ -313,6 +395,9 @@ class FigureSpec:
         date_range_selector: Offer the Plotly range-selector buttons. Ignored
             by matplotlib, which has no interactive widgets.
         chrome: How much surrounding furniture the chart carries.
+        arrangement: How the panels are laid out.
+        shared_y: Give side-by-side panels one vertical scale, so their
+            distributions are directly comparable.
         bar_mode: How bars from different series share an x position, or None
             for the backend's default.
 
@@ -324,4 +409,6 @@ class FigureSpec:
     figsize: tuple[int, int] | None = None
     date_range_selector: bool = True
     chrome: Chrome = "timeseries"
+    arrangement: Arrangement = "single"
+    shared_y: bool = False
     bar_mode: Literal["group", "overlay", "relative"] | None = None

--- a/src/jquantstats/_plots/_specs/__init__.py
+++ b/src/jquantstats/_plots/_specs/__init__.py
@@ -8,9 +8,13 @@ from ._cumulative import compare_spec as compare_spec
 from ._cumulative import cumulative_returns_spec as cumulative_returns_spec
 from ._cumulative import earnings_spec as earnings_spec
 from ._cumulative import log_returns_spec as log_returns_spec
+from ._distribution import distribution_spec as distribution_spec
+from ._distribution import histogram_spec as histogram_spec
 from ._drawdown import compute_drawdown_periods as compute_drawdown_periods
 from ._drawdown import drawdown_spec as drawdown_spec
 from ._drawdown import drawdowns_periods_spec as drawdowns_periods_spec
+from ._montecarlo import montecarlo_distribution_spec as montecarlo_distribution_spec
+from ._montecarlo import montecarlo_spec as montecarlo_spec
 from ._periodic import daily_returns_spec as daily_returns_spec
 from ._periodic import monthly_heatmap_spec as monthly_heatmap_spec
 from ._periodic import monthly_returns_spec as monthly_returns_spec
@@ -32,10 +36,14 @@ __all__ = [
     "compute_drawdown_periods",
     "cumulative_returns_spec",
     "daily_returns_spec",
+    "distribution_spec",
     "drawdown_spec",
     "drawdowns_periods_spec",
     "earnings_spec",
+    "histogram_spec",
     "log_returns_spec",
+    "montecarlo_distribution_spec",
+    "montecarlo_spec",
     "monthly_heatmap_spec",
     "monthly_returns_spec",
     "period_agg_exprs",

--- a/src/jquantstats/_plots/_specs/_distribution.py
+++ b/src/jquantstats/_plots/_specs/_distribution.py
@@ -1,0 +1,169 @@
+"""Spec builders for the return-distribution charts.
+
+`histogram_spec` overlays the whole return distribution of each series on one
+pair of axes. `distribution_spec` instead asks how the distribution *widens* as
+the holding period lengthens, which needs a panel per asset.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+from .._spec import Axis, BoxSeries, FigureSpec, HistogramSeries, HoverSpec, Panel
+from .._style import ticker_colors
+
+if TYPE_CHECKING:
+    from jquantstats._protocol import DataLike
+
+__all__ = ["distribution_spec", "histogram_spec"]
+
+# Overlaid distributions have to be seen through one another.
+_OVERLAY_OPACITY = 0.6
+
+# Holding periods, shortest first, so the widening reads left to right.
+# None means "no aggregation": the raw per-observation returns.
+_PERIODS: tuple[tuple[str, str | None], ...] = (
+    ("Daily", None),
+    ("Weekly", "1w"),
+    ("Monthly", "1mo"),
+    ("Quarterly", "3mo"),
+    ("Yearly", "1y"),
+)
+
+_PANEL_HEIGHT_PX = 500
+
+
+def _split_columns(frame: pl.DataFrame) -> tuple[str, list[str]]:
+    """Separate the date column from the value columns.
+
+    Args:
+        frame: A frame whose first column is the date axis.
+
+    Returns:
+        tuple[str, list[str]]: The date column name and every other column.
+
+    """
+    date_col = frame.columns[0]
+    return date_col, [c for c in frame.columns if c != date_col]
+
+
+def histogram_spec(data: DataLike, title: str, bins: int) -> FigureSpec:
+    """Describe the overlaid return-distribution histogram.
+
+    Args:
+        data: The dataset to plot.
+        title: Chart title.
+        bins: Number of histogram bins.
+
+    Returns:
+        FigureSpec: One translucent histogram per column, on shared axes.
+
+    """
+    df = data.all
+    _, tickers = _split_columns(df)
+    colors = ticker_colors(tickers)
+
+    panel = Panel(
+        histograms=tuple(
+            HistogramSeries(
+                name=ticker,
+                values=df[ticker].drop_nulls().to_list(),
+                color=colors[ticker],
+                bins=bins,
+                opacity=_OVERLAY_OPACITY,
+                hover=HoverSpec(
+                    label=ticker,
+                    value_format="percent2",
+                    date_header=False,
+                    axis="x",
+                    hide_extra=True,
+                ),
+            )
+            for ticker in tickers
+        ),
+        xaxis=Axis(title="Return", tick_format="percent1"),
+        yaxis=Axis(title="Count"),
+    )
+    # No range selector: the x-axis is return magnitude, not time.
+    return FigureSpec(title=title, panels=(panel,), date_range_selector=False, bar_mode="overlay")
+
+
+def _period_values(df: pl.DataFrame, date_col: str, ticker: str, trunc: str | None, compounded: bool) -> list[float]:
+    """Aggregate one ticker's returns into buckets of a given length.
+
+    Args:
+        df: The combined index/returns frame.
+        date_col: Name of the date column.
+        ticker: Column to aggregate.
+        trunc: Polars duration to bucket by, or None for no aggregation.
+        compounded: Compound returns within each bucket.
+
+    Returns:
+        list[float]: One value per bucket, nulls dropped.
+
+    """
+    if trunc is None:
+        return df[ticker].drop_nulls().to_list()
+
+    agg = ((1.0 + pl.col(ticker)).product() - 1.0) if compounded else pl.col(ticker).sum()
+    bucketed = (
+        df.with_columns(pl.col(date_col).dt.truncate(trunc).alias("_period")).group_by("_period").agg(agg.alias("ret"))
+    )
+    return bucketed["ret"].drop_nulls().to_list()
+
+
+def distribution_spec(data: DataLike, title: str, compounded: bool) -> FigureSpec:
+    """Describe the by-holding-period distribution chart.
+
+    One panel per asset, each holding a box per period, so the widening of the
+    distribution with holding length can be compared across assets.
+
+    Args:
+        data: The dataset to plot.
+        title: Chart title.
+        compounded: Compound returns within each period.
+
+    Returns:
+        FigureSpec: One side-by-side panel per asset, sharing a vertical scale.
+
+    """
+    df = data.all
+    date_col, tickers = _split_columns(df)
+    colors = ticker_colors(tickers)
+
+    panels = tuple(
+        Panel(
+            boxes=tuple(
+                BoxSeries(
+                    name=period_name,
+                    values=_period_values(df, date_col, ticker, trunc, compounded),
+                    color=colors[ticker],
+                    # The same periods repeat in every panel, so only the
+                    # first names them; the groups tie them together.
+                    show_legend=(index == 0),
+                    legend_group=period_name,
+                    hover=HoverSpec(
+                        label=period_name,
+                        value_format="percent2",
+                        date_header=False,
+                        hide_extra=True,
+                    ),
+                )
+                for period_name, trunc in _PERIODS
+            ),
+            title=ticker,
+            yaxis=Axis(tick_format="percent1"),
+        )
+        for index, ticker in enumerate(tickers)
+    )
+
+    return FigureSpec(
+        title=title,
+        panels=panels,
+        height=_PANEL_HEIGHT_PX,
+        chrome="panels",
+        arrangement="side_by_side",
+        shared_y=True,
+    )

--- a/src/jquantstats/_plots/_specs/_montecarlo.py
+++ b/src/jquantstats/_plots/_specs/_montecarlo.py
@@ -1,0 +1,271 @@
+"""Spec builders for the Monte Carlo charts.
+
+Both bootstrap from the trailing return history: `montecarlo_spec` draws the
+simulated paths themselves, `montecarlo_distribution_spec` reduces each path to
+one metric and shows where the observed value falls among them.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+
+from .._spec import Axis, FigureSpec, HistogramSeries, HoverSpec, LineSeries, Panel, RefLine
+from .._style import hex_to_rgba, ticker_colors
+
+if TYPE_CHECKING:
+    from jquantstats._protocol import DataLike
+
+__all__ = ["METRICS", "montecarlo_distribution_spec", "montecarlo_spec"]
+
+#: Metrics a simulated path can be reduced to, and how each is labelled.
+METRICS = {"sharpe": "Sharpe Ratio", "drawdown": "Max Drawdown", "cagr": "CAGR"}
+
+# Simulated paths are drawn very faintly: the point is the shape of the bundle,
+# not any individual path. The observed path is heavier so it stands clear.
+_SIM_ALPHA = 0.12
+_SIM_WIDTH = 1
+_OBSERVED_WIDTH = 2.5
+
+_OVERLAY_OPACITY = 0.6
+_PERIODS_PER_YEAR = 252.0
+
+# Fixed so a chart is reproducible: the same data always yields the same fan.
+_SEED = 42
+
+
+def _split_columns(frame: pl.DataFrame) -> tuple[str, list[str]]:
+    """Separate the date column from the value columns.
+
+    Args:
+        frame: A frame whose first column is the date axis.
+
+    Returns:
+        tuple[str, list[str]]: The date column name and every other column.
+
+    """
+    date_col = frame.columns[0]
+    return date_col, [c for c in frame.columns if c != date_col]
+
+
+def _require_positive(n: int, period: int) -> None:
+    """Reject non-positive simulation counts or path lengths.
+
+    Args:
+        n: Number of simulations.
+        period: Observations per simulation.
+
+    Raises:
+        ValueError: If either is not positive.
+
+    """
+    if n <= 0:
+        raise ValueError("n must be a positive integer")  # noqa: TRY003
+    if period <= 0:
+        raise ValueError("period must be a positive integer")  # noqa: TRY003
+
+
+def montecarlo_spec(
+    data: DataLike,
+    n: int,
+    period: int,
+    title: str,
+    figsize: tuple[int, int] | None,
+) -> FigureSpec:
+    """Describe the Monte Carlo fan chart.
+
+    Args:
+        data: The dataset to plot.
+        n: Number of simulated paths per asset.
+        period: Observations per path.
+        title: Chart title.
+        figsize: Optional ``(width, height)`` in pixels.
+
+    Returns:
+        FigureSpec: *n* faint simulated paths per asset, with the observed
+        path drawn over them.
+
+    Raises:
+        ValueError: If *n* or *period* is not positive.
+
+    """
+    _require_positive(n, period)
+
+    df = data.all
+    date_col, tickers = _split_columns(df)
+    colors = ticker_colors(tickers)
+
+    sample_len = min(period, df.height)
+    dates = df[date_col].tail(sample_len).to_list()
+    rng = np.random.default_rng(seed=_SEED)
+
+    lines = []
+    for ticker in tickers:
+        trailing = (
+            df[ticker].tail(sample_len - 1).fill_null(0.0).cast(pl.Float64).to_numpy()
+            if sample_len > 1
+            else np.array([], dtype=np.float64)
+        )
+
+        for i in range(n):
+            draws = (
+                rng.choice(trailing, size=sample_len - 1, replace=True)
+                if sample_len > 1
+                else np.array([], dtype=np.float64)
+            )
+            lines.append(
+                LineSeries(
+                    name=f"{ticker} Sim",
+                    x=dates,
+                    y=np.cumprod(np.concatenate(([1.0], 1.0 + draws))),
+                    color=hex_to_rgba(colors[ticker], alpha=_SIM_ALPHA),
+                    width=_SIM_WIDTH,
+                    # One legend entry for the whole bundle, not n of them.
+                    legend_group=f"{ticker}_sim",
+                    show_legend=(i == 0),
+                    hover=HoverSpec(
+                        label=f"{ticker} Sim",
+                        value_format="float2",
+                        suffix="x",
+                        date_header=False,
+                        hide_extra=True,
+                    ),
+                )
+            )
+
+        lines.append(
+            LineSeries(
+                name=f"{ticker} Observed",
+                x=dates,
+                y=np.cumprod(np.concatenate(([1.0], 1.0 + trailing))),
+                color=colors[ticker],
+                width=_OBSERVED_WIDTH,
+                legend_group=f"{ticker}_obs",
+                hover=HoverSpec(
+                    label=f"{ticker} Observed",
+                    value_format="float2",
+                    suffix="x",
+                    date_header=False,
+                    hide_extra=True,
+                ),
+            )
+        )
+
+    panel = Panel(lines=tuple(lines), yaxis=Axis(title="Cumulative Return", tick_format="float2"))
+    return FigureSpec(title=title, panels=(panel,), figsize=figsize)
+
+
+def _metric_value(returns: np.ndarray, metric_key: str) -> float:
+    """Reduce one simulated return path to a single number.
+
+    Args:
+        returns: The path's per-period returns.
+        metric_key: One of ``"sharpe"``, ``"drawdown"`` or ``"cagr"``.
+
+    Returns:
+        float: The metric's value for this path.
+
+    """
+    if metric_key == "sharpe":
+        std = returns.std(ddof=1)
+        return float(math.sqrt(_PERIODS_PER_YEAR) * returns.mean() / std) if std > 0 else 0.0
+    if metric_key == "drawdown":
+        path = np.cumprod(1.0 + returns)
+        hwm = np.maximum.accumulate(path)
+        dd = (path - hwm) / hwm
+        return float(dd.min()) if dd.size else 0.0
+    total_return = float(np.prod(1.0 + returns))
+    return float(total_return ** (_PERIODS_PER_YEAR / len(returns)) - 1.0) if len(returns) > 0 else 0.0
+
+
+def montecarlo_distribution_spec(
+    data: DataLike,
+    n: int,
+    period: int,
+    metric: str,
+    title: str,
+    figsize: tuple[int, int] | None,
+) -> FigureSpec:
+    """Describe the distribution of a metric across simulated paths.
+
+    Args:
+        data: The dataset to plot.
+        n: Number of simulations per asset.
+        period: Observations per simulation.
+        metric: One of ``"sharpe"``, ``"drawdown"`` or ``"cagr"``.
+        title: Chart title.
+        figsize: Optional ``(width, height)`` in pixels.
+
+    Returns:
+        FigureSpec: One histogram per asset, each with a marker at the
+        observed value.
+
+    Raises:
+        ValueError: If *n* or *period* is not positive, or *metric* is not one
+            of the supported names.
+
+    """
+    _require_positive(n, period)
+
+    metric_key = metric.strip().lower()
+    if metric_key not in METRICS:
+        raise ValueError("metric must be one of: sharpe, drawdown, cagr")  # noqa: TRY003
+
+    df = data.all
+    _, tickers = _split_columns(df)
+    colors = ticker_colors(tickers)
+    sample_len = min(period, df.height)
+    rng = np.random.default_rng(seed=_SEED)
+
+    histograms = []
+    ref_lines = []
+    for ticker in tickers:
+        history = df[ticker].tail(sample_len).fill_null(0.0).cast(pl.Float64).to_numpy()
+        if history.size == 0:  # pragma: no cover - a frame with no rows cannot reach a plot method
+            continue
+
+        histograms.append(
+            HistogramSeries(
+                name=ticker,
+                values=[
+                    _metric_value(rng.choice(history, size=sample_len, replace=True), metric_key) for _ in range(n)
+                ],
+                color=colors[ticker],
+                opacity=_OVERLAY_OPACITY,
+                hover=HoverSpec(
+                    label=ticker,
+                    value_format="float4",
+                    date_header=False,
+                    axis="x",
+                    hide_extra=True,
+                ),
+            )
+        )
+        ref_lines.append(
+            RefLine(
+                value=_metric_value(history, metric_key),
+                orientation="v",
+                color=colors[ticker],
+                width=2,
+                dash="dash",
+                label=f"{ticker} observed",
+            )
+        )
+
+    panel = Panel(
+        histograms=tuple(histograms),
+        ref_lines=tuple(ref_lines),
+        xaxis=Axis(title=METRICS[metric_key]),
+        yaxis=Axis(title="Count"),
+    )
+    # No range selector: the x-axis is the metric's value, not time.
+    return FigureSpec(
+        title=title,
+        panels=(panel,),
+        figsize=figsize,
+        date_range_selector=False,
+        bar_mode="overlay",
+    )

--- a/tests/test_jquantstats/test__plots/test_mpl_backend.py
+++ b/tests/test_jquantstats/test__plots/test_mpl_backend.py
@@ -465,6 +465,107 @@ def test_rolling_beta_requires_a_benchmark_on_both_backends(data_no_benchmark) -
             data_no_benchmark.plots.rolling_beta(backend=backend)
 
 
+def test_histogram_backends_bin_the_same_values(data) -> None:
+    """Both backends receive the same observations to bin.
+
+    Bin *edges* are each backend's own business — Plotly's `nbinsx` is a hint
+    and matplotlib's `bins` is exact — so the counts are what is compared.
+    """
+    plotly_fig = data.plots.histogram(bins=20, backend="plotly")
+    mpl_fig = data.plots.histogram(bins=20, backend="matplotlib")
+
+    assert len(mpl_fig.axes[0].containers) == len(plotly_fig.data)
+    for trace, container in zip(plotly_fig.data, mpl_fig.axes[0].containers, strict=True):
+        assert sum(patch.get_height() for patch in container) == pytest.approx(len(trace.x))
+
+
+def test_distribution_puts_one_panel_per_asset(data) -> None:
+    """The by-period chart is small multiples, one panel per asset."""
+    plotly_fig = data.plots.distribution(backend="plotly")
+    mpl_fig = data.plots.distribution(backend="matplotlib")
+
+    assert len(mpl_fig.axes) == len(data.assets)
+    assert [ax.get_title() for ax in mpl_fig.axes] == data.assets
+    assert [a.text for a in plotly_fig.layout.annotations] == data.assets
+
+
+def test_distribution_boxes_summarise_the_same_periods(data) -> None:
+    """Each panel holds one box per holding period, in the same order."""
+    periods = ["Daily", "Weekly", "Monthly", "Quarterly", "Yearly"]
+    mpl_fig = data.plots.distribution(backend="matplotlib")
+
+    for ax in mpl_fig.axes:
+        assert [t.get_text() for t in ax.get_xticklabels()] == periods
+
+
+def test_distribution_panels_share_a_vertical_scale(data) -> None:
+    """Sharing the y-axis is what makes the panels comparable."""
+    axes = data.plots.distribution(backend="matplotlib").axes
+    first = axes[0].get_ylim()
+    assert all(ax.get_ylim() == first for ax in axes[1:])
+
+
+def test_montecarlo_backends_draw_the_same_paths(data) -> None:
+    """The fan and the observed path match across backends.
+
+    The simulation is seeded, so the same data yields the same bundle every
+    time and the two backends can be compared point for point.
+    """
+    plotly_fig = data.plots.montecarlo(n=4, period=30, backend="plotly")
+    mpl_fig = data.plots.montecarlo(n=4, period=30, backend="matplotlib")
+
+    lines = mpl_fig.axes[0].get_lines()
+    assert len(lines) == len(plotly_fig.data)
+    for trace, line in zip(plotly_fig.data, lines, strict=True):
+        assert _floats(trace.y) == pytest.approx(_floats(line.get_ydata()), nan_ok=True)
+
+
+def test_montecarlo_names_each_bundle_once(data) -> None:
+    """Hundreds of paths must not become hundreds of legend entries."""
+    plotly_fig = data.plots.montecarlo(n=6, period=30, backend="plotly")
+    shown = [trace for trace in plotly_fig.data if trace.showlegend is not False]
+    # One "Sim" entry and one "Observed" entry per asset.
+    assert len(shown) == 2 * len(data.assets)
+
+
+def test_montecarlo_distribution_marks_the_observed_value(data) -> None:
+    """The observed metric is marked against the simulated distribution."""
+    plotly_fig = data.plots.montecarlo_distribution(n=40, period=30, backend="plotly")
+    mpl_fig = data.plots.montecarlo_distribution(n=40, period=30, backend="matplotlib")
+
+    plotly_labels = [a.text for a in plotly_fig.layout.annotations]
+    mpl_labels = [t.get_text() for t in mpl_fig.axes[0].texts]
+    assert plotly_labels == mpl_labels
+    assert all(label.endswith(" observed") for label in mpl_labels)
+
+
+@pytest.mark.parametrize("metric", ["sharpe", "drawdown", "cagr"])
+def test_montecarlo_distribution_supports_every_metric(data, metric: str) -> None:
+    """Each metric renders on both backends and labels its own axis."""
+    titles = {"sharpe": "Sharpe Ratio", "drawdown": "Max Drawdown", "cagr": "CAGR"}
+    plotly_fig = data.plots.montecarlo_distribution(n=20, period=30, metric=metric, backend="plotly")
+    mpl_fig = data.plots.montecarlo_distribution(n=20, period=30, metric=metric, backend="matplotlib")
+
+    assert plotly_fig.layout.xaxis.title.text == titles[metric]
+    assert mpl_fig.axes[0].get_xlabel() == titles[metric]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"n": 0}, "n must be a positive integer"),
+        ({"period": 0}, "period must be a positive integer"),
+        ({"metric": "not-a-metric"}, "metric must be one of"),
+    ],
+    ids=["n", "period", "metric"],
+)
+def test_montecarlo_validation_is_backend_independent(data, kwargs: dict, message: str) -> None:
+    """Validation sits in the builder, so both backends reject alike."""
+    for backend in ("plotly", "matplotlib"):
+        with pytest.raises(ValueError, match=message):
+            data.plots.montecarlo_distribution(**kwargs, backend=backend)
+
+
 def test_drawdown_backends_plot_the_same_curves(data) -> None:
     """The underwater curve matches, reference line excluded.
 
@@ -623,11 +724,15 @@ def test_lineless_spec_draws_no_legend() -> None:
     assert fig.axes[0].get_legend() is None
 
 
-def test_render_rejects_multi_panel_specs() -> None:
-    """Multi-panel rendering arrives with the dashboards, not before."""
+def test_multi_panel_specs_render_side_by_side() -> None:
+    """Panels are laid out in a row, one Axes each.
+
+    This replaces an earlier assertion that multi-panel specs were rejected;
+    the by-period distribution chart is the first that needs them.
+    """
     panel = Panel(lines=(_line(),))
-    with pytest.raises(ValueError, match="too many values"):
-        render_mpl(FigureSpec(title="T", panels=(panel, panel)))
+    fig = render_mpl(FigureSpec(title="T", panels=(panel, panel), arrangement="side_by_side"))
+    assert len(fig.axes) == 2
 
 
 def test_hover_is_dropped_rather_than_emulated(data) -> None:

--- a/tests/test_jquantstats/test__plots/test_no_pyplot.py
+++ b/tests/test_jquantstats/test__plots/test_no_pyplot.py
@@ -126,6 +126,9 @@ def test_rendering_does_not_import_pyplot() -> None:
     The import-time check above would still pass if the renderer imported
     pyplot lazily inside its drawing code, which is precisely where a
     ``plt.subplots()`` would end up.
+
+    One matplotlib-internal exception exists — see
+    `test_box_charts_may_import_pyplot_but_never_register_a_figure`.
     """
     script = (
         "import sys, datetime as dt, polars as pl\n"
@@ -143,3 +146,32 @@ def test_rendering_does_not_import_pyplot() -> None:
         check=True,
     )
     assert result.stdout.strip() == "False", "rendering a matplotlib figure pulled in pyplot"
+
+
+def test_box_charts_may_import_pyplot_but_never_register_a_figure() -> None:
+    """Box drawing pulls pyplot in from inside matplotlib, harmlessly.
+
+    ``Axes.bxp`` reads ``rcParams.items()``, and ``RcParams.__getitem__``
+    imports pyplot to resolve the lazily-chosen backend name
+    (``matplotlib/__init__.py``). So rendering `distribution` on the matplotlib
+    backend leaves ``matplotlib.pyplot`` in ``sys.modules`` even though this
+    package never imports it.
+
+    That is backend *name resolution*, not figure management, and it is the
+    latter that issue #628 is about. What must still hold — and what this
+    pins — is that no figure is registered in pyplot's global manager, so
+    nothing accumulates. Recorded as a known exception so nobody later
+    "fixes" the import away by reaching for ``plt``.
+    """
+    script = (
+        "import sys, datetime as dt, polars as pl\n"
+        "from jquantstats import Data\n"
+        "d0 = dt.date(2021, 1, 1)\n"
+        "r = pl.DataFrame({'date': [d0 + dt.timedelta(days=i) for i in range(40)],\n"
+        "                  'A': [0.01, -0.02, 0.03, -0.004] * 10})\n"
+        "Data.from_returns(returns=r).plots.distribution(backend='matplotlib')\n"
+        "import matplotlib.pyplot as plt\n"
+        "print(plt.get_fignums())\n"
+    )
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, check=True)
+    assert result.stdout.strip() == "[]", "a box chart registered a figure with pyplot"

--- a/tests/test_jquantstats/test__plots/test_spec_render.py
+++ b/tests/test_jquantstats/test__plots/test_spec_render.py
@@ -21,8 +21,10 @@ from jquantstats._plots._spec import (
     Axis,
     Band,
     BarSeries,
+    BoxSeries,
     FigureSpec,
     HeatmapGrid,
+    HistogramSeries,
     HoverSpec,
     LineSeries,
     Panel,
@@ -165,11 +167,16 @@ def test_opposite_side_resolves_per_axis() -> None:
 # ── renderer ─────────────────────────────────────────────────────────────────
 
 
-def test_render_rejects_multi_panel_specs() -> None:
-    """Multi-panel rendering arrives with the dashboards, not before."""
+def test_multi_panel_specs_render_side_by_side() -> None:
+    """Panels are laid out in a row, one Axes each.
+
+    This replaces an earlier assertion that multi-panel specs were rejected;
+    the by-period distribution chart is the first that needs them.
+    """
     panel = Panel(lines=(_line(),))
-    with pytest.raises(ValueError, match="too many values"):
-        render_plotly(FigureSpec(title="T", panels=(panel, panel)))
+    fig = render_plotly(FigureSpec(title="T", panels=(panel, panel), arrangement="side_by_side"))
+    layout = json.loads(fig.to_json())["layout"]
+    assert {"xaxis", "xaxis2"} <= set(layout), "expected one x-axis per panel"
 
 
 def test_unset_dash_omits_the_property() -> None:
@@ -211,6 +218,27 @@ def test_bar_without_hover_emits_no_hovertemplate() -> None:
     )
     fig = render_plotly(_spec(Panel(bars=(bar,))))
     assert "hovertemplate" not in json.loads(fig.to_json())["data"][0]
+
+
+def test_histogram_without_hover_emits_no_hovertemplate() -> None:
+    """Histograms may opt out of a tooltip too."""
+    hist = HistogramSeries(name="A", values=[0.1, 0.2], color="#636efa")
+    fig = render_plotly(_spec(Panel(histograms=(hist,))))
+    assert "hovertemplate" not in json.loads(fig.to_json())["data"][0]
+
+
+def test_histogram_without_bins_leaves_the_count_to_the_backend() -> None:
+    """A histogram may decline to fix its bin count."""
+    hist = HistogramSeries(name="A", values=[0.1, 0.2], color="#636efa")
+    assert "nbinsx" not in json.loads(render_plotly(_spec(Panel(histograms=(hist,)))).to_json())["data"][0]
+
+
+def test_box_without_hover_or_group_emits_neither() -> None:
+    """A box may stand alone, with no tooltip and no legend grouping."""
+    box = BoxSeries(name="Daily", values=[0.1, -0.2, 0.3], color="#636efa")
+    payload = json.loads(render_plotly(_spec(Panel(boxes=(box,)))).to_json())["data"][0]
+    assert "hovertemplate" not in payload
+    assert "legendgroup" not in payload
 
 
 def test_heatmap_without_hover_label_emits_no_hovertemplate() -> None:


### PR DESCRIPTION
Seventh of the #628 series. `histogram`, `distribution`, `montecarlo` and
`montecarlo_distribution` now render on either backend. **Plotly output is unchanged.**

> **Stacked on #947** → #946 → #945 → #944 → #943 → #940.

Progress: **21 of 29** charts migrated.

## Three additions to the IR

- **`HistogramSeries` and `BoxSeries`** — the last two mark types.
- **`HoverSpec.axis` / `.hide_extra`** — histograms bin along x, so their tooltip reads
  the x-value, and these charts suppress Plotly's trailing trace-name box.
- **Multi-panel layout.** `distribution` puts one panel per asset in a row sharing the
  vertical scale — which is exactly what makes the widening of the distribution
  comparable across assets. Both renderers lost their single-panel assumption.
  `Arrangement` has `"single"` and `"side_by_side"` today; stacking arrives with the
  dashboards.

`FigureSpec.chrome` gained a third value, `"panels"` — the small-multiples treatment
sits the legend clear of the subplot titles and rules only the horizontal axis, the
other being categorical.

## The "unset vs default" pattern, a fourth time

`LineSeries.show_legend` became optional for the same reason `dash` did in #947. The fan
chart states `showlegend` on **every** simulated path — `True` for the first of a bundle,
`False` for the rest — while other charts omit it entirely, and Plotly records the
difference.

That is now four fields widened for this reason (`color`, `height`, `dash`,
`show_legend`). It's a reliable signal rather than a surprise at this point.

`Values` also gained numpy arrays: the fan chart hands Plotly the output of `np.cumprod`
directly, which serialises like a Series rather than like a list.

## A genuine wrinkle in the no-pyplot story

`Axes.bxp` reads `rcParams.items()`, and `RcParams.__getitem__` **imports pyplot** to
resolve the lazily-chosen backend name. So rendering `distribution` on matplotlib leaves
pyplot in `sys.modules` even though this package never imports it.

That is backend *name resolution*, not figure management — I traced it to
`matplotlib/__init__.py` to be sure. No figure is registered and nothing accumulates,
which is what #628 is actually about. A new test pins exactly that, and records the
exception explicitly so nobody later "fixes" the import away by reaching for `plt`.

## Two gates caught things I had wrong

- **`ty`** rejected `**binning` unpacking into `Axes.hist` — the same class of error as
  `**_GRID` in #945: unpacking a dict makes every keyword look reachable. Passing `bins=`
  directly is both correct and simpler, since matplotlib already treats `None` as "use
  the default count".
- **`mypy`** caught the numpy return type above.

## Verification

`make all` green: **fmt, deps, test, docs-coverage, security, license, typecheck
(mypy --strict *and* ty), rhiza-test**.

- 1,638 passed, 5 skipped (kaleido, no local Chrome)
- **100% line + branch coverage**, 0 `noqa` added
- **67 snapshots passed without regeneration**
- `_data/_distribution.py` 43 → 11 stmts, `_data/_montecarlo.py` 75 → 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)