### PR TITLE
Correct the plotting comparisons now that both backends ship (#628)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ it significantly — particularly around position-level analysis that is impossi
 start from a return series alone. Key improvements include:
 
 - Polars-native design with zero pandas runtime dependency
-- Modern interactive visualizations using Plotly
+- Modern interactive visualizations using Plotly, or static ones using matplotlib
 - A **Portfolio route** — the primary entry point — that exposes tools unavailable in QuantStats
 - Comprehensive test coverage with pytest
 - Clean, fully type-annotated API
@@ -170,7 +170,7 @@ pf_smooth = pf.smoothed_holding(n=5)
 | Feature | jQuantStats | QuantStats |
 |---|---|---|
 | **DataFrame engine** | [Polars](https://pola.rs/) (zero pandas at runtime) | pandas |
-| **Visualisation** | Interactive [Plotly](https://plotly.com/python/) charts | Static matplotlib / seaborn |
+| **Visualisation** | [Plotly](https://plotly.com/python/) *or* [matplotlib](https://matplotlib.org/), both rendered natively | matplotlib / seaborn, with a `to_plotly()` converter |
 | **Input format** | `polars.DataFrame` | `pandas.Series` / `pandas.DataFrame` |
 | **Entry point — positions** | `Portfolio.from_cash_position(prices, cash_position, aum)` | — |
 | **Entry point — returns** | `Data.from_returns(returns, benchmark)` | `qs.reports.full(returns)` |
@@ -374,8 +374,10 @@ with configurable windows.
 - Position smoothing via `smoothed_holding(n)`
 - Risk-position entry via `from_risk_position()` with EWMA de-volatization
 
-**Interactive Visualizations** — all charts are Plotly (zoom, pan, hover tooltips,
-range selectors). Includes portfolio snapshot, lead/lag IR, correlation heatmap,
+**Visualizations, two ways** — every chart renders as an interactive Plotly figure
+(zoom, pan, hover tooltips, range selectors) or, with `pip install jquantstats[mpl]`
+and `set_plot_backend("matplotlib")`, as a static matplotlib one. Both draw from the
+same numbers. Includes portfolio snapshot, lead/lag IR, correlation heatmap,
 drawdown, rolling returns, rolling volatility, return distribution, monthly heatmap.
 
 **HTML Reports** — self-contained reports with embedded interactive charts and
@@ -388,6 +390,9 @@ categorized metric tables, rendered via Jinja2 templates.
 - polars
 - plotly
 - scipy
+
+Optional extras: `mpl` (matplotlib rendering backend), `plot` (static image
+export via kaleido), `web` (FastAPI service).
 
 ## Documentation
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -30,7 +30,7 @@ your existing workflows over.
 | | QuantStats | jquantstats |
 |---|---|---|
 | DataFrame engine | pandas | Polars (zero pandas at runtime) |
-| Charts | static matplotlib/seaborn | interactive Plotly |
+| Charts | matplotlib/seaborn | Plotly by default, matplotlib on request |
 | Type annotations | partial | full (PEP 484, `py.typed`) |
 | Multi-asset | single `pd.Series` per call | multi-column DataFrame, one call |
 | API style | functions (`qs.stats.sharpe(r)`) | object methods (`data.stats.sharpe()`) |

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -27,6 +27,9 @@ are covered by the stability guarantee described below.
 | `Plots` | class | `jquantstats._plots` |
 | `NativeFrame` | type alias | `jquantstats._types` |
 | `NativeFrameOrScalar` | type alias | `jquantstats._types` |
+| `set_plot_backend` | function | `jquantstats._plots._backend` |
+| `get_plot_backend` | function | `jquantstats._plots._backend` |
+| `plot_backend` | context manager | `jquantstats._plots._backend` |
 
 All of the above are importable directly from `jquantstats`:
 
@@ -110,10 +113,28 @@ was settled in 0.11: before then `Data.from_returns` defaulted to `Date` while
 thing to write against.  An index nominated with `date_col=` that is *not*
 temporal — an integer row index, say — keeps its own name.
 
+**The plotting backend.**  `"plotly"` is the default and changing that default
+would be a breaking change, held for 1.0.  Two consequences follow from the
+selection being global, and neither will change before then:
+
+- The *type* of a figure now depends on the backend in effect.  A plot method
+  returns a `plotly.graph_objects.Figure` or a `matplotlib.figure.Figure`.
+  Methods are overloaded on the literal `backend` argument, so a call that
+  passes none is still typed as returning Plotly's — which is a lie once
+  `set_plot_backend` has been called.  Pass `backend=` explicitly if you change
+  the global default and care about static types.
+- The interactive affordances — hover tooltips, the date range-selector
+  buttons, legend click-to-toggle — have no matplotlib equivalent and will not
+  gain one.  They are absent from matplotlib figures by design, not by
+  omission.
+
+HTML reports render Plotly whatever the selected backend, and that is a
+guarantee rather than an implementation detail: they embed Plotly JSON.
+
 **What may still move.**  Individual metric methods on `Stats` may gain
 keyword arguments, change default values, or be renamed for consistency as
 the QuantStats-parity work settles; chart signatures on `Plots` may change
-as the Plotly builders are refactored.  Anything private — see
+as the chart builders are refactored.  Anything private — see
 [What is *not* stable](#what-is-not-stable) — may change in any release,
 including the internal module layout, which has been reorganised more than
 once during 0.x.

--- a/docs/difference.md
+++ b/docs/difference.md
@@ -21,7 +21,7 @@ diverged considerably. This document explains where they differ, what
 | Dimension | jquantstats | QuantStats |
 |---|---|---|
 | DataFrame engine | Polars-native (narwhals abstraction; no pandas at runtime) | pandas |
-| Plotting | Plotly-native (interactive HTML) | Matplotlib (static); optional `plotly` extra *converts* figures |
+| Plotting | Plotly *and* matplotlib, both rendered natively | Matplotlib; the optional `plotly` extra *converts* finished figures |
 | Primary input | **Prices + positions** *or* returns | Returns series only |
 | Position-level analytics | Yes (turnover, costs, attribution, lag) | No |
 | Market-data fetching | Not built in (bring your own data) | Built in via `yfinance` |
@@ -143,15 +143,23 @@ distinct from IEEE-754 `NaN`, and null-handling is explicit:
 `null_strategy={"raise","drop","forward_fill"}`). QuantStats is pandas through
 and through.
 
-### Interactive vs. static plots
-`jquantstats` renders **Plotly** figures natively — zoomable, hoverable, and
-embeddable as self-contained interactive HTML (`portfolio.report.to_html()`).
-QuantStats' core plotting is **Matplotlib** (with `seaborn` as a dependency),
-producing static images that are simpler and lighter but not interactive.
-Recent QuantStats versions add an optional `plotly` extra, but it is a
-`to_plotly(fig)` *converter* that wraps existing Matplotlib figures rather than
-a native interactive charting layer — so the experience is still
-Matplotlib-first.
+### Two native backends vs. one plus a converter
+Both libraries can give you a Plotly figure and a Matplotlib one. The
+difference is how.
+
+`jquantstats` describes each chart once, in a backend-agnostic form, and has two
+renderers turn that description into a figure. Neither backend wraps the other,
+and both draw from the same numbers — so `data.plots.drawdown()` and
+`data.plots.drawdown(backend="matplotlib")` plot identical series. Plotly is the
+default, giving zoomable, hoverable charts that embed as self-contained
+interactive HTML (`portfolio.report.to_html()`); matplotlib is an optional extra
+(`pip install jquantstats[mpl]`) that produces static figures far more cheaply
+when a script builds many charts at once.
+
+QuantStats' core plotting is **Matplotlib** (with `seaborn` as a dependency).
+Its optional `plotly` extra is a `to_plotly(fig)` *converter* that re-wraps a
+finished Matplotlib figure, so interactivity is bolted on rather than rendered
+— the experience is still Matplotlib-first.
 
 ### API design
 QuantStats favours `extend_pandas()` monkey-patching, which is discoverable but
@@ -202,8 +210,9 @@ advantages:
 - You have **positions and prices**, and want to analyse *how* the strategy
   traded — turnover, costs, execution delay, tilt/timing attribution.
 - You want **net-of-cost** realism and cost-sensitivity sweeps.
-- You prefer **interactive Plotly** reports and a **Polars-native**, strictly
-  typed, heavily tested codebase.
+- You want **interactive Plotly** reports, or **static matplotlib** figures
+  from the same call, on a **Polars-native**, strictly typed, heavily tested
+  codebase.
 - You're building on modern Python (3.11+) and want explicit objects over
   pandas monkey-patching.
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -27,14 +27,14 @@ neither ships a compiled extension).
 | Paradigm | OO: frozen dataclasses, mixins, protocols | Procedural: module-level functions |
 | Public API | Explicit `Portfolio`/`Data` objects + accessors | Free functions + `extend_pandas()` monkey-patch |
 | State model | Immutable (frozen, slotted) + memoised | Stateless functions over mutable frames |
-| Source size | ~10.6k LOC across ~34 files | ~12.3k LOC across ~12 files |
-| Largest module | 1.4k LOC (`_plots/_data.py`) | 3.3k LOC (`stats.py`) |
+| Source size | ~16.0k LOC across ~77 files | ~12.3k LOC across ~12 files |
+| Largest module | 583 LOC (`portfolio.py`) | 3.3k LOC (`stats.py`) |
 | Runtime deps | 6 (no pandas) | 8 (incl. pandas, matplotlib, yfinance) |
 | Type coverage | Full annotations, strict (`ty`), `py.typed` | Partial (~50% in `stats.py`), `py.typed` |
 | Docstring coverage | 100% enforced (`interrogate`) | Good, not gated |
 | Tests shipped | 15k LOC test suite in repo | Not shipped in wheel |
 | Quality gates | 100% line+branch cov, mutation, property, snapshot | Lighter (pytest + coverage, no enforced gate) |
-| Plotting engine | Plotly-native | Matplotlib core + optional `to_plotly()` converter |
+| Plotting engine | Plotly and matplotlib, both native | Matplotlib core + optional `to_plotly()` converter |
 | Python | 3.11+ | 3.10+ |
 
 ---
@@ -99,7 +99,7 @@ src/jquantstats/
 │   └── _portfolio_cost.py         (cost models)
 ├── data.py                 Data (returns route)
 ├── _stats/   (5 mixins: _basic, _performance, _reporting, _rolling, _montecarlo)
-├── _plots/   (Plotly figures, protocol-segregated)
+├── _plots/   (backend-agnostic specs + Plotly/matplotlib renderers)
 ├── _reports/ (Jinja2 HTML)
 ├── _utils/, _cache.py, exceptions.py, result.py
 └── *_protocol.py  (interface-segregation protocols)
@@ -220,8 +220,10 @@ runs, a Makefile) reflecting a heavier engineering process.
 ## 6. Dependency footprint
 
 **jquantstats runtime (6):** `jinja2`, `narwhals`, `numpy`, `plotly`, `polars`,
-`scipy`. No pandas. Data fetching and web/static-export deps are *optional*
-extras (`web`, `plot`).
+`scipy`. No pandas — and no matplotlib, which is an *optional* extra rather than
+a runtime dependency, so the second plotting backend costs nothing unless you
+ask for it. The remaining optional extras are `mpl` (matplotlib), `plot`
+(static image export via kaleido) and `web` (the FastAPI service).
 
 **QuantStats runtime (8):** `matplotlib`, `numpy`, `pandas`, `python-dateutil`,
 `scipy`, `seaborn`, `tabulate`, `yfinance`. The base install therefore pulls in
@@ -242,10 +244,15 @@ opinionated dependency graph.
   *converter* (behind the `plotly` extra) that re-wraps Matplotlib figures — so
   interactivity is bolted on, not native. Reports are assembled in `reports.py`.
 
-- **jquantstats** builds **Plotly figures natively** (`_plots/`) and renders
-  self-contained interactive HTML through **Jinja2 templates** (`_reports/`,
-  hence the `jinja2` runtime dependency). Plot and report layers are
-  protocol-segregated from the data layer.
+- **jquantstats** builds **both natively**. Every chart is described once as a
+  backend-agnostic spec (`_plots/_specs/`), which one of two renderers
+  (`_plots/_render/`) turns into a Plotly or a matplotlib figure — so the
+  arithmetic behind a chart is written once and neither backend is a wrapper
+  over the other. Plotly is the default; `set_plot_backend("matplotlib")`
+  switches. Reports render self-contained interactive HTML through **Jinja2
+  templates** (`_reports/`, hence the `jinja2` runtime dependency), and stay
+  Plotly-only. Plot and report layers are protocol-segregated from the data
+  layer.
 
 ---
 

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -42,9 +42,10 @@ uv run --with pillow python book/shots/generate.py
 
 !!! note "The images are static; the figures are not"
 
-    Each chart is a `plotly.graph_objects.Figure`. In a notebook or a browser
-    you get hover tooltips, zoom, legend toggles and — on the time-series
-    charts — a working range selector. The images below are flattened exports;
+    Each chart below is a `plotly.graph_objects.Figure`. In a notebook or a
+    browser you get hover tooltips, zoom, legend toggles and — on the
+    time-series charts — a working range selector. The images below are
+    flattened exports;
     click any of them for the full-resolution version.
 
 ---

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -65,6 +65,7 @@ pip install jquantstats
 Optional extras:
 
 ```bash
+pip install jquantstats[mpl]    # matplotlib rendering backend
 pip install jquantstats[plot]   # static chart export via kaleido
 pip install jquantstats[web]    # FastAPI web server
 ```
@@ -287,6 +288,50 @@ fig.show()
 ```python
 html = data.reports.full()
 ```
+
+---
+
+## Choosing a plotting backend
+
+Charts render with Plotly by default. Install the `mpl` extra and you can ask
+for matplotlib instead, which is markedly cheaper when a script builds many
+charts at once — the reason the option exists.
+
+```bash
+pip install jquantstats[mpl]
+```
+
+Three ways to select it, most specific first:
+
+```python
+import jquantstats as jqs
+
+# 1. one call
+fig = data.plots.drawdown(backend="matplotlib")
+
+# 2. a block — restored on exit, even if the body raises
+with jqs.plot_backend("matplotlib"):
+    fig = data.plots.drawdown()
+
+# 3. the process-wide default
+jqs.set_plot_backend("matplotlib")
+fig = data.plots.drawdown()
+```
+
+Both backends draw from the same numbers, so the two figures plot identical
+series. What differs is what a figure *is*: `plotly.graph_objects.Figure` one
+way, `matplotlib.figure.Figure` the other.
+
+!!! note "The matplotlib backend is static"
+
+    Hover tooltips, the date range-selector buttons and legend click-to-toggle
+    are interactive features with no matplotlib equivalent, so they are simply
+    absent. Everything that determines *what* is plotted — series, colours,
+    axis scales and tick formats — is reproduced.
+
+HTML reports (`portfolio.report.to_html()`, `data.reports.full()`) always
+render Plotly regardless of the selected backend, since they embed Plotly JSON
+and link plotly.js.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ hide:
 
 # jquantstats
 
-**Portfolio analytics for quants** — built on Polars, powered by Plotly.
+**Portfolio analytics for quants** — built on Polars, plotted with Plotly or matplotlib.
 
 [![PyPI version](https://badge.fury.io/py/jquantstats.svg)](https://badge.fury.io/py/jquantstats)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://pypi.org/project/jquantstats/)
@@ -128,7 +128,7 @@ See [Getting Started](getting_started.md) for a complete walkthrough.
 | Feature | QuantStats | jquantstats |
 |---|---|---|
 | DataFrame engine | pandas | Polars |
-| Charts | matplotlib (static) | Plotly (interactive) |
+| Charts | matplotlib, plus a `to_plotly()` converter | Plotly *or* matplotlib, both native |
 | Multi-asset in one call | no | yes |
 | Portfolio route | no | yes |
 | Execution-delay analysis | no | `pf.lag(n)` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 INHERIT: docs/mkdocs-base.yml
 
 site_name: jquantstats
-site_description: Portfolio analytics for quants – built on Polars, powered by Plotly.
+site_description: Portfolio analytics for quants – built on Polars, plotted with Plotly or matplotlib.
 site_author: Jebel Quant Research
 site_url: https://jebel-quant.github.io/jquantstats/
 repo_url: https://github.com/jebel-quant/jquantstats

--- a/tests/test_jquantstats/test_docs_claims.py
+++ b/tests/test_jquantstats/test_docs_claims.py
@@ -1,0 +1,74 @@
+"""Guard the numeric claims the comparison docs make about this package.
+
+`docs/engineering.md` compares jquantstats with QuantStats, and several of its
+rows are facts about *this* repository rather than prose. Those drift silently:
+the dependency count was a headline differentiator ("6, no pandas") at a point
+when adding matplotlib to `[project] dependencies` rather than to an extra would
+have quietly invalidated it, and the module-size row named a file that had not
+existed for several releases.
+
+Only the self-referential claims are checked. The QuantStats columns describe a
+package this suite does not install and are left to human review.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+_ROOT = Path(__file__).absolute().parent.parent.parent
+_ENGINEERING = _ROOT / "docs" / "engineering.md"
+
+
+def _pyproject() -> dict:
+    """Parse the project manifest.
+
+    Returns:
+        dict: The decoded ``pyproject.toml``.
+
+    """
+    return tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+def test_runtime_dependency_count_matches_the_manifest() -> None:
+    """The documented runtime-dependency count is the real one.
+
+    "6 runtime deps, no pandas" is a claim the comparison leans on, so moving a
+    package out of an extra and into `[project] dependencies` has to be a
+    deliberate act that updates the prose too.
+    """
+    declared = len(_pyproject()["project"]["dependencies"])
+    text = _ENGINEERING.read_text(encoding="utf-8")
+    assert f"jquantstats runtime ({declared}):" in text, (
+        f"docs/engineering.md does not say 'jquantstats runtime ({declared})' — "
+        "the manifest declares that many runtime dependencies"
+    )
+
+
+def test_matplotlib_is_an_extra_not_a_runtime_dependency() -> None:
+    """The second plotting backend must not reach the base install.
+
+    Keeping it optional is the reason the count above stays at 6.
+    """
+    project = _pyproject()["project"]
+    runtime = {d.split(">")[0].split("=")[0].split("[")[0] for d in project["dependencies"]}
+    assert "matplotlib" not in runtime
+    assert "matplotlib" in " ".join(project["optional-dependencies"]["mpl"])
+
+
+def test_engineering_doc_names_a_module_that_exists() -> None:
+    """The "largest module" row must name a real file.
+
+    It named `_plots/_data.py` for several releases after that file was split
+    into a package.
+    """
+    row = next(line for line in _ENGINEERING.read_text(encoding="utf-8").splitlines() if "| Largest module" in line)
+    # Backtick-quoted filenames, wherever they sit in the cell — they are
+    # parenthesised, so splitting on whitespace alone would miss them.
+    named = re.findall(r"`([^`]+\.py)`", row)
+    assert named, f"no module named in: {row}"
+    for module in named:
+        if module == "stats.py":  # QuantStats' file, not ours
+            continue
+        assert (_ROOT / "src" / "jquantstats" / module).exists(), f"{module} does not exist"


### PR DESCRIPTION
Last PR of the #628 series. Four comparison tables used **"Plotly vs matplotlib"** as the
differentiator against QuantStats — which stopped being true the moment jquantstats grew
a matplotlib backend.

> **Stacked on #951** → #950 → #948 → #947 → #946 → #945 → #944 → #943 → #940.

## The differentiator is native-ness, not which library

jquantstats describes each chart once and has two renderers draw it, so neither backend
wraps the other. QuantStats renders with matplotlib and offers a `to_plotly(fig)`
converter that re-wraps a *finished* figure. That is still a real distinction — it is
just a different one.

| File | Was | Now |
|---|---|---|
| `README.md` | Interactive Plotly charts ∥ Static matplotlib / seaborn | Plotly *or* matplotlib, both native ∥ matplotlib / seaborn, with a `to_plotly()` converter |
| `docs/index.md` | matplotlib (static) ∥ Plotly (interactive) | matplotlib, plus a `to_plotly()` converter ∥ Plotly *or* matplotlib, both native |
| `docs/MIGRATION.md` | static matplotlib/seaborn ∥ interactive Plotly | matplotlib/seaborn ∥ Plotly by default, matplotlib on request |
| `docs/difference.md` | Plotly-native ∥ Matplotlib (static) | Plotly *and* matplotlib, both rendered natively ∥ Matplotlib; the `plotly` extra *converts* finished figures |
| `docs/engineering.md` | Plotly-native ∥ Matplotlib core + converter | Plotly and matplotlib, both native ∥ (unchanged) |

Each respects its own table's **column order** — which is not the same in all five; two
put QuantStats first.

The prose follows: `difference.md`'s *"Interactive vs. static plots"* is rewritten as
*"Two native backends vs. one plus a converter"*, `engineering.md` §7 describes the
spec/renderer split, and the taglines in `docs/index.md` and `mkdocs.yml` no longer say
"powered by Plotly" alone.

## New material

- **`getting_started.md` gains "Choosing a plotting backend"** — all three ways to select
  one, the fact that both plot identical series, the interactive affordances matplotlib
  does not have, and that HTML reports stay Plotly whatever is selected. **Every snippet
  in it was run.**
- **`STABILITY.md`** lists the three new exports and states the policy: `"plotly"` stays
  the default before 1.0; a figure's *type* now depends on the backend; the overloads
  make a bare call's static type a lie once the global default changes; and the missing
  interactive affordances are by design, not omission.

## Two stale claims, and a guard so they stay fixed

Both predate this series but were made worse by it:

- source size said *~10.6k LOC across ~34 files* — actually **~16.0k across 77**
- *"largest module"* named `_plots/_data.py`, which stopped existing when **#846** split
  it into a package

A new `test_docs_claims.py` guards the self-referential numbers, because these are facts
about *this* repository that drift silently. It checks the runtime-dependency count
against `pyproject.toml` — *"6 runtime deps, no pandas"* is a headline claim, and moving
matplotlib out of its extra would have quietly invalidated it — and that the "largest
module" row names a file that exists. I confirmed both fail when the claim is wrong.

## One thing I tried and reverted

I added a bare `jqs` prefix to `test_docs_api_names.py` so `jqs.set_plot_backend(...)` in
prose would be checked. It flags `jqs.sh` (a shell script) and `MIGRATION.md`'s
deliberate `jqs.stats.sharpe()` ❌-counter-example — **exactly the hazard that file
already documents** for the bare `data` prefix. Silencing them with `KNOWN_ABSENT`
entries would weaken the guard to buy very little, so top-level function names in prose
stay unchecked. Reverted rather than papered over.

## Verification

`make all` green: **fmt, deps, test, docs-coverage, security, license, typecheck, rhiza-test**.

- 1,667 passed, 5 skipped
- 100% line + branch coverage; markdownlint clean
- `test_docs_api_names.py` still passes — no prose names an API that does not exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)