### PR TITLE
chore: prune exclude entries the template no longer ships

### DIFF
--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -10,11 +10,6 @@ templates:
 # Destination paths, as they land in this repo. Source-path entries
 # (bundles/github/...) are inert since the exclude semantics were fixed.
 exclude:
-  # Issue and discussion forms. Multi-field forms with required textareas, for a
-  # repository whose issues are opened by the people who wrote the code. Removed
-  # upstream in rhiza v1.5.0; excluded here so the v1.4.2 sync stops delivering them.
-  - .github/ISSUE_TEMPLATE
-  - .github/DISCUSSION_TEMPLATE
 
   - .github/workflows/rhiza_fuzzing.yml
   - .github/workflows/rhiza_weekly.yml


### PR DESCRIPTION
Removes `exclude:` entries that no longer match anything.

The template dropped both directories in **v1.5.0**:

- `bundles/github/.github/ISSUE_TEMPLATE` — rhiza #1567 (`a34059d`)
- `bundles/github/.github/DISCUSSION_TEMPLATE` — rhiza #1566 (`20e0ffa`)

This repo is pinned at v1.5.x, so the sync never delivers those paths and the entries match nothing. `exclude:` is matched against destination paths, and an entry that resolves to nothing is silently inert — dead config that reads like an active decision.

Only `.rhiza/template.yml` is touched; no template-owned file and no repo source is in this PR. Verified with `git tag --contains`: both deletions are in v1.5.0 and v1.5.1, and `git ls-tree v1.5.1` reports 0 files for each directory.

**No gates were run.** Run `/rhiza:quality` for a scorecard.
