### PR TITLE
chore: drop the exclude entries for the retired mutation/fuzzing workflows

### DIFF
--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -10,10 +10,5 @@ templates:
 # Destination paths, as they land in this repo. Source-path entries
 # (bundles/github/...) are inert since the exclude semantics were fixed.
 exclude:
-  # The mutation-testing workflow. Retired upstream in rhiza v1.5.0 and removed here;
-  # it survived the orphan sweep only because it was never listed in template.lock.
-  - .github/workflows/rhiza_mutation.yml
-
-  - .github/workflows/rhiza_fuzzing.yml
   - .github/workflows/rhiza_weekly.yml
   - .github/workflows/rhiza_scorecard.yml


### PR DESCRIPTION
rhiza v1.5.0 retired `.github/workflows/rhiza_fuzzing.yml` (#1568) and `.github/workflows/rhiza_mutation.yml` (#1572), and stopped offering mutation testing in the ecosystem at all (#1492). Nothing under `bundles/` ships either path now, so excluding them declines a file the sync can no longer deliver.

This drops the two entries and the comment paragraphs that existed only to justify them. Where a comment also explained why the *other* workflow was deliberately left in the sync, that note goes too — it describes a live gate that no longer exists.

**No CI behaviour changes.** Neither workflow is delivered with or without these entries.

**This does not delete any leftover workflow file.** Orphan cleanup only considers paths recorded in `.rhiza/template.lock`'s `files:` list, and these are absent from it, so a copy still present in `.github/workflows/` stays put either way. That is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)