### PR TITLE
feat: add Mean Absolute Deviation (MAD) metric (closes #671)

### DIFF
--- a/src/jquantstats/_stats/_basic_core.py
+++ b/src/jquantstats/_stats/_basic_core.py
@@ -214,6 +214,34 @@ class _BasicCoreMixin:
         std_val = cast(float, series.std())
         return (std_val if std_val is not None else 0.0) * factor
 
+    @columnwise_stat
+    def mad(self, series: pl.Series, periods: int | float | None = None, annualize: bool = True) -> float:
+        """Calculate the Mean Absolute Deviation (MAD) of returns.
+
+        MAD is the mean of absolute deviations from the mean return:
+        mean(|r - mean(r)|). It is a robust measure of dispersion less
+        sensitive to outliers than standard deviation.
+
+        - Annualized by sqrt(periods) if `annualize` is True.
+
+        Args:
+            series (pl.Series): The series to calculate MAD for.
+            periods (int, optional): Number of periods per year. Defaults to periods_per_year.
+            annualize (bool, optional): Whether to annualize the result. Defaults to True.
+
+        Returns:
+            float: The MAD value.
+        """
+        raw_periods = periods or self._data._periods_per_year
+
+        if not isinstance(raw_periods, int | float):
+            raise TypeError(f"Expected int or float for periods, got {type(raw_periods).__name__}")  # noqa: TRY003
+
+        factor = _annualization_factor(raw_periods) if annualize else 1.0
+        mean_val = _mean(series)
+        mad_val = cast(float, (series - mean_val).abs().mean())
+        return (mad_val if mad_val is not None else 0.0) * factor
+
     # ── Win / loss metrics ────────────────────────────────────────────────────
 
     @columnwise_stat

--- a/tests/test_jquantstats/test__stats/test_stats.py
+++ b/tests/test_jquantstats/test__stats/test_stats.py
@@ -157,6 +157,73 @@ def test_volatility(stats):
     assert result["META"] == pytest.approx(0.40072031010504233)
 
 
+def test_mad(stats):
+    """Tests that the mad method calculates Mean Absolute Deviation correctly.
+
+    Args:
+        stats: The stats fixture containing a Stats object.
+
+    Verifies:
+        The annualized MAD value for META matches the expected value.
+    """
+    result = stats.mad(periods=252, annualize=True)
+    assert result["META"] == pytest.approx(0.26006904645978096)
+
+
+def test_mad_not_annualized(stats):
+    """Tests that the mad method calculates MAD correctly without annualization.
+
+    Args:
+        stats: The stats fixture containing a Stats object.
+
+    Verifies:
+        The non-annualized MAD value for META matches the expected value.
+    """
+    result = stats.mad(annualize=False)
+    assert result["META"] == pytest.approx(0.016382810015197223)
+
+
+def test_mad_aapl(stats):
+    """Tests that the mad method calculates MAD correctly for AAPL.
+
+    Args:
+        stats: The stats fixture containing a Stats object.
+
+    Verifies:
+        The annualized MAD value for AAPL matches the expected value.
+    """
+    result = stats.mad(periods=252, annualize=True)
+    assert result["AAPL"] == pytest.approx(0.28564761387721205)
+
+
+def test_mad_custom_periods(stats):
+    """Tests that the mad method respects custom periods parameter.
+
+    Args:
+        stats: The stats fixture containing a Stats object.
+
+    Verifies:
+        The MAD with custom periods=12 matches the expected value.
+    """
+    result = stats.mad(periods=12, annualize=True)
+    # sqrt(252/12) = sqrt(21) scaling difference from 252
+    expected = 0.016382810015197223 * (12**0.5)
+    assert result["META"] == pytest.approx(expected)
+
+
+def test_mad_invalid_periods_type(stats):
+    """Tests that mad raises TypeError for non-numeric periods.
+
+    Args:
+        stats: The stats fixture containing a Stats object.
+
+    Verifies:
+        A TypeError is raised when periods is not an int or float.
+    """
+    with pytest.raises(TypeError, match="Expected int or float for periods"):
+        stats.mad(periods="invalid")
+
+
 def test_rolling_volatility(stats):
     """Tests that the rolling_volatility method calculates rolling volatility correctly.
 


### PR DESCRIPTION
Implements the `mad()` method for Mean Absolute Deviation — a robust measure of dispersion less sensitive to outliers than standard deviation.

## Changes
- Added `mad()` to `_BasicCoreMixin` in `src/jquantstats/_stats/_basic_core.py`
- Follows the same signature/patterns as `volatility()`:
  - `@columnwise_stat` decorator for per-asset computation
  - `periods` parameter for annualization (defaults to `periods_per_year`)
  - `annualize` boolean flag (defaults to `True`)
  - Proper TypeError for non-numeric `periods`

## Tests
- 5 new tests covering: annualized, non-annualized, multi-asset, custom periods, and invalid type error

## Quality Gates
All CI gates pass locally:
- `make test` — 1458 passed, 100% coverage
- `make fmt` — all pre-commit hooks pass
- `make typecheck` — no mypy issues
- `make docs-coverage` — 100% docstring coverage
- `make security` — bandit clean

Closes #671
