### PR TITLE
build: derive the version from the git tag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,3 +81,8 @@ revert your change. Everything below is locally owned and edited here:
 - **Tests** live under `tests/`; `test_quantstats.py` validates metrics against the
   `quantstats` reference implementation (a dev-only dependency).
 - Fully type-annotated public API (`py.typed`).
+- **Versioning is dynamic:** there is no `version` in `[project]` — hatch-vcs derives it
+  from the git tag (`[tool.hatch.version] source = "vcs"`), and `jquantstats.__version__`
+  reads it back through `importlib.metadata`. So a release is a tag and nothing else:
+  never hand-edit a version number, and expect a working tree between tags to report the
+  next patch as a dev version (`0.11.1.dev4+g<sha>`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,10 @@
 # Main project metadata
 [project]
 name = 'jquantstats'
-version = "0.11.0"
+# Derived from the git tag by hatch-vcs (see [tool.hatch.version]) rather than written
+# here, so the tag is the single source of truth and a release is `git tag` alone -- no
+# bump commit, and no way for a number in this file to disagree with what was tagged.
+dynamic = ["version"]
 description = "Analytics for quants"
 authors = [{name='tschm', email= 'thomas.schmelzer@gmail.com'}]
 readme = "README.md"
@@ -106,8 +109,22 @@ test = [
 
 # Build system configuration
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# Supplies the `version` that [project] declares dynamic, from `git describe`. Two
+# consequences worth knowing:
+#   * The build needs the tag to be visible. hatch-vcs does not fail without it -- it
+#     falls back to a dev version like 0.11.1.dev3+g<sha> -- so rhiza_release.yml checks
+#     the built distribution's filename against the tag, and its checkout uses
+#     fetch-depth: 0. An sdist carries the resolved number in PKG-INFO, so building from
+#     one needs no git.
+#   * Between tags the local version is the *next* patch as a dev release
+#     (guess-next-dev, the default), which is why nothing pins a fallback-version here:
+#     a wrong-looking version must surface as a release failure, not as a plausible
+#     constant.
+[tool.hatch.version]
+source = "vcs"
 
 # Configuration for wheel build
 [tool.hatch.build.targets.wheel]
@@ -151,10 +168,16 @@ marimo_folder = "book/marimo/notebooks"
 
 # Was RHIZA_CHECKS_VERSION in .rhiza/make.d/quality.mk, consumed as
 # `pytest-rhiza==$(RHIZA_CHECKS_VERSION)`. The CLI default resolves
-# `pytest-rhiza @ git+…@v0.2.0`; this repo ran 0.2.1, so the pin is preserved
-# rather than silently rolled back. (Latest on PyPI is 0.4.0 — upgrading is a
-# deliberate decision, not part of this migration.)
-pytest_rhiza = "pytest-rhiza==0.2.1"
+# `pytest-rhiza @ git+…@v0.2.0`, older than what this repo needs.
+#
+# 0.6.0 is the floor, not a routine refresh: it is the release whose pyproject
+# check learned that `[project].version` may be *derived* from the VCS. Up to and
+# including 0.2.1 the check reads a written number unconditionally, so against the
+# `dynamic = ["version"]` above it fails three ways — `version` missing from the
+# required-[project]-fields list, "" failing the semver regex, and
+# `Version("")` raising InvalidVersion while comparing against the latest tag. All
+# three are artefacts of the checker, not of this repo.
+pytest_rhiza = "pytest-rhiza==0.6.0"
 
 # Replaces `DEPTRY_FOLDERS += api` from the old Makefile. v1.4.0 removed that
 # accumulator and now *derives* the deptry folder set — source_folder plus
@@ -265,21 +288,23 @@ enforce = false
 # configparser (radon, for one) treat it as interpolation syntax and crash outright.
 reason = "Tests are organised by behaviour under tests/test_jquantstats/; per-module coverage is guaranteed by the full line-and-branch pytest coverage gate rather than 1:1 file mirroring."
 
-# Declares every location the release version lives, so `bump-my-version` rewrites
-# them all in one step. Without this, a bump silently touches no files and the
-# release CI fails its pyproject-version-vs-tag check.
+# Kept even though there is no longer a version in this file to rewrite, because its
+# *presence* is what `/rhiza:release` reads to tell "this repo declares where its version
+# lives, and it is the tag" from "this repo declares nothing" -- the second of which makes
+# the command stop. Deliberately carries no `current_version`: bump-my-version then
+# derives the current version from the newest matching tag, which is the same fact
+# hatch-vcs builds from, so the two cannot drift. This is the shape rhiza's `go-core` and
+# `rust-core` bundles ship for exactly the same reason.
+#
+# There is no `[[tool.bumpversion.files]]` entry, and adding one would be the mistake:
+# every location that used to hold the number is now derived from the tag, so a file
+# listed here could only reintroduce the drift this change removed.
 [tool.bumpversion]
-current_version = "0.11.0"
-
-# Anchored to the [project] table on purpose: search/replace applies to every match
-# in the file, so an unanchored `version = "..."` would also rewrite any [tool.*]
-# table that happens to share the current version number.
-[[tool.bumpversion.files]]
-filename = "pyproject.toml"
-regex = true
-search = '(?ms)^\[project\]((?:(?!^\[)[\s\S])*?)^version = "{current_version}"'
-replace = '[project]\1version = "{new_version}"'
-
+allow_dirty = false
+# The release flow commits and tags itself, so that the regenerated changelog lands in
+# the bump commit rather than in a second one after the tag.
+commit = false
+tag = false
 
 # Architectural import contracts (import-linter), run via `make arch` and hooked
 # into `make test`. These encode the layering that src/jquantstats/_protocol.py

--- a/uv.lock
+++ b/uv.lock
@@ -629,7 +629,6 @@ wheels = [
 
 [[package]]
 name = "jquantstats"
-version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
@@ -685,7 +684,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.14.1" },
     { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.32.0" },
 ]
-provides-extras = ["plot", "mpl", "web"]
+provides-extras = ["mpl", "plot", "web"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Moves the project to dynamic versioning: `[project].version` is gone, and hatch-vcs derives it from the git tag. The tag becomes the single source of truth, so a release is `git tag` and nothing else — no bump commit, and no way for a number in a file to disagree with what was tagged.

`jquantstats.__version__` already read through `importlib.metadata`, so no source change was needed.

## What changed

All three files are locally owned; nothing rhiza-managed was touched.

- **`pyproject.toml`**
  - `[project]`: `version = "0.11.0"` → `dynamic = ["version"]`.
  - `[build-system]` gains `hatch-vcs`, plus `[tool.hatch.version] source = "vcs"`. No `fallback-version` is pinned on purpose: hatch-vcs falls back to a dev version when the tag is not visible, and that has to surface as a release failure rather than as a plausible constant — which is exactly what `rhiza_release.yml`'s dist-versus-tag check already catches (its checkout uses `fetch-depth: 0` for the same reason).
  - `[tool.bumpversion]` keeps its table but loses `current_version` and the `[[files]]` rewrite rule. The table's *presence* is what `/rhiza:release` reads to tell "the version lives in the tag" from "this repo declares nothing" — the latter makes the command stop. Without `current_version`, bump-my-version derives the number from the newest tag, the same fact hatch-vcs builds from, so the two cannot drift. This is the shape rhiza's `go-core` and `rust-core` bundles ship, for the same reason.
  - `pytest_rhiza` pin `0.2.1` → `0.6.0`.
- **`uv.lock`** — the project entry drops its `version` key; uv records it as dynamic.
- **`CLAUDE.md`** — one bullet under Conventions, so a future session doesn't go hunting for a version number to edit.

## Why the pytest-rhiza pin has to move

Not a routine refresh. 0.2.1's pyproject check reads a written version unconditionally, so against `dynamic = ["version"]` it fails three ways: `version` missing from the required-`[project]`-fields list, `""` failing the semver regex, and `Version("")` raising `InvalidVersion` while comparing against the latest tag. All three are artefacts of the checker, not of this repo. 0.6.0 is the release whose check learned that a version may be derived from the VCS, and it skips those assertions with a reason.

## Verification

- `make test` — 1476 passed, 100% line + branch coverage. `tests/test_rhiza_packaging.py` and the version-vs-tag checks skip cleanly on a dynamic version.
- `make fmt`, `make deps`, `make rhiza-test`, `make test-pyproject` — green.
- **Build**, in a throwaway clone: tag `v0.12.0` produces `jquantstats-0.12.0.tar.gz` and `jquantstats-0.12.0-py3-none-any.whl`, so the release workflow's filename check passes. uv builds the wheel *from the sdist*, which confirms PKG-INFO carries the resolved number and building from an sdist needs no git. A working tree between tags reports `0.11.1.dev4+geb3d566c3`.
- **Release flow**, same clone: `bump-my-version show current_version` → `0.11.0` (derived from the tag), and `bump --new-version 0.12.0 --no-commit --no-tag` exits 0 leaving a clean tree — so `/rhiza:release` step 6 succeeds and the release branch carries only the changelog, which is the evidence that flow uses for tag-derived repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
