### PR TITLE
docs: write example reports under output/ so they stay untracked

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,9 +329,7 @@ beta = greeks["Strategy"]["beta"]
 ```python
 pf = Portfolio.from_cash_position(prices=prices, cash_position=positions, aum=1_000_000)
 
-html = pf.report.to_html()
-with open("report.html", "w") as f:
-    f.write(html)
+pf.report.to_html(path="output/report.html")  # parent dirs are created for you
 ```
 
 ### Hosted report API

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -352,7 +352,7 @@ data.reports.full(title="My Strategy")  # str — self-contained HTML document
 
 # The Portfolio route spells it differently: .report (singular), and the
 # HTML entry point is to_html(), which returns a str or writes to `path`.
-pf.report.to_html(title="My Portfolio", path="report.html")
+pf.report.to_html(title="My Portfolio", path="output/report.html")
 ```
 
 There is no `data.reports.summary()`.  The composite stats table lives on the

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -230,7 +230,10 @@ build step, nothing to ship alongside it:
 
 ```python
 html = data.reports.full(title="Performance Report")
-pathlib.Path("report.html").write_text(html)
+
+out = pathlib.Path("output/report.html")
+out.parent.mkdir(parents=True, exist_ok=True)
+out.write_text(html)
 ```
 
 ### Metrics

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -194,10 +194,7 @@ fig.show()  # opens in browser / notebook
 ### Report
 
 ```python
-html = pf.report.to_html()
-
-with open("report.html", "w") as f:
-    f.write(html)
+pf.report.to_html(path="output/report.html")  # parent dirs are created for you
 ```
 
 ---


### PR DESCRIPTION
## Why

Following the README quickstart leaves a stray untracked `report.html` at the repo root. That was noticed before and fixed by adding the file to `.gitignore` in 909bb71 — but `.gitignore` is rhiza-managed (`.rhiza/template.lock:31`), and the v1.3.0 sync (7152802) deleted the line again. Any local `.gitignore` fix has the same fate.

## What

Point the doc examples at `output/` instead. The template `.gitignore` already ignores it (line 8, *"HTML outputs from docstring examples"*), and `src/jquantstats/_reports/_portfolio.py:201` and `book/shots/generate.py:209` already write there. No template-owned file is touched, so a sync cannot undo this.

| File | Change |
|---|---|
| `README.md:331` | collapsed to `pf.report.to_html(path="output/report.html")` |
| `docs/getting_started.md:196` | same |
| `docs/gallery.md:232` | explicit write kept, gains `mkdir(parents=True, exist_ok=True)` |
| `docs/MIGRATION.md:355` | path string only |

`docs/index.md` is `--8<-- "README.md"`, so the landing page follows automatically.

For the Portfolio route `to_html(path=...)` creates the parent directory itself (`_portfolio.py:331`), so no `mkdir` is needed. `data.reports.full()` only returns a `str`, which is why the gallery example keeps a manual write.

## Verified

Ran the rewritten README example in an empty directory: `output/` was created and a 101 KB report written. Docs-only otherwise — no doc code blocks are executed by the suite (no doctest/mktestdocs/markdown-exec configured).

## Not in scope

`docs/paper/jquantstats.tex:785` writes `strategy_report.html` to the cwd. It is a published paper, so I left it alone — say the word if you want it aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)